### PR TITLE
MultiComboBox fix

### DIFF
--- a/src/z2ui5_cl_xml_view.clas.abap
+++ b/src/z2ui5_cl_xml_view.clas.abap
@@ -3978,7 +3978,7 @@ CLASS Z2UI5_CL_XML_VIEW IMPLEMENTATION.
 
 
   METHOD multi_combobox.
-    result = _generic( name   = `ComboBox`
+    result = _generic( name   = `MultiComboBox`
                        t_prop = VALUE #( (  n = `selectionChange`     v = selectionchange )
                                          (  n = `selectedKeys`        v = selectedkeys )
                                          (  n = `items`               v = items )


### PR DESCRIPTION
Method multi_combobox was using the generic "ComboBox" instead of "MultiComboBox".