### PR TITLE
Fix spelling errors in error messages and comments

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -103,7 +103,7 @@ sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/core/mvc/XMLView", "sap/ui/
                     BusyIndicator.hide();
                     z2ui5.isBusy = false;
                     MessageBox.error(e.toLocaleString(), {
-                        title: "Unexpected Error Occured - App Terminated",
+                        title: "Unexpected Error Occurred - App Terminated",
                         actions: [],
                         onClose: () => {
                             new mBusyDialog({

--- a/src/00/03/01/z2ui5_cl_util_ext.clas.abap
+++ b/src/00/03/01/z2ui5_cl_util_ext.clas.abap
@@ -954,7 +954,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     CLEAR <fs_target_tab>.
 
-    " we dont want to loose all inputs in row ...
+    " we don't want to lose all inputs in row ...
     IF ms_data_row IS NOT BOUND.
       CREATE DATA ms_data_row TYPE HANDLE strucdescr.
     ENDIF.

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -78,7 +78,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
 
     RAISE EXCEPTION TYPE z2ui5_cx_util_error
       EXPORTING
-        val = `BINDING_ERROR_TAB_CELL_LEVEL - No class attribute for binding found - Please check if the binded values are public attributes of your class`.
+        val = `BINDING_ERROR_TAB_CELL_LEVEL - No class attribute for binding found - Please check if the bound values are public attributes of your class`.
 
   ENDMETHOD.
 
@@ -197,7 +197,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     IF |/{ z2ui5_if_core_types=>cs_ui5-two_way_model }| = result.
       RAISE EXCEPTION TYPE z2ui5_cx_util_error
         EXPORTING
-          val = `<p>Name of variable not allowed - x is reserved word - use anoter name for your attribute`.
+          val = `<p>Name of variable not allowed - x is reserved word - use another name for your attribute`.
 
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -344,7 +344,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
 
     RAISE EXCEPTION TYPE z2ui5_cx_util_error
       EXPORTING
-        val = `BINDING_ERROR - No class attribute for binding found - Please check if the binded values are public attributes of your class or switch to bind_local`.
+        val = `BINDING_ERROR - No class attribute for binding found - Please check if the bound values are public attributes of your class or switch to bind_local`.
 
   ENDMETHOD.
 


### PR DESCRIPTION
- Fix "dont" → "don't" and "loose" → "lose" in z2ui5_cl_util_ext.clas.abap
- Fix "binded" → "bound" in z2ui5_cl_core_srv_bind.clas.abap and z2ui5_cl_core_srv_model.clas.abap
- Fix "anoter" → "another" in z2ui5_cl_core_srv_bind.clas.abap
- Fix "Occured" → "Occurred" in View1.controller.js