### PR TITLE
disable caching of abap2ui5 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ METHOD if_http_extension~handle_request.
       WHEN 'GET'  THEN z2ui5_cl_http_handler=>http_get( )
       WHEN 'POST' THEN z2ui5_cl_http_handler=>http_post( ) ).
 
+   server->response->set_header_field(
+     exporting
+       name  = 'cache-control'
+       value = 'no-cache'
+   ).
+
    server->response->set_cdata( lv_resp ).
    server->response->set_status( code = 200 reason = 'success' ).
 


### PR DESCRIPTION
This is a proposal to disable caching for resources served by the `GET` handler. All the generated views (and especially the index file) should always be retrieved from the server. 

⚠ I have no way of testing in an ABAP Cloud environment, so I only enhanced the documentation section for on-premise.