### PR TITLE
use ui5 resources with active cachebuster

### DIFF
--- a/src/z2ui5_cl_http_handler.clas.abap
+++ b/src/z2ui5_cl_http_handler.clas.abap
@@ -45,7 +45,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     IF lt_config IS INITIAL.
       lt_config = VALUE #(
           (  name = `data-sap-ui-theme`         value = `sap_horizon` )
-          (  name = `src`                       value = `https://sdk.openui5.org/resources/sap-ui-core.js` )
+          (  name = `src`                       value = `https://sdk.openui5.org/resources/sap-ui-cachebuster/sap-ui-core.js` )
           (  name = `data-sap-ui-libs`          value = `sap.m` )
           (  name = `data-sap-ui-bindingSyntax` value = `complex` )
           (  name = `data-sap-ui-frameOptions`  value = `trusted` )


### PR DESCRIPTION
Hi, I modified the UI5 CDN URL so it uses the CDN's cache buster.
This makes sure that the UI5 libraries are properly cached and their versions always match (so the used version of `sap.m` is always the same as the version of `sap.ui.core`, which might not be the case if the libraries are loaded without cachebuster).

See UI5 documentation: [Cache Buster for SAPUI5](https://ui5.sap.com/#/topic/91f080966f4d1014b6dd926db0e91070)