### PR TITLE
Data loss protection with dirty flag

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -337,4 +337,9 @@ CLASS Z2UI5_CL_CORE_CLIENT IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD z2ui5_if_client~dirty.
+    mo_action->ms_next-s_set-dirty = val.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/01/02/z2ui5_cl_core_http_get.clas.abap
+++ b/src/01/02/z2ui5_cl_core_http_get.clas.abap
@@ -398,6 +398,16 @@ CLASS Z2UI5_CL_CORE_HTTP_GET IMPLEMENTATION.
                `            if (sap.z2ui5.oResponse.PARAMS?.S_VIEW?.CHECK_DESTROY) {` && |\n| &&
                `                sap.z2ui5.oController.ViewDestroy();` && |\n| &&
                `            };` && |\n| &&
+               `            const dirty = !!sap.z2ui5.oResponse.PARAMS?.DIRTY;` && |\n| &&
+               `            if (sap.ushell?.Container) {` && |\n| &&
+               `                sap.ushell.Container.setDirtyFlag(dirty);` && |\n| &&
+               `            } else {` && |\n| &&
+               `                window.onbeforeunload = function (e) { ` && |\n| &&
+               `                    if (dirty) {` && |\n| &&
+               `                        e.preventDefault();    ` && |\n| &&
+               `                    }                ` && |\n| &&
+               `                }        ` && |\n| &&
+               `            }` && |\n| &&
                `            if(sap.z2ui5.oResponse.PARAMS?.S_FOLLOW_UP_ACTION?.CUSTOM_JS) {` && |\n| &&
                `              setTimeout(() => {` && |\n| &&
                `                  let mParams = sap.z2ui5.oResponse?.PARAMS.S_FOLLOW_UP_ACTION.CUSTOM_JS.split("'");` && |\n| &&

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -47,6 +47,7 @@ INTERFACE z2ui5_if_core_types
 
   TYPES:
     BEGIN OF ty_s_next_frontend,
+      dirty TYPE abap_bool,
       BEGIN OF s_view,
         xml                TYPE string,
         check_destroy      TYPE abap_bool,

--- a/src/02/03/z2ui5_if_client.intf.abap
+++ b/src/02/03/z2ui5_if_client.intf.abap
@@ -185,4 +185,8 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val      TYPE string.
 
+  METHODS dirty
+    IMPORTING
+      val TYPE abap_bool.
+
 ENDINTERFACE.


### PR DESCRIPTION
This is a first try to implement kind of data loss protection, which triggers this popup when browser back or reload button is pressed, or FLP back navigation is used. 
![image](https://github.com/user-attachments/assets/f344fbd0-ae01-4488-bf48-fa44a703527f)

Therefore I introduced a new method `z2ui5_if_client~dirty` and a new flag `dirty` which can be used to set the page dirty.
![image](https://github.com/user-attachments/assets/336c058d-2256-46b4-97a0-e9c52a09dbd6)

Note that we use `sap.ushell.Container.setDirtyFlag` while running in shell context, e.g. FLP, and `window.onbeforeunload` when running standalone. 

As I'm not too familiar with the inner workings of abap2UI5 I have know clue whether that's the right way to do it. Feel free to improve.

See also demo app z2ui5_cl_demo_app_279.

fixes #1348 