### PR TITLE
Update z2ui5_cl_xml_view.clas.abap

### DIFF
--- a/src/02/01/01/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/01/01/z2ui5_cl_xml_view.clas.abap
@@ -2068,6 +2068,8 @@ CLASS z2ui5_cl_xml_view DEFINITION
       RETURNING
         VALUE(result) TYPE REF TO z2ui5_cl_xml_view .
     METHODS proportion_zoom_strategy
+     importing
+      !ZOOMLEVEL type CLIKE optional
       RETURNING
         VALUE(result) TYPE REF TO z2ui5_cl_xml_view .
     METHODS total_horizon
@@ -6464,7 +6466,9 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD proportion_zoom_strategy.
     result = _generic( name = `ProportionZoomStrategy`
-                       ns   = `axistime` ).
+                       ns   = `axistime`
+                       t_prop = VALUE #( ( n = `zoomLevel` v = zoomLevel ) )
+                     ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
Change on Element proportion_zoom_strategy. Added property zoomLevel

Reason: Gantt Chart with Container ToolBar: Toolbar has the feature zoomlevel and can now be forwarded to the axis

![image](https://github.com/abap2UI5/abap2UI5/assets/54766892/bf053b1c-ba0a-4520-8225-1410c6045663)
