### PR TITLE
Downport rtti_get_classes_impl_intf

### DIFF
--- a/src/00/z2ui5_cl_util_func.clas.abap
+++ b/src/00/z2ui5_cl_util_func.clas.abap
@@ -912,9 +912,15 @@ CLASS z2ui5_cl_util_func IMPLEMENTATION.
 
         FIELD-SYMBOLS <any> TYPE any.
         ASSIGN obj->('IF_XCO_AO_INTERFACE~IMPLEMENTATIONS') TO <any>.
+        IF sy-subrc <> 0.
+          RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
+        ENDIF.
         obj = <any>.
 
         ASSIGN obj->('IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL') TO <any>.
+        IF sy-subrc <> 0.
+          RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
+        ENDIF.
         obj = <any>.
 
         CALL METHOD obj->('IF_XCO_INTF_IMPLEMENTATIONS~GET').


### PR DESCRIPTION
Fix this dump on S/4 HANA 2022 SP02

![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/f14a1227-1849-456d-ad0b-c43db7bd618b)
![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/43b1d014-bf45-42de-a3d5-479d1a66d816)
![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/3f82dcb4-c93d-4374-a61f-d4e0a6c0e42b)
![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/45125ecb-5abb-44b6-bbe6-3ec35b8c8cd8)
