### PR TITLE
Fix CX_SY_DYN_CALL_ILLEGAL_TYPE

### DIFF
--- a/src/01/00/02/z2ui5_cl_stmpncfctn_api.clas.abap
+++ b/src/01/00/02/z2ui5_cl_stmpncfctn_api.clas.abap
@@ -299,9 +299,11 @@ CLASS z2ui5_cl_stmpncfctn_api IMPLEMENTATION.
 
     TRY.
 
+        ls_clskey-clsname = val.
+
         CALL METHOD ('XCO_CP_ABAP')=>interface
           EXPORTING
-            iv_name      = val
+            iv_name      = ls_clskey-clsname
           RECEIVING
             ro_interface = obj.
 


### PR DESCRIPTION
Fixes CX_SY_DYN_CALL_ILLEGAL_TYPE error on S/4HANA systems
![grafik](https://github.com/abap2UI5/abap2UI5/assets/17437789/c65dda76-9149-49e0-b74b-be839bb078cf)
