### PR TITLE
catch cx_sy_rtti_syntax_error

### DIFF
--- a/src/01/01/z2ui5_cl_util_api.clas.abap
+++ b/src/01/01/z2ui5_cl_util_api.clas.abap
@@ -725,7 +725,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
           result = abap_true.
         ENDIF.
 
-      CATCH cx_sy_rtti_syntax_error.
+      CATCH cx_root. " cx_sy_rtti_syntax_error
     ENDTRY.
 
   ENDMETHOD.

--- a/src/01/01/z2ui5_cl_util_api.clas.abap
+++ b/src/01/01/z2ui5_cl_util_api.clas.abap
@@ -725,7 +725,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
           result = abap_true.
         ENDIF.
 
-      CATCH cx_root. " cx_sy_rtti_syntax_error
+      CATCH cx_root.
+        " cx_sy_rtti_syntax_error
     ENDTRY.
 
   ENDMETHOD.

--- a/src/01/01/z2ui5_cl_util_api.clas.abap
+++ b/src/01/01/z2ui5_cl_util_api.clas.abap
@@ -715,14 +715,18 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
   METHOD rtti_check_class_exists.
 
-    cl_abap_classdescr=>describe_by_name(
-       EXPORTING
-           p_name      = val
-       EXCEPTIONS
-        type_not_found = 1 ).
-    IF sy-subrc = 0.
-      result = abap_true.
-    ENDIF.
+    TRY.
+        cl_abap_classdescr=>describe_by_name(
+          EXPORTING
+            p_name        = val
+          EXCEPTIONS
+           type_not_found = 1 ).
+        IF sy-subrc = 0.
+          result = abap_true.
+        ENDIF.
+
+      CATCH cx_sy_rtti_syntax_error.
+    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
If class has syntax error cx_sy_rtti_syntax_error is raised and propagated.
![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/f04903f6-abe0-488f-a6a4-ca447a09ff49)

With this fix we catch it and deal with it as the class doesn't exist.