### PR TITLE
Replace single quotes with backticks in ABAP string literals

### DIFF
--- a/src/00/03/01/z2ui5_cl_util_ext.clas.abap
+++ b/src/00/03/01/z2ui5_cl_util_ext.clas.abap
@@ -365,18 +365,18 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     lv_classname = i_classname.
 
-    xco_cp_abap = 'XCO_CP_ABAP'.
-    CALL METHOD (xco_cp_abap)=>('CLASS')
+    xco_cp_abap = `XCO_CP_ABAP`.
+    CALL METHOD (xco_cp_abap)=>(`CLASS`)
       EXPORTING
         iv_name  = lv_classname
       RECEIVING
         ro_class = obj.
 
-    CALL METHOD obj->('IF_XCO_AO_CLASS~CONTENT')
+    CALL METHOD obj->(`IF_XCO_AO_CLASS~CONTENT`)
       RECEIVING
         ro_content = content.
 
-    CALL METHOD content->('IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION')
+    CALL METHOD content->(`IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION`)
       RECEIVING
         rv_short_description = result.
 
@@ -454,9 +454,9 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *             nohistory   TYPE c LENGTH 1,
 *             ampmformat  TYPE c LENGTH 1,
 *           END OF ty_s_dfies.
-*    temp10 ?= cl_abap_structdescr=>describe_by_name( 'TY_S_DFIES' ).
+*    temp10 ?= cl_abap_structdescr=>describe_by_name( `TY_S_DFIES` ).
 
-    temp10 ?= cl_abap_structdescr=>describe_by_name( 'DFIES' ).
+    temp10 ?= cl_abap_structdescr=>describe_by_name( `DFIES` ).
 
     lo_struct = temp10.
     comps = lo_struct->get_components( ).
@@ -533,33 +533,33 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
     TRY.
         TRY.
             DATA(lv_method2) = `XCO_CP_ABAP_DICTIONARY`.
-            CALL METHOD (lv_method2)=>('DATABASE_TABLE')
+            CALL METHOD (lv_method2)=>(`DATABASE_TABLE`)
               EXPORTING
                 iv_name           = lv_tabname
               RECEIVING
                 ro_database_table = obj.
-            ASSIGN obj->('IF_XCO_DATABASE_TABLE~FIELDS->IF_XCO_DBT_FIELDS_FACTORY~KEY') TO <any>.
+            ASSIGN obj->(`IF_XCO_DATABASE_TABLE~FIELDS->IF_XCO_DBT_FIELDS_FACTORY~KEY`) TO <any>.
             IF sy-subrc  <> 0.
 * fallback to RTTI, KEY field does not exist in S/4 2020
               RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
             ENDIF.
             obj = <any>.
-            CALL METHOD obj->('IF_XCO_DBT_FIELDS~GET_NAMES')
+            CALL METHOD obj->(`IF_XCO_DBT_FIELDS~GET_NAMES`)
               RECEIVING
                 rt_names = names.
           CATCH cx_sy_dyn_call_illegal_class.
-            DATA(workaround) = 'DDFIELDS'.
+            DATA(workaround) = `DDFIELDS`.
             CREATE DATA lr_ddfields TYPE (workaround).
             ASSIGN lr_ddfields->* TO <ddfields>.
             ASSERT sy-subrc = 0.
             <ddfields> = CAST cl_abap_structdescr( cl_abap_typedescr=>describe_by_name(
               lv_tabname ) )->get_ddic_field_list( ).
             LOOP AT <ddfields> ASSIGNING <any>.
-              ASSIGN COMPONENT 'KEYFLAG' OF STRUCTURE <any> TO <field>.
+              ASSIGN COMPONENT `KEYFLAG` OF STRUCTURE <any> TO <field>.
               IF sy-subrc <> 0 OR <field> <> abap_true.
                 CONTINUE.
               ENDIF.
-              ASSIGN COMPONENT 'FIELDNAME' OF STRUCTURE <any> TO <field>.
+              ASSIGN COMPONENT `FIELDNAME` OF STRUCTURE <any> TO <field>.
               ASSERT sy-subrc = 0.
               APPEND <field> TO names.
             ENDLOOP.
@@ -636,13 +636,13 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *
 *    tab = tabname.
 *
-*    CALL METHOD ('XCO_CP_ABAP_DICTIONARY')=>database_table
+*    CALL METHOD (`XCO_CP_ABAP_DICTIONARY`)=>database_table
 *      EXPORTING
 *        iv_name           = tab
 *      RECEIVING
 *        ro_database_table = db.
 *
-*    ASSIGN db->('IF_XCO_DATABASE_TABLE~FIELDS->IF_XCO_DBT_FIELDS_FACTORY~ALL') TO <any>.
+*    ASSIGN db->(`IF_XCO_DATABASE_TABLE~FIELDS->IF_XCO_DBT_FIELDS_FACTORY~ALL`) TO <any>.
 *
 *    IF sy-subrc <> 0.
 *      RETURN.
@@ -650,13 +650,13 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *
 *    fields = <any>.
 *
-*    CREATE DATA r_names TYPE ('SXCO_T_AD_FIELD_NAMES').
+*    CREATE DATA r_names TYPE (`SXCO_T_AD_FIELD_NAMES`).
 *    ASSIGN r_names->* TO <Names>.
 *    IF <Names> IS NOT ASSIGNED.
 *      RETURN.
 *    ENDIF.
 *
-*    CALL METHOD fields->('IF_XCO_DBT_FIELDS~GET_NAMES')
+*    CALL METHOD fields->(`IF_XCO_DBT_FIELDS~GET_NAMES`)
 *      RECEIVING
 *        rt_names = <Names>.
 *
@@ -664,17 +664,17 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *
 *      CLEAR t_param.
 *
-*      INSERT VALUE #( name  = 'IV_NAME'
+*      INSERT VALUE #( name  = `IV_NAME`
 *                      kind  = cl_abap_objectdescr=>exporting
 *                      value = REF #( <name> ) ) INTO TABLE t_param.
-*      INSERT VALUE #( name  = 'RO_FIELD'
+*      INSERT VALUE #( name  = `RO_FIELD`
 *                      kind  = cl_abap_objectdescr=>receiving
 *                      value = REF #( field ) ) INTO TABLE t_param.
 *
 *      CALL METHOD db->(`IF_XCO_DATABASE_TABLE~FIELD`)
 *        PARAMETER-TABLE t_param.
 *
-*      ASSIGN t_param[ name = 'RO_FIELD' ] TO FIELD-SYMBOL(<line>).
+*      ASSIGN t_param[ name = `RO_FIELD` ] TO FIELD-SYMBOL(<line>).
 *      IF <line> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
@@ -683,36 +683,36 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *        CONTINUE.
 *      ENDIF.
 *
-*      CALL METHOD <fiel>->('IF_XCO_DBT_FIELD~CONTENT')
+*      CALL METHOD <fiel>->(`IF_XCO_DBT_FIELD~CONTENT`)
 *        RECEIVING
 *          ro_content = content.
 *
-*      CREATE DATA r_content TYPE ('IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT').
-*      ASSIGN r_content->* TO FIELD-SYMBOL(<Content>) CASTING TYPE ('IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT').
+*      CREATE DATA r_content TYPE (`IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT`).
+*      ASSIGN r_content->* TO FIELD-SYMBOL(<Content>) CASTING TYPE (`IF_XCO_DBT_FIELD_CONTENT=>TS_CONTENT`).
 *      IF <content> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
 *
-*      CALL METHOD content->('IF_XCO_DBT_FIELD_CONTENT~GET')
+*      CALL METHOD content->(`IF_XCO_DBT_FIELD_CONTENT~GET`)
 *        RECEIVING
 *          rs_content = <Content>.
 *
-*      ASSIGN COMPONENT 'KEY_INDICATOR' OF STRUCTURE <content> TO FIELD-SYMBOL(<key>).
+*      ASSIGN COMPONENT `KEY_INDICATOR` OF STRUCTURE <content> TO FIELD-SYMBOL(<key>).
 *      IF <key> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
-*      ASSIGN COMPONENT 'SHORT_DESCRIPTION' OF STRUCTURE <content> TO FIELD-SYMBOL(<text>).
+*      ASSIGN COMPONENT `SHORT_DESCRIPTION` OF STRUCTURE <content> TO FIELD-SYMBOL(<text>).
 *      IF <text> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
-*      ASSIGN COMPONENT 'TYPE' OF STRUCTURE <content> TO FIELD-SYMBOL(<type>).
+*      ASSIGN COMPONENT `TYPE` OF STRUCTURE <content> TO FIELD-SYMBOL(<type>).
 *      IF <type> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
 *
 *      type = <type>.
 *
-*      CALL METHOD type->('IF_XCO_DBT_FIELD_TYPE~GET_DATA_ELEMENT')
+*      CALL METHOD type->(`IF_XCO_DBT_FIELD_TYPE~GET_DATA_ELEMENT`)
 *        RECEIVING
 *          ro_data_element = element.
 *
@@ -720,7 +720,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *        <text> = <name>.
 *      ENDIF.
 *
-*      ASSIGN element->('IF_XCO_AD_OBJECT~NAME') TO FIELD-SYMBOL(<rname>).
+*      ASSIGN element->(`IF_XCO_AD_OBJECT~NAME`) TO FIELD-SYMBOL(<rname>).
 *      IF <rname> IS NOT ASSIGNED.
 *        CONTINUE.
 *      ENDIF.
@@ -798,7 +798,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     DATA lr_shlp       TYPE REF TO data.
 
-    DATA(lv_type) = 'SHLP_DESCR'.
+    DATA(lv_type) = `SHLP_DESCR`.
     CREATE DATA lr_shlp TYPE (lv_type).
     FIELD-SYMBOLS <shlp> TYPE any.
     ASSIGN lr_shlp->* TO <shlp>.
@@ -810,7 +810,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     IF ms_shlp IS INITIAL.
       " Suchhilfe lesen
-      DATA(lv_fm) = 'F4IF_DETERMINE_SEARCHHELP'.
+      DATA(lv_fm) = `F4IF_DETERMINE_SEARCHHELP`.
       CALL FUNCTION lv_fm
         EXPORTING
           tabname           = lv_tabname
@@ -831,12 +831,12 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
 *      DATA lt_shlp       TYPE shlp_desct.
         DATA lr_t_shlp TYPE REF TO data.
-        DATA(lv_type2) = 'SHLP_DESCT'.
+        DATA(lv_type2) = `SHLP_DESCT`.
         CREATE DATA lr_t_shlp TYPE (lv_type2).
         FIELD-SYMBOLS <shlp2> TYPE STANDARD TABLE.
         ASSIGN lr_t_shlp->* TO <shlp2>.
 
-        lv_fm = 'F4IF_EXPAND_SEARCHHELP'.
+        lv_fm = `F4IF_EXPAND_SEARCHHELP`.
         CALL FUNCTION lv_fm
           EXPORTING
             shlp_top = ms_shlp
@@ -881,8 +881,8 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
         ms_shlp-selopt = VALUE #( BASE ms_shlp-selopt
                                   ( shlpfield = interface-shlpfield
                                     shlpname  = interface-valtabname
-                                    option    = COND #( WHEN interface-value CA `*` THEN 'CP' ELSE 'EQ' )
-                                    sign      = 'I'
+                                    option    = COND #( WHEN interface-value CA `*` THEN `CP` ELSE `EQ` )
+                                    sign      = `I`
                                     low       = interface-value  ) ).
 
       ENDIF.
@@ -901,8 +901,8 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
       ms_shlp-selopt = VALUE #( BASE ms_shlp-selopt
                                 ( shlpfield = fieldrop-fieldname
 *                                  shlpname  =
-                                  option    = COND #( WHEN fieldrop-defaultval CA `*` THEN 'CP' ELSE 'EQ' )
-                                  sign      = 'I'
+                                  option    = COND #( WHEN fieldrop-defaultval CA `*` THEN `CP` ELSE `EQ` )
+                                  sign      = `I`
                                   low       = valule  ) ).
 
     ENDLOOP.
@@ -912,7 +912,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
     CLEAR: <shlp>.
     MOVE-CORRESPONDING ms_shlp TO <shlp>.
 
-    lv_fm = 'F4IF_SELECT_VALUES'.
+    lv_fm = `F4IF_SELECT_VALUES`.
     CALL FUNCTION lv_fm
       EXPORTING
         shlp           = <shlp>
@@ -934,9 +934,9 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     ENDLOOP.
 
-    IF NOT line_exists( lt_comps[ name = 'ROW_ID' ] ).
-      lo_datadescr ?= cl_abap_datadescr=>describe_by_name( 'INT4' ).
-      ls_comp-name  = 'ROW_ID'.
+    IF NOT line_exists( lt_comps[ name = `ROW_ID` ] ).
+      lo_datadescr ?= cl_abap_datadescr=>describe_by_name( `INT4` ).
+      ls_comp-name  = `ROW_ID`.
       ls_comp-type ?= lo_datadescr.
       APPEND ls_comp TO lt_comps.
     ENDIF.
@@ -954,7 +954,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 
     CLEAR <fs_target_tab>.
 
-    " we don't want to lose all inputs in row ...
+    " we don`t want to lose all inputs in row ...
     IF ms_data_row IS NOT BOUND.
       CREATE DATA ms_data_row TYPE HANDLE strucdescr.
     ENDIF.
@@ -1025,7 +1025,7 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
 *          CONTINUE.
 *        ENDIF.
 *        <value> = fieldrop-defaultval.
-*       REPLACE ALL OCCURRENCES OF `'` in <value> with ``.
+*       REPLACE ALL OCCURRENCES OF ``` in <value> with ``.
 *      ENDIF.
 *
 *    ENDLOOP.

--- a/src/00/03/02/z2ui5_cl_util_api.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api.clas.abap
@@ -352,7 +352,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
   METHOD context_check_abap_cloud.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
         result = abap_false.
       CATCH cx_root.
         result = abap_true.
@@ -378,10 +378,10 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
     DATA lr_fix    LIKE REF TO temp1.
     DATA temp2     TYPE z2ui5_cl_util_api=>ty_s_fix_val.
 
-    lv_langu = ' '.
+    lv_langu = ` `.
     lv_langu = langu.
 
-    CALL METHOD elemdescr->('GET_DDIC_FIXED_VALUES')
+    CALL METHOD elemdescr->(`GET_DDIC_FIXED_VALUES`)
       EXPORTING
         p_langu        = lv_langu
       RECEIVING
@@ -410,8 +410,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('DECODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -419,8 +419,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('DECODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -436,8 +436,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('ENCODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -445,8 +445,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('ENCODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -464,12 +464,12 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_in
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_IN~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_IN~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -477,14 +477,14 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_in_class = 'CL_ABAP_CONV_IN_CE'.
+        conv_in_class = `CL_ABAP_CONV_IN_CE`.
         CALL METHOD (conv_in_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             input = val
           IMPORTING
@@ -501,12 +501,12 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_out
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_OUT~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_OUT~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -514,14 +514,14 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_out_class = 'CL_ABAP_CONV_OUT_CE'.
+        conv_out_class = `CL_ABAP_CONV_OUT_CE`.
         CALL METHOD (conv_out_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             data   = val
           IMPORTING
@@ -549,45 +549,45 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
         lv_class  = to_upper( iv_classname ).
         lv_method = to_upper( iv_methodname ).
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_class
           RECEIVING
             ro_class = object.
 
-        ASSIGN object->('IF_XCO_AO_CLASS~IMPLEMENTATION') TO <any>.
+        ASSIGN object->(`IF_XCO_AO_CLASS~IMPLEMENTATION`) TO <any>.
         ASSERT sy-subrc = 0.
         object = <any>.
 
-        CALL METHOD object->('IF_XCO_CLAS_IMPLEMENTATION~METHOD')
+        CALL METHOD object->(`IF_XCO_CLAS_IMPLEMENTATION~METHOD`)
           EXPORTING
             iv_name   = lv_method
           RECEIVING
             ro_method = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD~CONTENT')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD~CONTENT`)
           RECEIVING
             ro_content = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE`)
           RECEIVING
             rt_source = result.
 
       CATCH cx_root.
 
-        lv_name = 'CL_OO_FACTORY'.
-        CALL METHOD (lv_name)=>('CREATE_INSTANCE')
+        lv_name = `CL_OO_FACTORY`.
+        CALL METHOD (lv_name)=>(`CREATE_INSTANCE`)
           RECEIVING
             result = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE`)
           EXPORTING
             clif_name = lv_class
           RECEIVING
             result    = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE~GET_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE~GET_SOURCE`)
           IMPORTING
             source = lt_source.
 
@@ -652,26 +652,26 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
       ls_clskey-clsname = val.
 
-      xco_cp_abap = 'XCO_CP_ABAP'.
+      xco_cp_abap = `XCO_CP_ABAP`.
       CALL METHOD (xco_cp_abap)=>interface
         EXPORTING
           iv_name      = ls_clskey-clsname
         RECEIVING
           ro_interface = obj.
 
-      ASSIGN obj->('IF_XCO_AO_INTERFACE~IMPLEMENTATIONS') TO <any>.
+      ASSIGN obj->(`IF_XCO_AO_INTERFACE~IMPLEMENTATIONS`) TO <any>.
       IF sy-subrc <> 0.
         RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
       ENDIF.
       obj = <any>.
 
-      ASSIGN obj->('IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL') TO <any>.
+      ASSIGN obj->(`IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL`) TO <any>.
       IF sy-subrc <> 0.
         RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
       ENDIF.
       obj = <any>.
 
-      CALL METHOD obj->('IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES')
+      CALL METHOD obj->(`IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES`)
         RECEIVING
           rt_names = lt_implementation_names.
 
@@ -703,7 +703,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-      type = 'SEOC_CLASS_R'.
+      type = `SEOC_CLASS_R`.
       CREATE DATA class TYPE (type).
 
       ASSIGN class->* TO <class>.
@@ -728,7 +728,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
         ENDIF.
 
         ASSIGN
-          COMPONENT 'DESCRIPT'
+          COMPONENT `DESCRIPT`
           OF STRUCTURE <class>
           TO <description>.
         ASSERT sy-subrc = 0.
@@ -769,9 +769,9 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
     data_element_name = val.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
 
-        temp7 ?= cl_abap_structdescr=>describe_by_name( 'DFIES' ).
+        temp7 ?= cl_abap_structdescr=>describe_by_name( `DFIES` ).
 
         struct_desrc = temp7.
 
@@ -791,7 +791,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
         data_descr = temp8.
 
-        CALL METHOD data_descr->('GET_DDIC_FIELD')
+        CALL METHOD data_descr->(`GET_DDIC_FIELD`)
           RECEIVING
             p_flddescr   = <ddic>
           EXCEPTIONS
@@ -811,14 +811,14 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
       CATCH cx_root.
         TRY.
             DATA lv_xco_cp_abap_dictionary TYPE string.
-            lv_xco_cp_abap_dictionary = 'XCO_CP_ABAP_DICTIONARY'.
-            CALL METHOD (lv_xco_cp_abap_dictionary)=>('DATA_ELEMENT')
+            lv_xco_cp_abap_dictionary = `XCO_CP_ABAP_DICTIONARY`.
+            CALL METHOD (lv_xco_cp_abap_dictionary)=>(`DATA_ELEMENT`)
               EXPORTING
                 iv_name         = data_element_name
               RECEIVING
                 ro_data_element = data_element.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~EXISTS')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~EXISTS`)
               RECEIVING
                 rv_exists = exists.
 
@@ -826,23 +826,23 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
               RETURN.
             ENDIF.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~CONTENT')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~CONTENT`)
               RECEIVING
                 ro_content = content.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL`)
               RECEIVING
                 rs_heading_field_label = result-header.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL`)
               RECEIVING
                 rs_short_field_label = result-short.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL`)
               RECEIVING
                 rs_medium_field_label = result-medium.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL`)
               RECEIVING
                 rs_long_field_label = result-long.
 
@@ -949,18 +949,18 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 
         lv_classname = i_classname.
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_classname
           RECEIVING
             ro_class = obj.
 
-        CALL METHOD obj->('IF_XCO_AO_CLASS~CONTENT')
+        CALL METHOD obj->(`IF_XCO_AO_CLASS~CONTENT`)
           RECEIVING
             ro_content = content.
 
-        CALL METHOD content->('IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION')
+        CALL METHOD content->(`IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION`)
           RECEIVING
             rv_short_description = result.
 
@@ -1014,8 +1014,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
     DATA lo_util TYPE REF TO object.
     IF context_check_abap_cloud( ).
 
-      CREATE OBJECT lo_util TYPE ('Z2UI5_CL_UTIL_ABAP_C').
-      CALL METHOD lo_util->('CONTEXT_GET_CALLSTACK')
+      CREATE OBJECT lo_util TYPE (`Z2UI5_CL_UTIL_ABAP_C`).
+      CALL METHOD lo_util->(`CONTEXT_GET_CALLSTACK`)
         RECEIVING
           result = result.
 
@@ -1057,8 +1057,8 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 *" Create and set header
 *
 *
-*DATA(lo_header) = cl_bali_header_setter=>create( object      = 'ZBS_DEMO_LOG_OBJECT'
-*                                                 subobject   = 'TEST'
+*DATA(lo_header) = cl_bali_header_setter=>create( object      = `ZBS_DEMO_LOG_OBJECT`
+*                                                 subobject   = `TEST`
 *                                                 external_id = cl_system_uuid=>create_uuid_c32_static( )
 *                                                 ).
 *
@@ -1067,7 +1067,7 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
 *
 *lo_ohandler->read_object(
 *  EXPORTING
-*    iv_object      = 'TEST'
+*    iv_object      = `TEST`
 *  IMPORTING
 **    ev_object_text =
 *    et_subobjects  = data(lo_obj)

--- a/src/00/03/02/z2ui5_cl_util_api.clas.testclasses.abap
+++ b/src/00/03/02/z2ui5_cl_util_api.clas.testclasses.abap
@@ -46,7 +46,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test_element_text.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -59,7 +59,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test_classes_impl_intf.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/00/03/02/z2ui5_cl_util_api_c.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_c.clas.abap
@@ -132,8 +132,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
     TRY.
 
         DATA(lv_result) = VALUE string( ).
-        DATA(lv_class) = 'CL_ABAP_CONTEXT_INFO'.
-        CALL METHOD (lv_class)=>('GET_USER_TECHNICAL_NAME')
+        DATA(lv_class) = `CL_ABAP_CONTEXT_INFO`.
+        CALL METHOD (lv_class)=>(`GET_USER_TECHNICAL_NAME`)
           RECEIVING
             rv_business_partner_id = lv_result.
 
@@ -152,7 +152,7 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
   METHOD context_check_abap_cloud.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
         result = abap_false.
       CATCH cx_root.
         result = abap_true.
@@ -179,10 +179,10 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
     DATA lr_fix    LIKE REF TO temp1.
     DATA temp2     TYPE z2ui5_cl_util_api=>ty_s_fix_val.
 
-    lv_langu = ' '.
+    lv_langu = ` `.
     lv_langu = langu.
 
-    CALL METHOD elemdescr->('GET_DDIC_FIXED_VALUES')
+    CALL METHOD elemdescr->(`GET_DDIC_FIXED_VALUES`)
       EXPORTING
         p_langu        = lv_langu
       RECEIVING
@@ -211,8 +211,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('DECODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -220,8 +220,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('DECODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -237,8 +237,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('ENCODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -246,8 +246,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('ENCODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -265,12 +265,12 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_in
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_IN~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_IN~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -278,14 +278,14 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_in_class = 'CL_ABAP_CONV_IN_CE'.
+        conv_in_class = `CL_ABAP_CONV_IN_CE`.
         CALL METHOD (conv_in_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             input = val
           IMPORTING
@@ -302,12 +302,12 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_out
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_OUT~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_OUT~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -315,14 +315,14 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_out_class = 'CL_ABAP_CONV_OUT_CE'.
+        conv_out_class = `CL_ABAP_CONV_OUT_CE`.
         CALL METHOD (conv_out_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             data   = val
           IMPORTING
@@ -350,45 +350,45 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
         lv_class  = to_upper( iv_classname ).
         lv_method = to_upper( iv_methodname ).
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_class
           RECEIVING
             ro_class = object.
 
-        ASSIGN object->('IF_XCO_AO_CLASS~IMPLEMENTATION') TO <any>.
+        ASSIGN object->(`IF_XCO_AO_CLASS~IMPLEMENTATION`) TO <any>.
         ASSERT sy-subrc = 0.
         object = <any>.
 
-        CALL METHOD object->('IF_XCO_CLAS_IMPLEMENTATION~METHOD')
+        CALL METHOD object->(`IF_XCO_CLAS_IMPLEMENTATION~METHOD`)
           EXPORTING
             iv_name   = lv_method
           RECEIVING
             ro_method = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD~CONTENT')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD~CONTENT`)
           RECEIVING
             ro_content = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE`)
           RECEIVING
             rt_source = result.
 
       CATCH cx_root.
 
-        lv_name = 'CL_OO_FACTORY'.
-        CALL METHOD (lv_name)=>('CREATE_INSTANCE')
+        lv_name = `CL_OO_FACTORY`.
+        CALL METHOD (lv_name)=>(`CREATE_INSTANCE`)
           RECEIVING
             result = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE`)
           EXPORTING
             clif_name = lv_class
           RECEIVING
             result    = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE~GET_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE~GET_SOURCE`)
           IMPORTING
             source = lt_source.
 
@@ -453,26 +453,26 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
         ls_clskey-clsname = val.
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
+        xco_cp_abap = `XCO_CP_ABAP`.
         CALL METHOD (xco_cp_abap)=>interface
           EXPORTING
             iv_name      = ls_clskey-clsname
           RECEIVING
             ro_interface = obj.
 
-        ASSIGN obj->('IF_XCO_AO_INTERFACE~IMPLEMENTATIONS') TO <any>.
+        ASSIGN obj->(`IF_XCO_AO_INTERFACE~IMPLEMENTATIONS`) TO <any>.
         IF sy-subrc <> 0.
           RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
         ENDIF.
         obj = <any>.
 
-        ASSIGN obj->('IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL') TO <any>.
+        ASSIGN obj->(`IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL`) TO <any>.
         IF sy-subrc <> 0.
           RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
         ENDIF.
         obj = <any>.
 
-        CALL METHOD obj->('IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES')
+        CALL METHOD obj->(`IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES`)
           RECEIVING
             rt_names = lt_implementation_names.
 
@@ -516,9 +516,9 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
     data_element_name = val.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
 
-        temp7 ?= cl_abap_structdescr=>describe_by_name( 'DFIES' ).
+        temp7 ?= cl_abap_structdescr=>describe_by_name( `DFIES` ).
 
         struct_desrc = temp7.
 
@@ -538,7 +538,7 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
         data_descr = temp8.
 
-        CALL METHOD data_descr->('GET_DDIC_FIELD')
+        CALL METHOD data_descr->(`GET_DDIC_FIELD`)
           RECEIVING
             p_flddescr   = <ddic>
           EXCEPTIONS
@@ -558,14 +558,14 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
       CATCH cx_root.
         TRY.
             DATA lv_xco_cp_abap_dictionary TYPE string.
-            lv_xco_cp_abap_dictionary = 'XCO_CP_ABAP_DICTIONARY'.
-            CALL METHOD (lv_xco_cp_abap_dictionary)=>('DATA_ELEMENT')
+            lv_xco_cp_abap_dictionary = `XCO_CP_ABAP_DICTIONARY`.
+            CALL METHOD (lv_xco_cp_abap_dictionary)=>(`DATA_ELEMENT`)
               EXPORTING
                 iv_name         = data_element_name
               RECEIVING
                 ro_data_element = data_element.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~EXISTS')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~EXISTS`)
               RECEIVING
                 rv_exists = exists.
 
@@ -573,23 +573,23 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
               RETURN.
             ENDIF.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~CONTENT')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~CONTENT`)
               RECEIVING
                 ro_content = content.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL`)
               RECEIVING
                 rs_heading_field_label = result-header.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL`)
               RECEIVING
                 rs_short_field_label = result-short.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL`)
               RECEIVING
                 rs_medium_field_label = result-medium.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL`)
               RECEIVING
                 rs_long_field_label = result-long.
 
@@ -697,18 +697,18 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 
         lv_classname = i_classname.
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_classname
           RECEIVING
             ro_class = obj.
 
-        CALL METHOD obj->('IF_XCO_AO_CLASS~CONTENT')
+        CALL METHOD obj->(`IF_XCO_AO_CLASS~CONTENT`)
           RECEIVING
             ro_content = content.
 
-        CALL METHOD content->('IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION')
+        CALL METHOD content->(`IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION`)
           RECEIVING
             rv_short_description = result.
 
@@ -785,44 +785,44 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
       ASSIGN (lv_assign) TO <format2>.
       format_obj2 = <format2>.
 
-      CALL METHOD format_obj2->('IF_XCO_CP_CS_FORMAT_FACTORY~ADT')
+      CALL METHOD format_obj2->(`IF_XCO_CP_CS_FORMAT_FACTORY~ADT`)
         RECEIVING
           ro_adt = format_obj3.
 
-      CALL METHOD format_obj3->('WITH_LINE_NUMBER_FLAVOR')
+      CALL METHOD format_obj3->(`WITH_LINE_NUMBER_FLAVOR`)
         EXPORTING
           io_line_number_flavor = <format>
         RECEIVING
           ro_me                 = format_source.
 
-      lv_xco_cp = 'XCO_CP'.
-      ASSIGN (lv_xco_cp)=>('CURRENT') TO <current>.
+      lv_xco_cp = `XCO_CP`.
+      ASSIGN (lv_xco_cp)=>(`CURRENT`) TO <current>.
       current_obj = <current>.
 
-      ASSIGN current_obj->('IF_XCO_CP_STD_CURRENT~CALL_STACK') TO <call_stack>.
+      ASSIGN current_obj->(`IF_XCO_CP_STD_CURRENT~CALL_STACK`) TO <call_stack>.
       stack = <call_stack>.
 
-      CALL METHOD stack->('IF_XCO_CP_STD_CUR_API_CLL_STCK~FULL')
+      CALL METHOD stack->(`IF_XCO_CP_STD_CUR_API_CLL_STCK~FULL`)
         RECEIVING
           ro_full = full_stack.
 
       DATA r TYPE REF TO data.
-      CREATE DATA r TYPE REF TO ('IF_XCO_CS_FORMAT').
+      CREATE DATA r TYPE REF TO (`IF_XCO_CS_FORMAT`).
       ASSIGN r->* TO <any>.
       <any> ?= format_source.
 
-      CALL METHOD full_stack->('IF_XCO_CP_CALL_STACK~AS_TEXT')
+      CALL METHOD full_stack->(`IF_XCO_CP_CALL_STACK~AS_TEXT`)
         EXPORTING
           io_format = <any>
         RECEIVING
           ro_text   = text_obj.
 
-      CALL METHOD text_obj->('IF_XCO_TEXT~GET_LINES')
+      CALL METHOD text_obj->(`IF_XCO_TEXT~GET_LINES`)
         RECEIVING
           ro_lines = ro_lines.
 
       FIELD-SYMBOLS <lt_lines> TYPE string_table.
-      ASSIGN ro_lines->('IF_XCO_STRINGS~VALUE') TO <lt_lines>.
+      ASSIGN ro_lines->(`IF_XCO_STRINGS~VALUE`) TO <lt_lines>.
 
     ELSE.
 
@@ -870,8 +870,8 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 *" Create and set header
 *
 *
-*DATA(lo_header) = cl_bali_header_setter=>create( object      = 'ZBS_DEMO_LOG_OBJECT'
-*                                                 subobject   = 'TEST'
+*DATA(lo_header) = cl_bali_header_setter=>create( object      = `ZBS_DEMO_LOG_OBJECT`
+*                                                 subobject   = `TEST`
 *                                                 external_id = cl_system_uuid=>create_uuid_c32_static( )
 *                                                 ).
 *
@@ -880,7 +880,7 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
 *
 *lo_ohandler->read_object(
 *  EXPORTING
-*    iv_object      = 'TEST'
+*    iv_object      = `TEST`
 *  IMPORTING
 **    ev_object_text =
 *    et_subobjects  = data(lo_obj)

--- a/src/00/03/02/z2ui5_cl_util_api_c.clas.testclasses.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_c.clas.testclasses.abap
@@ -54,7 +54,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test_element_text.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -69,7 +69,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
     RETURN.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/00/03/02/z2ui5_cl_util_api_s.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_s.clas.abap
@@ -132,8 +132,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
     TRY.
 
         DATA(lv_result) = VALUE string( ).
-        DATA(lv_class) = 'CL_ABAP_CONTEXT_INFO'.
-        CALL METHOD (lv_class)=>('GET_USER_BUSINESS_PARTNER_ID')
+        DATA(lv_class) = `CL_ABAP_CONTEXT_INFO`.
+        CALL METHOD (lv_class)=>(`GET_USER_BUSINESS_PARTNER_ID`)
           RECEIVING
             rv_business_partner_id = lv_result.
 
@@ -152,7 +152,7 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
   METHOD context_check_abap_cloud.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
         result = abap_false.
       CATCH cx_root.
         result = abap_true.
@@ -179,10 +179,10 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
     DATA lr_fix    LIKE REF TO temp1.
     DATA temp2     TYPE z2ui5_cl_util_api=>ty_s_fix_val.
 
-    lv_langu = ' '.
+    lv_langu = ` `.
     lv_langu = langu.
 
-    CALL METHOD elemdescr->('GET_DDIC_FIXED_VALUES')
+    CALL METHOD elemdescr->(`GET_DDIC_FIXED_VALUES`)
       EXPORTING
         p_langu        = lv_langu
       RECEIVING
@@ -211,8 +211,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('DECODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -220,8 +220,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('DECODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`DECODE_X_BASE64`)
           EXPORTING
             encoded = val
           RECEIVING
@@ -237,8 +237,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
     TRY.
 
-        lv_web_http_name = 'CL_WEB_HTTP_UTILITY'.
-        CALL METHOD (lv_web_http_name)=>('ENCODE_X_BASE64')
+        lv_web_http_name = `CL_WEB_HTTP_UTILITY`.
+        CALL METHOD (lv_web_http_name)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -246,8 +246,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
       CATCH cx_root.
 
-        classname = 'CL_HTTP_UTILITY'.
-        CALL METHOD (classname)=>('ENCODE_X_BASE64')
+        classname = `CL_HTTP_UTILITY`.
+        CALL METHOD (classname)=>(`ENCODE_X_BASE64`)
           EXPORTING
             unencoded = val
           RECEIVING
@@ -265,12 +265,12 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_in
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_IN~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_IN~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -278,14 +278,14 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_in_class = 'CL_ABAP_CONV_IN_CE'.
+        conv_in_class = `CL_ABAP_CONV_IN_CE`.
         CALL METHOD (conv_in_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             input = val
           IMPORTING
@@ -302,12 +302,12 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
     TRY.
 
-        conv_codepage = 'CL_ABAP_CONV_CODEPAGE'.
+        conv_codepage = `CL_ABAP_CONV_CODEPAGE`.
         CALL METHOD (conv_codepage)=>create_out
           RECEIVING
             instance = conv.
 
-        CALL METHOD conv->('IF_ABAP_CONV_OUT~CONVERT')
+        CALL METHOD conv->(`IF_ABAP_CONV_OUT~CONVERT`)
           EXPORTING
             source = val
           RECEIVING
@@ -315,14 +315,14 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
       CATCH cx_root.
 
-        conv_out_class = 'CL_ABAP_CONV_OUT_CE'.
+        conv_out_class = `CL_ABAP_CONV_OUT_CE`.
         CALL METHOD (conv_out_class)=>create
           EXPORTING
-            encoding = 'UTF-8'
+            encoding = `UTF-8`
           RECEIVING
             conv     = conv.
 
-        CALL METHOD conv->('CONVERT')
+        CALL METHOD conv->(`CONVERT`)
           EXPORTING
             data   = val
           IMPORTING
@@ -350,45 +350,45 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
         lv_class  = to_upper( iv_classname ).
         lv_method = to_upper( iv_methodname ).
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_class
           RECEIVING
             ro_class = object.
 
-        ASSIGN object->('IF_XCO_AO_CLASS~IMPLEMENTATION') TO <any>.
+        ASSIGN object->(`IF_XCO_AO_CLASS~IMPLEMENTATION`) TO <any>.
         ASSERT sy-subrc = 0.
         object = <any>.
 
-        CALL METHOD object->('IF_XCO_CLAS_IMPLEMENTATION~METHOD')
+        CALL METHOD object->(`IF_XCO_CLAS_IMPLEMENTATION~METHOD`)
           EXPORTING
             iv_name   = lv_method
           RECEIVING
             ro_method = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD~CONTENT')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD~CONTENT`)
           RECEIVING
             ro_content = object.
 
-        CALL METHOD object->('IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE')
+        CALL METHOD object->(`IF_XCO_CLAS_I_METHOD_CONTENT~GET_SOURCE`)
           RECEIVING
             rt_source = result.
 
       CATCH cx_root.
 
-        lv_name = 'CL_OO_FACTORY'.
-        CALL METHOD (lv_name)=>('CREATE_INSTANCE')
+        lv_name = `CL_OO_FACTORY`.
+        CALL METHOD (lv_name)=>(`CREATE_INSTANCE`)
           RECEIVING
             result = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE_FACTORY~CREATE_CLIF_SOURCE`)
           EXPORTING
             clif_name = lv_class
           RECEIVING
             result    = object.
 
-        CALL METHOD object->('IF_OO_CLIF_SOURCE~GET_SOURCE')
+        CALL METHOD object->(`IF_OO_CLIF_SOURCE~GET_SOURCE`)
           IMPORTING
             source = lt_source.
 
@@ -453,26 +453,26 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
         ls_clskey-clsname = val.
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
+        xco_cp_abap = `XCO_CP_ABAP`.
         CALL METHOD (xco_cp_abap)=>interface
           EXPORTING
             iv_name      = ls_clskey-clsname
           RECEIVING
             ro_interface = obj.
 
-        ASSIGN obj->('IF_XCO_AO_INTERFACE~IMPLEMENTATIONS') TO <any>.
+        ASSIGN obj->(`IF_XCO_AO_INTERFACE~IMPLEMENTATIONS`) TO <any>.
         IF sy-subrc <> 0.
           RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
         ENDIF.
         obj = <any>.
 
-        ASSIGN obj->('IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL') TO <any>.
+        ASSIGN obj->(`IF_XCO_INTF_IMPLEMENTATIONS_FC~ALL`) TO <any>.
         IF sy-subrc <> 0.
           RAISE EXCEPTION TYPE cx_sy_dyn_call_illegal_class.
         ENDIF.
         obj = <any>.
 
-        CALL METHOD obj->('IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES')
+        CALL METHOD obj->(`IF_XCO_INTF_IMPLEMENTATIONS~GET_NAMES`)
           RECEIVING
             rt_names = lt_implementation_names.
 
@@ -516,9 +516,9 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
     data_element_name = val.
 
     TRY.
-        cl_abap_typedescr=>describe_by_name( 'T100' ).
+        cl_abap_typedescr=>describe_by_name( `T100` ).
 
-        temp7 ?= cl_abap_structdescr=>describe_by_name( 'DFIES' ).
+        temp7 ?= cl_abap_structdescr=>describe_by_name( `DFIES` ).
 
         struct_desrc = temp7.
 
@@ -538,7 +538,7 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
         data_descr = temp8.
 
-        CALL METHOD data_descr->('GET_DDIC_FIELD')
+        CALL METHOD data_descr->(`GET_DDIC_FIELD`)
           RECEIVING
             p_flddescr   = <ddic>
           EXCEPTIONS
@@ -558,14 +558,14 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
       CATCH cx_root.
         TRY.
             DATA lv_xco_cp_abap_dictionary TYPE string.
-            lv_xco_cp_abap_dictionary = 'XCO_CP_ABAP_DICTIONARY'.
-            CALL METHOD (lv_xco_cp_abap_dictionary)=>('DATA_ELEMENT')
+            lv_xco_cp_abap_dictionary = `XCO_CP_ABAP_DICTIONARY`.
+            CALL METHOD (lv_xco_cp_abap_dictionary)=>(`DATA_ELEMENT`)
               EXPORTING
                 iv_name         = data_element_name
               RECEIVING
                 ro_data_element = data_element.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~EXISTS')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~EXISTS`)
               RECEIVING
                 rv_exists = exists.
 
@@ -573,23 +573,23 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
               RETURN.
             ENDIF.
 
-            CALL METHOD data_element->('IF_XCO_AD_DATA_ELEMENT~CONTENT')
+            CALL METHOD data_element->(`IF_XCO_AD_DATA_ELEMENT~CONTENT`)
               RECEIVING
                 ro_content = content.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_HEADING_FIELD_LABEL`)
               RECEIVING
                 rs_heading_field_label = result-header.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_SHORT_FIELD_LABEL`)
               RECEIVING
                 rs_short_field_label = result-short.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_MEDIUM_FIELD_LABEL`)
               RECEIVING
                 rs_medium_field_label = result-medium.
 
-            CALL METHOD content->('IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL')
+            CALL METHOD content->(`IF_XCO_DTEL_CONTENT~GET_LONG_FIELD_LABEL`)
               RECEIVING
                 rs_long_field_label = result-long.
 
@@ -697,18 +697,18 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 
         lv_classname = i_classname.
 
-        xco_cp_abap = 'XCO_CP_ABAP'.
-        CALL METHOD (xco_cp_abap)=>('CLASS')
+        xco_cp_abap = `XCO_CP_ABAP`.
+        CALL METHOD (xco_cp_abap)=>(`CLASS`)
           EXPORTING
             iv_name  = lv_classname
           RECEIVING
             ro_class = obj.
 
-        CALL METHOD obj->('IF_XCO_AO_CLASS~CONTENT')
+        CALL METHOD obj->(`IF_XCO_AO_CLASS~CONTENT`)
           RECEIVING
             ro_content = content.
 
-        CALL METHOD content->('IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION')
+        CALL METHOD content->(`IF_XCO_CLAS_CONTENT~GET_SHORT_DESCRIPTION`)
           RECEIVING
             rv_short_description = result.
 
@@ -786,44 +786,44 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 *        ASSIGN (lv_assign) TO <format2>.
 *        format_obj2 = <format2>.
 *
-*        CALL METHOD format_obj2->('IF_XCO_CP_CS_FORMAT_FACTORY~ADT')
+*        CALL METHOD format_obj2->(`IF_XCO_CP_CS_FORMAT_FACTORY~ADT`)
 *          RECEIVING
 *            ro_adt = format_obj3.
 *
-*        CALL METHOD format_obj3->('WITH_LINE_NUMBER_FLAVOR')
+*        CALL METHOD format_obj3->(`WITH_LINE_NUMBER_FLAVOR`)
 *          EXPORTING
 *            io_line_number_flavor = <format>
 *          RECEIVING
 *            ro_me                 = format_source.
 *
-*        lv_xco_cp = 'XCO_CP'.
-*        ASSIGN (lv_xco_cp)=>('CURRENT') TO <current>.
+*        lv_xco_cp = `XCO_CP`.
+*        ASSIGN (lv_xco_cp)=>(`CURRENT`) TO <current>.
 *        current_obj = <current>.
 *
-*        ASSIGN current_obj->('IF_XCO_CP_STD_CURRENT~CALL_STACK') TO <call_stack>.
+*        ASSIGN current_obj->(`IF_XCO_CP_STD_CURRENT~CALL_STACK`) TO <call_stack>.
 *        stack = <call_stack>.
 *
-*        CALL METHOD stack->('IF_XCO_CP_STD_CUR_API_CLL_STCK~FULL')
+*        CALL METHOD stack->(`IF_XCO_CP_STD_CUR_API_CLL_STCK~FULL`)
 *          RECEIVING
 *            ro_full = full_stack.
 *
 *        DATA r TYPE REF TO data.
-*        CREATE DATA r TYPE REF TO ('IF_XCO_CS_FORMAT').
+*        CREATE DATA r TYPE REF TO (`IF_XCO_CS_FORMAT`).
 *        ASSIGN r->* TO <any>.
 *        <any> ?= format_source.
 *
-*        CALL METHOD full_stack->('IF_XCO_CP_CALL_STACK~AS_TEXT')
+*        CALL METHOD full_stack->(`IF_XCO_CP_CALL_STACK~AS_TEXT`)
 *          EXPORTING
 *            io_format = <any>
 *          RECEIVING
 *            ro_text   = text_obj.
 *
-*        CALL METHOD text_obj->('IF_XCO_TEXT~GET_LINES')
+*        CALL METHOD text_obj->(`IF_XCO_TEXT~GET_LINES`)
 *          RECEIVING
 *            ro_lines = ro_lines.
 *
 *        FIELD-SYMBOLS <lt_lines> TYPE string_table.
-*        ASSIGN ro_lines->('IF_XCO_STRINGS~VALUE') TO <lt_lines>.
+*        ASSIGN ro_lines->(`IF_XCO_STRINGS~VALUE`) TO <lt_lines>.
 *
 *      CATCH cx_root INTO DATA(x).
 *        "TODO ABAP Standard
@@ -871,8 +871,8 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 *" Create and set header
 *
 *
-*DATA(lo_header) = cl_bali_header_setter=>create( object      = 'ZBS_DEMO_LOG_OBJECT'
-*                                                 subobject   = 'TEST'
+*DATA(lo_header) = cl_bali_header_setter=>create( object      = `ZBS_DEMO_LOG_OBJECT`
+*                                                 subobject   = `TEST`
 *                                                 external_id = cl_system_uuid=>create_uuid_c32_static( )
 *                                                 ).
 *
@@ -881,7 +881,7 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
 *
 *lo_ohandler->read_object(
 *  EXPORTING
-*    iv_object      = 'TEST'
+*    iv_object      = `TEST`
 *  IMPORTING
 **    ev_object_text =
 *    et_subobjects  = data(lo_obj)

--- a/src/00/03/02/z2ui5_cl_util_api_s.clas.testclasses.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_s.clas.testclasses.abap
@@ -46,7 +46,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test_element_text.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -59,7 +59,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test_classes_impl_intf.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -6,7 +6,7 @@ CLASS z2ui5_cl_util DEFINITION
   PUBLIC SECTION.
 
     " abap-toolkit - Utility Functions for ABAP Cloud & Standard ABAP
-    " version: '0.0.1'.
+    " version: `0.0.1`.
     " origin: https://github.com/oblomov-dev/abap-toolkit
     " author: https://github.com/oblomov-dev
     " license: MIT.
@@ -532,15 +532,15 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
   METHOD boolean_check_by_name.
 
     CASE val.
-      WHEN 'ABAP_BOOL'
-          OR 'XSDBOOLEAN'
-          OR 'FLAG'
-          OR 'XFLAG'
-          OR 'XFELD'
-          OR 'ABAP_BOOLEAN'
-          OR 'WDY_BOOLEAN'
-          OR 'BOOLE_D'
-          OR 'OS_BOOLEAN'.
+      WHEN `ABAP_BOOL`
+          OR `XSDBOOLEAN`
+          OR `FLAG`
+          OR `XFLAG`
+          OR `XFELD`
+          OR `ABAP_BOOLEAN`
+          OR `WDY_BOOLEAN`
+          OR `BOOLE_D`
+          OR `OS_BOOLEAN`.
         result = abap_true.
     ENDCASE.
 
@@ -855,7 +855,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     DATA lr_row TYPE REF TO data.
 
     SPLIT val AT cl_abap_char_utilities=>newline INTO TABLE DATA(lt_rows).
-    SPLIT lt_rows[ 1 ] AT ';' INTO TABLE DATA(lt_cols).
+    SPLIT lt_rows[ 1 ] AT `;` INTO TABLE DATA(lt_cols).
 
     LOOP AT lt_cols REFERENCE INTO DATA(lr_col).
 
@@ -878,7 +878,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
     LOOP AT lt_rows REFERENCE INTO DATA(lr_rows) FROM 2.
 
-      SPLIT lr_rows->* AT ';' INTO TABLE lt_cols.
+      SPLIT lr_rows->* AT `;` INTO TABLE lt_cols.
       CREATE DATA lr_row TYPE HANDLE struc.
 
       LOOP AT lt_cols REFERENCE INTO lr_col.
@@ -1147,7 +1147,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 |x, nsis, objectivec, ocaml, pascal, perl, pgsql, php, plain_text, powershell, praat, prolog, properties, protobuf, python, r, razor, rdoc, rhtml, rst, ruby, rust, sass, scad, scala, scheme, scss, sh, sjs, smarty, snippets, soy_template, space, sql,| &&
       | sqlserver, stylus, svg, swift, swig, tcl, tex, text, textile, toml, tsx, twig, typescript, vala, vbscript, velocity, verilog, vhdl, wollok, xml, xquery, terraform, slim, redshift, red, puppet, php_laravel_blade, mixal, jssm, fsharp, edifact,| &&
       | csp, cssound_score, cssound_orchestra, cssound_document| ##NO_TEXT.
-    SPLIT lv_types AT ',' INTO TABLE result.
+    SPLIT lv_types AT `,` INTO TABLE result.
 
   ENDMETHOD.
 
@@ -1180,7 +1180,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     DATA(lv_sql) = CONV string( val ).
     REPLACE ALL OCCURRENCES OF ` ` IN lv_sql WITH ``.
     lv_sql = to_upper( lv_sql ).
-    SPLIT lv_sql AT 'SELECTFROM' INTO DATA(lv_dummy) DATA(lv_tab).
+    SPLIT lv_sql AT `SELECTFROM` INTO DATA(lv_dummy) DATA(lv_tab).
     SPLIT lv_tab AT `FIELDS` INTO lv_tab lv_dummy.
 
     result-tabname = lv_tab.
@@ -1257,12 +1257,12 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
     DATA(lv_search) = replace( val  = i_val
                                sub  = `%3D`
-                               with = '='
+                               with = `=`
                                occ  = 0 ).
 
     lv_search = replace( val  = lv_search
                          sub  = `%26`
-                         with = '&'
+                         with = `&`
                          occ  = 0 ).
 
     lv_search = shift_left( val = lv_search
@@ -1331,7 +1331,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     CALL TRANSFORMATION id SOURCE XML rtti_data RESULT srtti = srtti.
 
     DATA rtti_type TYPE REF TO cl_abap_typedescr.
-    CALL METHOD srtti->('GET_RTTI')
+    CALL METHOD srtti->(`GET_RTTI`)
       RECEIVING
         rtti = rtti_type.
 
@@ -1347,11 +1347,11 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
   METHOD xml_srtti_stringify.
 
-    IF rtti_check_class_exists( 'ZCL_SRTTI_TYPEDESCR' ) = abap_true.
+    IF rtti_check_class_exists( `ZCL_SRTTI_TYPEDESCR` ) = abap_true.
 
       DATA srtti TYPE REF TO object.
       DATA(lv_classname) = `ZCL_SRTTI_TYPEDESCR`.
-      CALL METHOD (lv_classname)=>('CREATE_BY_DATA_OBJECT')
+      CALL METHOD (lv_classname)=>(`CREATE_BY_DATA_OBJECT`)
         EXPORTING
           data_object = data
         RECEIVING
@@ -1361,7 +1361,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     ELSE.
 
       TRY.
-          CALL METHOD z2ui5_cl_srt_typedescr=>('CREATE_BY_DATA_OBJECT')
+          CALL METHOD z2ui5_cl_srt_typedescr=>(`CREATE_BY_DATA_OBJECT`)
             EXPORTING
               data_object = data
             RECEIVING
@@ -1434,7 +1434,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     IF table_name IS INITIAL.
       RAISE EXCEPTION TYPE z2ui5_cx_util_error
         EXPORTING
-          val = 'TABLE_NAME_INITIAL_ERROR'.
+          val = `TABLE_NAME_INITIAL_ERROR`.
     ENDIF.
 
     TRY.
@@ -1579,7 +1579,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
 *      DATA result TYPE string.
 *    DATA lt_where TYPE rsdmd_t_where.
-      DATA(lv_fm) = 'RSDS_RANGE_TO_WHERE'.
+      DATA(lv_fm) = `RSDS_RANGE_TO_WHERE`.
       CALL FUNCTION lv_fm
         EXPORTING
           i_t_range      = lt_range
@@ -1626,8 +1626,8 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
   METHOD ui5_get_msg_type.
 
     result = SWITCH #( val
-                       WHEN 'E' THEN cs_ui5_msg_type-e
-                       WHEN 'S' THEN cs_ui5_msg_type-s
+                       WHEN `E` THEN cs_ui5_msg_type-e
+                       WHEN `S` THEN cs_ui5_msg_type-s
                        WHEN `W` THEN cs_ui5_msg_type-w
                        ELSE cs_ui5_msg_type-i ).
 

--- a/src/00/03/z2ui5_cl_util.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_util.clas.testclasses.abap
@@ -167,16 +167,16 @@ CLASS ltcl_unit_test_open_abap IMPLEMENTATION.
   METHOD test_substring_after.
 
     cl_abap_unit_assert=>assert_equals( exp = ` string`
-                                        act = substring_after( val = 'this is a string'
-                                                               sub = 'a' ) ).
+                                        act = substring_after( val = `this is a string`
+                                                               sub = `a` ) ).
 
   ENDMETHOD.
 
   METHOD test_substring_before.
 
     cl_abap_unit_assert=>assert_equals( exp = `this is `
-                                        act = substring_before( val = 'this is a string'
-                                                                sub = 'a' ) ).
+                                        act = substring_before( val = `this is a string`
+                                                                sub = `a` ) ).
 
   ENDMETHOD.
 
@@ -192,13 +192,13 @@ CLASS ltcl_unit_test_open_abap IMPLEMENTATION.
 
     DATA(lv_search) = replace( val  = `one two three`
                                sub  = `two`
-                               with = 'ABC'
+                               with = `ABC`
                                occ  = 0 ) ##NEEDED.
 
     cl_abap_unit_assert=>assert_equals( exp = `one ABC three`
                                         act = replace( val  = `one two three`
                                                        sub  = `two`
-                                                       with = 'ABC'
+                                                       with = `ABC`
                                                        occ  = 0 ) ).
 
   ENDMETHOD.
@@ -409,7 +409,7 @@ CLASS ltcl_unit_test IMPLEMENTATION.
 
   METHOD test_func_get_user_tech.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -721,13 +721,13 @@ CLASS ltcl_unit_test IMPLEMENTATION.
 
   METHOD test_get_token_t_by_r_t.
 
-    DATA(lt_range) = VALUE z2ui5_cl_util=>ty_t_range( ( sign = 'I' option = 'EQ' low = `table` high = `` )
+    DATA(lt_range) = VALUE z2ui5_cl_util=>ty_t_range( ( sign = `I` option = `EQ` low = `table` high = `` )
      ).
 
     DATA(lt_result) = z2ui5_cl_util=>filter_get_token_t_by_range_t( lt_range ).
 
     DATA(lt_exp) = VALUE z2ui5_cl_util=>ty_t_token(
-                             ( key = `=table` text = `=table` visible = 'X' selkz = '' editable = 'X' )
+                             ( key = `=table` text = `=table` visible = `X` selkz = `` editable = `X` )
     ).
 
     cl_abap_unit_assert=>assert_equals( exp = lt_exp
@@ -738,7 +738,7 @@ CLASS ltcl_unit_test IMPLEMENTATION.
 
   METHOD test_rtti_get_t_attri_by_incl.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/00/03/z2ui5_cl_util_http.clas.abap
+++ b/src/00/03/z2ui5_cl_util_http.clas.abap
@@ -90,16 +90,16 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
       DATA object TYPE REF TO object.
       FIELD-SYMBOLS <any> TYPE any.
 
-      ASSIGN mo_server_onprem->('RESPONSE') TO <any>.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('DELETE_COOKIE')
+      CALL METHOD object->(`DELETE_COOKIE`)
         EXPORTING
           name = lv_val.
 
     ELSE.
 
-*      CALL METHOD mo_response_cloud->('DELETE_COOKIE_AT_CLIENT')
+*      CALL METHOD mo_response_cloud->(`DELETE_COOKIE_AT_CLIENT`)
 *        EXPORTING
 *          name = lv_val.
 
@@ -116,10 +116,10 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('RESPONSE') TO <any>.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('GET_COOKIE')
+      CALL METHOD object->(`GET_COOKIE`)
         EXPORTING
           name  = lv_val
         IMPORTING
@@ -127,7 +127,7 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     ELSE.
 
-*      CALL METHOD mo_request_cloud->('GET_COOKIE')
+*      CALL METHOD mo_request_cloud->(`GET_COOKIE`)
 *        EXPORTING
 *          i_name  = lv_val
 *        RECEIVING
@@ -146,10 +146,10 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('REQUEST') TO <any>.
+      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('GET_HEADER_FIELD')
+      CALL METHOD object->(`GET_HEADER_FIELD`)
         EXPORTING
           name  = lv_val
         RECEIVING
@@ -157,7 +157,7 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     ELSE.
 
-      CALL METHOD mo_request_cloud->('IF_WEB_HTTP_REQUEST~GET_HEADER_FIELD')
+      CALL METHOD mo_request_cloud->(`IF_WEB_HTTP_REQUEST~GET_HEADER_FIELD`)
         EXPORTING
           i_name  = lv_val
         RECEIVING
@@ -176,17 +176,17 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
     DATA(lv_v) = CONV string( v ).
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('RESPONSE') TO <any>.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('SET_HEADER_FIELD')
+      CALL METHOD object->(`SET_HEADER_FIELD`)
         EXPORTING
           name  = lv_n
           value = lv_v.
 
     ELSE.
 
-      CALL METHOD mo_response_cloud->('IF_WEB_HTTP_RESPONSE~SET_HEADER_FIELD')
+      CALL METHOD mo_response_cloud->(`IF_WEB_HTTP_RESPONSE~SET_HEADER_FIELD`)
         EXPORTING
           i_name  = lv_n
           i_value = lv_v.
@@ -217,16 +217,16 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('REQUEST') TO <any>.
+      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('GET_CDATA')
+      CALL METHOD object->(`GET_CDATA`)
         RECEIVING
           data = result.
 
     ELSE.
 
-      CALL METHOD mo_request_cloud->('IF_WEB_HTTP_REQUEST~GET_TEXT')
+      CALL METHOD mo_request_cloud->(`IF_WEB_HTTP_REQUEST~GET_TEXT`)
         RECEIVING
           r_value = result.
 
@@ -241,16 +241,16 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('REQUEST') TO <any>.
+      ASSIGN mo_server_onprem->(`REQUEST`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('IF_HTTP_REQUEST~GET_METHOD')
+      CALL METHOD object->(`IF_HTTP_REQUEST~GET_METHOD`)
         RECEIVING
           method = result.
 
     ELSE.
 
-      CALL METHOD mo_request_cloud->('IF_WEB_HTTP_REQUEST~GET_METHOD')
+      CALL METHOD mo_request_cloud->(`IF_WEB_HTTP_REQUEST~GET_METHOD`)
         RECEIVING
           r_value = result.
 
@@ -265,16 +265,16 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('RESPONSE') TO <any>.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('SET_CDATA')
+      CALL METHOD object->(`SET_CDATA`)
         EXPORTING
           data = val.
 
     ELSE.
 
-      CALL METHOD mo_response_cloud->('IF_WEB_HTTP_RESPONSE~SET_TEXT')
+      CALL METHOD mo_response_cloud->(`IF_WEB_HTTP_RESPONSE~SET_TEXT`)
         EXPORTING
           i_text = val.
 
@@ -291,17 +291,17 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      ASSIGN mo_server_onprem->('RESPONSE') TO <any>.
+      ASSIGN mo_server_onprem->(`RESPONSE`) TO <any>.
       object = <any>.
 
-      CALL METHOD object->('IF_HTTP_RESPONSE~SET_STATUS')
+      CALL METHOD object->(`IF_HTTP_RESPONSE~SET_STATUS`)
         EXPORTING
           code   = code
           reason = lv_reason.
 
     ELSE.
 
-      CALL METHOD mo_response_cloud->('IF_WEB_HTTP_RESPONSE~SET_STATUS')
+      CALL METHOD mo_response_cloud->(`IF_WEB_HTTP_RESPONSE~SET_STATUS`)
         EXPORTING
           i_code   = code
           i_reason = lv_reason.
@@ -314,14 +314,14 @@ CLASS z2ui5_cl_util_http IMPLEMENTATION.
 
     IF mo_server_onprem IS BOUND.
 
-      CALL METHOD mo_server_onprem->('SET_SESSION_STATEFUL')
+      CALL METHOD mo_server_onprem->(`SET_SESSION_STATEFUL`)
         EXPORTING
           stateful = val.
 
     ELSE.
 
       "FEATURE IN CLOUD NOT RELEASED
-*      ASSERT 1 = 'NO_STATEFUL_FEATURE_IN_CLOUD_ERROR'.
+*      ASSERT 1 = `NO_STATEFUL_FEATURE_IN_CLOUD_ERROR`.
 
     ENDIF.
 

--- a/src/00/03/z2ui5_cl_util_msg.clas.abap
+++ b/src/00/03/z2ui5_cl_util_msg.clas.abap
@@ -56,7 +56,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
           ASSIGN COMPONENT ls_attri->name OF STRUCTURE val TO FIELD-SYMBOL(<comp>).
 *          ASSIGN (lv_name) TO FIELD-SYMBOL(<comp>).
 
-          IF ls_attri->name = 'ITEM'.
+          IF ls_attri->name = `ITEM`.
             lt_tab = msg_get( <comp> ).
             INSERT LINES OF lt_tab INTO TABLE result.
             RETURN.
@@ -67,7 +67,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
         ENDLOOP.
         IF ls_result-text IS INITIAL AND ls_result-id IS NOT INITIAL.
           ls_result-id = to_upper( ls_result-id ).
-          MESSAGE ID ls_result-id TYPE 'I' NUMBER ls_result-no
+          MESSAGE ID ls_result-id TYPE `I` NUMBER ls_result-no
                   WITH ls_result-v1 ls_result-v2 ls_result-v3 ls_result-v4
                   INTO ls_result-text.
         ENDIF.
@@ -76,10 +76,10 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
       WHEN cl_abap_datadescr=>typekind_oref.
         TRY.
             DATA(lx) = CAST cx_root( val ).
-            ls_result = VALUE #( type = 'E' text = lx->get_text( ) ).
+            ls_result = VALUE #( type = `E` text = lx->get_text( ) ).
             DATA(lt_attri_o) = z2ui5_cl_util=>rtti_get_t_attri_by_oref( val ).
             LOOP AT lt_attri_o REFERENCE INTO DATA(ls_attri_o)
-                 WHERE visibility = 'U'.
+                 WHERE visibility = `U`.
               DATA(lv_name) = ls_attri_o->name.
               ASSIGN val->(lv_name) TO <comp>.
               ls_result = msg_map( name = ls_attri_o->name val = <comp> is_msg = ls_result ).
@@ -93,7 +93,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
             TRY.
 
                 DATA lr_tab TYPE REF TO data.
-                CREATE DATA lr_tab TYPE ('if_bali_log=>ty_item_table').
+                CREATE DATA lr_tab TYPE (`if_bali_log=>ty_item_table`).
                 ASSIGN lr_tab->* TO FIELD-SYMBOL(<tab2>).
 
                 CALL METHOD obj->(`IF_BALI_LOG~GET_ALL_ITEMS`)
@@ -107,7 +107,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
 
                 TRY.
 
-                    CREATE DATA lr_tab TYPE ('BAPIRETTAB').
+                    CREATE DATA lr_tab TYPE (`BAPIRETTAB`).
                     ASSIGN lr_tab->* TO <tab2>.
 
                     CALL METHOD obj->(`ZIF_LOGGER~EXPORT_TO_TABLE`)
@@ -122,7 +122,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
 
                     lt_attri_o = z2ui5_cl_util=>rtti_get_t_attri_by_oref( val ).
                     LOOP AT lt_attri_o REFERENCE INTO ls_attri_o
-                         WHERE visibility = 'U'.
+                         WHERE visibility = `U`.
                       lv_name = ls_attri_o->name.
                       ASSIGN obj->(lv_name) TO <comp>.
                       ls_result = msg_map( name = ls_attri_o->name val = <comp> is_msg = ls_result ).
@@ -150,23 +150,23 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
 
     result = is_msg.
     CASE name.
-      WHEN 'ID' OR 'MSGID'.
+      WHEN `ID` OR `MSGID`.
         result-id = val.
-      WHEN 'NO' OR 'NUMBER' OR 'MSGNO'.
+      WHEN `NO` OR `NUMBER` OR `MSGNO`.
         result-no = val.
-      WHEN 'MESSAGE' OR 'TEXT'.
+      WHEN `MESSAGE` OR `TEXT`.
         result-text = val.
-      WHEN 'TYPE' OR 'MSGTY'.
+      WHEN `TYPE` OR `MSGTY`.
         result-type = val.
-      WHEN 'MESSAGE_V1' OR 'MSGV1' OR 'V1'.
+      WHEN `MESSAGE_V1` OR `MSGV1` OR `V1`.
         result-v1 = val.
-      WHEN 'MESSAGE_V2' OR 'MSGV2' OR 'V2'.
+      WHEN `MESSAGE_V2` OR `MSGV2` OR `V2`.
         result-v2 = val.
-      WHEN 'MESSAGE_V3' OR 'MSGV3' OR 'V3'.
+      WHEN `MESSAGE_V3` OR `MSGV3` OR `V3`.
         result-v3 = val.
-      WHEN 'MESSAGE_V4' OR 'MSGV4' OR 'V4'.
+      WHEN `MESSAGE_V4` OR `MSGV4` OR `V4`.
         result-v4 = val.
-      WHEN 'TIME_STMP'.
+      WHEN `TIME_STMP`.
         result-timestampl = val.
     ENDCASE.
 

--- a/src/00/03/z2ui5_cl_util_msg.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_util_msg.clas.testclasses.abap
@@ -17,12 +17,12 @@ CLASS ltcl_unit_test_msg_mapper IMPLEMENTATION.
 
   METHOD test_sy.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
-    data(lv_dummy2) = 'NET'.
-    MESSAGE ID lv_dummy2 TYPE 'I' NUMBER '001' INTO DATA(lv_dummy).
+    data(lv_dummy2) = `NET`.
+    MESSAGE ID lv_dummy2 TYPE `I` NUMBER `001` INTO DATA(lv_dummy).
     DATA(lt_result) = z2ui5_cl_util_msg=>msg_get_by_sy( ).
 
    cl_abap_unit_assert=>assert_equals( exp = `NET`
@@ -38,12 +38,12 @@ CLASS ltcl_unit_test_msg_mapper IMPLEMENTATION.
 
   METHOD test_bapiret.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
     DATA(lt_msg) = VALUE bapirettab(
-      ( type = 'E' id = 'MSG1' number = '001' message = 'An empty Report field causes an empty XML Message to be sent' )
+      ( type = `E` id = `MSG1` number = `001` message = `An empty Report field causes an empty XML Message to be sent` )
      ).
 
     DATA(lt_result) = z2ui5_cl_util_msg=>msg_get( lt_msg[ 1 ] ).
@@ -61,13 +61,13 @@ CLASS ltcl_unit_test_msg_mapper IMPLEMENTATION.
 
   METHOD test_bapirettab.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
     DATA(lt_msg) = VALUE bapirettab(
-      ( type = 'E' id = 'MSG1' number = '001' message = 'An empty Report field causes an empty XML Message to be sent' )
-      ( type = 'I' id = 'MSG2' number = '002' message = 'Product already in use' ) ).
+      ( type = `E` id = `MSG1` number = `001` message = `An empty Report field causes an empty XML Message to be sent` )
+      ( type = `I` id = `MSG2` number = `002` message = `Product already in use` ) ).
 
     DATA(lt_result) = z2ui5_cl_util_msg=>msg_get( lt_msg ).
 

--- a/src/00/03/z2ui5_cl_util_range.clas.abap
+++ b/src/00/03/z2ui5_cl_util_range.clas.abap
@@ -4,22 +4,22 @@ CLASS z2ui5_cl_util_range DEFINITION PUBLIC
 
     CONSTANTS:
       BEGIN OF signs,
-        including TYPE string VALUE 'I',
-        excluding TYPE string VALUE 'E',
+        including TYPE string VALUE `I`,
+        excluding TYPE string VALUE `E`,
       END OF signs.
 
     CONSTANTS:
       BEGIN OF options,
-        equal                TYPE string VALUE 'EQ',
-        not_equal            TYPE string VALUE 'NE',
-        between              TYPE string VALUE 'BT',
-        not_between          TYPE string VALUE 'NB',
-        contains_pattern     TYPE string VALUE 'CP',
-        not_contains_pattern TYPE string VALUE 'NP',
-        greater_than         TYPE string VALUE 'GT',
-        greater_equal        TYPE string VALUE 'GE',
-        less_equal           TYPE string VALUE 'LE',
-        less_than            TYPE string VALUE 'LT',
+        equal                TYPE string VALUE `EQ`,
+        not_equal            TYPE string VALUE `NE`,
+        between              TYPE string VALUE `BT`,
+        not_between          TYPE string VALUE `NB`,
+        contains_pattern     TYPE string VALUE `CP`,
+        not_contains_pattern TYPE string VALUE `NP`,
+        greater_than         TYPE string VALUE `GT`,
+        greater_equal        TYPE string VALUE `GE`,
+        less_equal           TYPE string VALUE `LE`,
+        less_than            TYPE string VALUE `LT`,
       END OF options.
 
     METHODS constructor
@@ -66,10 +66,10 @@ CLASS z2ui5_cl_util_range IMPLEMENTATION.
 
     LOOP AT <lt_range> ASSIGNING FIELD-SYMBOL(<ls_range_item>).
 
-      ASSIGN COMPONENT 'SIGN' OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_sign>).
-      ASSIGN COMPONENT 'OPTION' OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_option>).
-      ASSIGN COMPONENT 'LOW' OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_low>).
-      ASSIGN COMPONENT 'HIGH' OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_high>).
+      ASSIGN COMPONENT `SIGN` OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_sign>).
+      ASSIGN COMPONENT `OPTION` OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_option>).
+      ASSIGN COMPONENT `LOW` OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_low>).
+      ASSIGN COMPONENT `HIGH` OF STRUCTURE <ls_range_item> TO FIELD-SYMBOL(<lv_high>).
 
       IF sy-tabix <> 1.
         result = |{ result } OR|.
@@ -97,11 +97,11 @@ CLASS z2ui5_cl_util_range IMPLEMENTATION.
           result = |{ result } NOT BETWEEN { quote( <lv_low> ) } AND { quote( <lv_high> ) }|.
 
         WHEN options-contains_pattern.
-          TRANSLATE <lv_low> USING '*%'.
+          TRANSLATE <lv_low> USING `*%`.
           result = |{ result } LIKE { quote( <lv_low> ) }|.
 
         WHEN options-not_contains_pattern.
-          TRANSLATE <lv_low> USING '*%'.
+          TRANSLATE <lv_low> USING `*%`.
           result = |{ result } NOT LIKE { quote( <lv_low> ) }|.
       ENDCASE.
     ENDLOOP.

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -88,7 +88,7 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
               result->mo_app = lo_app.
               result->ms_actual-check_on_navigated = abap_true.
               result->ms_next-s_set-set_app_state_active = abap_true.
-              result->mo_app->ms_draft-id_prev_app_stack = ''.
+              result->mo_app->ms_draft-id_prev_app_stack = ``.
               result->mo_app->ms_draft-id = z2ui5_cl_util=>uuid_get_c32( ).
               RETURN.
             CATCH cx_root ##NO_HANDLER.

--- a/src/01/02/z2ui5_cl_core_app.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_app.clas.testclasses.abap
@@ -42,7 +42,7 @@ CLASS ltcl_test_db IMPLEMENTATION.
 
   METHOD test_db_save.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -112,8 +112,8 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
         DATA(lv_type) = z2ui5_cl_util=>ui5_get_msg_type( lt_msg[ 1 ]-type ).
         lv_type = to_lower( lv_type ).
         DATA(lv_title) = SWITCH #( lt_msg[ 1 ]-type
-                                   WHEN 'E' THEN `Error`
-                                   WHEN 'S' THEN `Success`
+                                   WHEN `E` THEN `Error`
+                                   WHEN `S` THEN `Success`
                                    WHEN `W` THEN `Warning`
                                    ELSE `Information` ).
 
@@ -126,8 +126,8 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
         lv_details = |{ lv_details }</ul>|.
         IF title IS INITIAL.
           lv_title = SWITCH #( lt_msg[ 1 ]-type
-                               WHEN 'E' THEN `Error`
-                               WHEN 'S' THEN `Success`
+                               WHEN `E` THEN `Error`
+                               WHEN `S` THEN `Success`
                                WHEN `W` THEN `Warning`
                                ELSE `Information` ).
         ENDIF.
@@ -141,16 +141,16 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
       lv_title = title.
       lv_details = details.
 
-      IF lv_type = 'information'.
-        lv_type = 'show'.
+      IF lv_type = `information`.
+        lv_type = `show`.
         IF lv_title IS INITIAL.
-          lv_title = 'Information'.
+          lv_title = `Information`.
         ENDIF.
       ENDIF.
     ENDIF.
 
-    IF lv_type = ''.
-      lv_type = 'show'.
+    IF lv_type = ``.
+      lv_type = `show`.
     ENDIF.
 
     mo_action->ms_next-s_set-s_msg_box = VALUE #( text              = lv_text
@@ -316,7 +316,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
     ELSE.
 
       DATA(lo_object) = CAST object( val ).
-      CALL METHOD lo_object->('STRINGIFY')
+      CALL METHOD lo_object->(`STRINGIFY`)
         RECEIVING result = mo_action->ms_next-s_set-s_view-xml.
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -51,7 +51,7 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     TRY.
 
         DATA(lo_ajson) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>parse( val ) ).
-        lo_ajson = lo_ajson->slice( 'value' ).
+        lo_ajson = lo_ajson->slice( `value` ).
 
         DATA(lv_model_edit_name) = |/{ z2ui5_if_core_types=>cs_ui5-two_way_model }|.
 
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
         TRY.
             DATA(lv_hash) = result-s_front-hash.
 
-            SPLIT lv_hash AT '&/' INTO DATA(lv_dummy) lv_hash.
+            SPLIT lv_hash AT `&/` INTO DATA(lv_dummy) lv_hash.
             IF lv_hash IS INITIAL.
               lv_hash = result-s_front-hash+2.
             ENDIF.
@@ -256,7 +256,7 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     TRY.
         DATA(li_client2) = CAST z2ui5_if_client( li_client ).
 
-        IF li_client2->get( )-event = '___ZZZ_NAL'.
+        IF li_client2->get( )-event = `___ZZZ_NAL`.
           li_client2->popup_destroy( ).
           li_client2->nav_app_leave( ).
         ELSE.

--- a/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
@@ -11,7 +11,7 @@ CLASS z2ui5_cl_core_handler DEFINITION LOCAL FRIENDS ltcl_test_handler_post.
 CLASS ltcl_test_handler_post IMPLEMENTATION.
   METHOD load_startup_app.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
@@ -78,7 +78,7 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
   METHOD test_one_way.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -98,7 +98,7 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
   METHOD test_error_diff.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -125,7 +125,7 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
   METHOD test_two_way.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -185,7 +185,7 @@ ENDCLASS.
 CLASS ltcl_test_main_structure IMPLEMENTATION.
   METHOD test_one_way_lev1.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -212,7 +212,7 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
 
   METHOD test_one_way_lev2.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -232,7 +232,7 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
 
   METHOD test_one_way_lev3.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -251,7 +251,7 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
 
   METHOD test_one_way_lev4_long_name.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -306,7 +306,7 @@ CLASS ltcl_test_main_object IMPLEMENTATION.
 
   METHOD test_one_way_value.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -328,7 +328,7 @@ CLASS ltcl_test_main_object IMPLEMENTATION.
 
   METHOD test_one_way_struc.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
@@ -519,7 +519,7 @@ CLASS ltcl_test_app_root_attri IMPLEMENTATION.
   METHOD test_obj_tab_ref.
 
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -531,7 +531,7 @@ CLASS ltcl_test_app_root_attri IMPLEMENTATION.
 
     DATA(ls_attri) = lo_model->main_attri_search( lo_app->mo_obj->mr_tab ).
 
-    IF ls_attri->name <> 'MT_TAB'.
+    IF ls_attri->name <> `MT_TAB`.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
 
@@ -545,8 +545,8 @@ CLASS ltcl_test_app_root IMPLEMENTATION.
   METHOD constructor.
 
     INSERT VALUE #(
-        comp1 = 'comp1'
-        comp2 = 'comp2'
+        comp1 = `comp1`
+        comp2 = `comp2`
       ) INTO TABLE mt_tab.
 
     mo_obj = NEW ltcl_test_app_root_attri(
@@ -599,7 +599,7 @@ CLASS ltcl_test_app_root_attri2 IMPLEMENTATION.
 
   METHOD test_obj_struc_ref.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -611,7 +611,7 @@ CLASS ltcl_test_app_root_attri2 IMPLEMENTATION.
 
     DATA(ls_attri) = lo_model->main_attri_search( lo_app->mo_obj->mr_struc ).
 
-    IF ls_attri->name <> 'MS_STRUC'.
+    IF ls_attri->name <> `MS_STRUC`.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
 
@@ -624,8 +624,8 @@ CLASS ltcl_test_app_root2 IMPLEMENTATION.
   METHOD constructor.
 
     ms_struc = VALUE #(
-        comp1 = 'comp1'
-        comp2 = 'comp2' ).
+        comp1 = `comp1`
+        comp2 = `comp2` ).
 
     mo_obj = NEW ltcl_test_app_root_attri2(
       ir_struc = REF #( ms_struc ) ).
@@ -649,7 +649,7 @@ CLASS ltcl_test_app_root4 IMPLEMENTATION.
 
   METHOD test_tab_ref_gen.
 
-    IF sy-sysid = 'ABC'.
+    IF sy-sysid = `ABC`.
       RETURN.
     ENDIF.
 
@@ -669,8 +669,8 @@ CLASS ltcl_test_app_root4 IMPLEMENTATION.
     FIELD-SYMBOLS <tab> TYPE STANDARD TABLE.
     ASSIGN lo_app->mr_tab->* TO <tab>.
     INSERT VALUE ty_s_row(
-      comp1 = 'comp1'
-      comp2 = 'comp2'
+      comp1 = `comp1`
+      comp2 = `comp2`
       ) INTO TABLE <tab>.
 
 
@@ -682,7 +682,7 @@ CLASS ltcl_test_app_root4 IMPLEMENTATION.
 
     DATA(ls_attri) = lo_model->main_attri_search( lo_app->mr_tab ).
 
-    IF ls_attri->name <> 'MR_TAB->*'.
+    IF ls_attri->name <> `MR_TAB->*`.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
 

--- a/src/02/01/z2ui5_cl_pop_bal.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_bal.clas.abap
@@ -82,32 +82,32 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
     popup = popup->dialog( title             = `Business Application Log`
-                           contentheight     = '50%'
-                           contentwidth      = '50%'
+                           contentheight     = `50%`
+                           contentwidth      = `50%`
                            verticalscrolling = abap_false
-                           afterclose        = client->_event( 'BUTTON_CONTINUE' ) ).
+                           afterclose        = client->_event( `BUTTON_CONTINUE` ) ).
 
     DATA(table) = popup->table( client->_bind( mt_msg ) ).
     table->columns(
-         )->column( )->text( 'Date' )->get_parent(
-         )->column( )->text( 'Time' )->get_parent(
-         )->column( )->text( 'Type' )->get_parent(
-         )->column( )->text( 'ID' )->get_parent(
-         )->column( )->text( 'No' )->get_parent(
-         )->column( )->text( 'Message' ).
+         )->column( )->text( `Date` )->get_parent(
+         )->column( )->text( `Time` )->get_parent(
+         )->column( )->text( `Type` )->get_parent(
+         )->column( )->text( `ID` )->get_parent(
+         )->column( )->text( `No` )->get_parent(
+         )->column( )->text( `Message` ).
 
     table->items( )->column_list_item( )->cells(
-       )->text( '{DATE}'
-       )->text( '{TIME}'
-       )->text( '{TYPE}'
-       )->text( '{ID}'
-       )->text( '{NUMBER}'
-       )->text( '{MESSAGE}' ).
+       )->text( `{DATE}`
+       )->text( `{TIME}`
+       )->text( `{TYPE}`
+       )->text( `{ID}`
+       )->text( `{NUMBER}`
+       )->text( `{MESSAGE}` ).
 
     popup->buttons(
-       )->button( text  = 'continue'
-                  press = client->_event( 'BUTTON_CONTINUE' )
-                  type  = 'Emphasized' ).
+       )->button( text  = `continue`
+                  press = client->_event( `BUTTON_CONTINUE` )
+                  type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_data.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_data.clas.abap
@@ -15,7 +15,7 @@ CLASS z2ui5_cl_pop_data DEFINITION
     DATA mr_data TYPE REF TO data.
 
   PROTECTED SECTION.
-    DATA title  TYPE string VALUE 'Table View'.
+    DATA title  TYPE string VALUE `Table View`.
     DATA client TYPE REF TO z2ui5_if_client.
 
     METHODS display.

--- a/src/02/01/z2ui5_cl_pop_error.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_error.clas.abap
@@ -33,15 +33,15 @@ CLASS z2ui5_cl_pop_error IMPLEMENTATION.
   METHOD view_display.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = `Error View`
-                                                               afterclose = client->_event( 'BUTTON_CONFIRM' )
+                                                               afterclose = client->_event( `BUTTON_CONFIRM` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                       )->text( error->get_text( )
               )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = `OK`
-                             press = client->_event( 'BUTTON_CONFIRM' )
-                             type  = 'Emphasized' ).
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_file_dl.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_file_dl.clas.abap
@@ -67,7 +67,7 @@ CLASS z2ui5_cl_pop_file_dl IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
-                                                               afterclose = client->_event( 'BUTTON_CANCEL' )
+                                                               afterclose = client->_event( `BUTTON_CANCEL` )
               )->content( ).
 
     IF mv_check_download = abap_true.
@@ -82,7 +82,7 @@ CLASS z2ui5_cl_pop_file_dl IMPLEMENTATION.
 
     ENDIF.
 
-    popup->vbox( 'sapUiMediumMargin'
+    popup->vbox( `sapUiMediumMargin`
       )->label( `Name`
       )->input( value   = mv_name
                 enabled = abap_false
@@ -95,10 +95,10 @@ CLASS z2ui5_cl_pop_file_dl IMPLEMENTATION.
       )->get_parent( )->get_parent(
       )->buttons(
       )->button( text  = button_text_cancel
-                 press = client->_event( 'BUTTON_CANCEL' )
+                 press = client->_event( `BUTTON_CANCEL` )
       )->button( text  = `Download`
-                 press = client->_event( 'BUTTON_CONFIRM' )
-                 type  = 'Emphasized' ).
+                 press = client->_event( `BUTTON_CONFIRM` )
+                 type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_file_ul.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_file_ul.clas.abap
@@ -68,22 +68,22 @@ CLASS z2ui5_cl_pop_file_ul IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
-                                                               afterclose = client->_event( 'BUTTON_CANCEL' )
+                                                               afterclose = client->_event( `BUTTON_CANCEL` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                   )->label( question_text
                   )->_z2ui5( )->file_uploader( value       = client->_bind_edit( mv_value )
                                                path        = client->_bind_edit( mv_path )
-                                               placeholder = 'filepath here...'
-                                               upload      = client->_event( 'UPLOAD' )
+                                               placeholder = `filepath here...`
+                                               upload      = client->_event( `UPLOAD` )
               )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = button_text_cancel
-                             press = client->_event( 'BUTTON_CANCEL' )
+                             press = client->_event( `BUTTON_CANCEL` )
                   )->button( text    = button_text_confirm
-                             press   = client->_event( 'BUTTON_CONFIRM' )
+                             press   = client->_event( `BUTTON_CONFIRM` )
                              enabled = client->_bind( check_confirm_enabled )
-                             type    = 'Emphasized' ).
+                             type    = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_get_range.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_get_range.clas.abap
@@ -67,49 +67,49 @@ CLASS z2ui5_cl_pop_get_range IMPLEMENTATION.
 
     DATA(lo_popup) = z2ui5_cl_xml_view=>factory_popup( ).
 
-    lo_popup = lo_popup->dialog( afterclose    = client->_event( 'BUTTON_CANCEL' )
+    lo_popup = lo_popup->dialog( afterclose    = client->_event( `BUTTON_CANCEL` )
                                  contentheight = `50%`
                                  contentwidth  = `50%`
-                                 title         = 'Define Filter Conditons' ).
+                                 title         = `Define Filter Conditons` ).
 
     DATA(vbox) = lo_popup->vbox( height         = `100%`
-                                 justifycontent = 'SpaceBetween' ).
+                                 justifycontent = `SpaceBetween` ).
 
     DATA(item) = vbox->list( nodata          = `no conditions defined`
                              items           = client->_bind_edit( mt_filter )
-                             selectionchange = client->_event( 'SELCHANGE' )
+                             selectionchange = client->_event( `SELCHANGE` )
                 )->custom_list_item( ).
 
     DATA(grid) = item->grid( ).
 
     grid->combobox( selectedkey = `{OPTION}`
                     items       = client->_bind( mt_mapping )
-             )->item( key  = '{N}'
-                      text = '{N}'
+             )->item( key  = `{N}`
+                      text = `{N}`
              )->get_parent(
              )->input( value  = `{LOW}`
-                       submit = client->_event( 'BUTTON_CONFIRM' )
+                       submit = client->_event( `BUTTON_CONFIRM` )
              )->input( value   = `{HIGH}`
                        visible = `{= ${OPTION} === 'BT' }`
-                       submit  = client->_event( 'BUTTON_CONFIRM' )
-             )->button( icon  = 'sap-icon://decline'
+                       submit  = client->_event( `BUTTON_CONFIRM` )
+             )->button( icon  = `sap-icon://decline`
                         type  = `Transparent`
                         press = client->_event( val   = `POPUP_DELETE`
                                                 t_arg = VALUE #( ( `${KEY}` ) ) ) ).
 
     lo_popup->buttons(
         )->button( text  = `Delete All`
-                   icon  = 'sap-icon://delete'
+                   icon  = `sap-icon://delete`
                    type  = `Transparent`
                    press = client->_event( val = `POPUP_DELETE_ALL` )
         )->button( text  = `Add Item`
                    icon  = `sap-icon://add`
                    press = client->_event( val = `POPUP_ADD` )
-       )->button( text  = 'Cancel'
-                  press = client->_event( 'BUTTON_CANCEL' )
-       )->button( text  = 'OK'
-                  press = client->_event( 'BUTTON_CONFIRM' )
-                  type  = 'Emphasized' ).
+       )->button( text  = `Cancel`
+                  press = client->_event( `BUTTON_CANCEL` )
+       )->button( text  = `OK`
+                  press = client->_event( `BUTTON_CONFIRM` )
+                  type  = `Emphasized` ).
 
     client->popup_display( lo_popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
@@ -53,17 +53,17 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
   METHOD popup_display.
 
     DATA(lo_popup) = z2ui5_cl_xml_view=>factory_popup( ).
-    lo_popup = lo_popup->dialog( afterclose    = client->_event( 'BUTTON_CANCEL' )
+    lo_popup = lo_popup->dialog( afterclose    = client->_event( `BUTTON_CANCEL` )
                                  contentheight = `50%`
                                  contentwidth  = `50%`
-                                 title         = 'Define Filter Conditons' ).
+                                 title         = `Define Filter Conditons` ).
 
     DATA(vbox) = lo_popup->vbox( height         = `100%`
-                                 justifycontent = 'SpaceBetween' ).
+                                 justifycontent = `SpaceBetween` ).
 
     DATA(item) = vbox->list( nodata          = `no conditions defined`
                              items           = client->_bind( ms_result-t_filter )
-                             selectionchange = client->_event( 'SELCHANGE' )
+                             selectionchange = client->_event( `SELCHANGE` )
                 )->custom_list_item( ).
 
     DATA(grid) = item->grid( class = `sapUiSmallMarginTop sapUiSmallMarginBottom sapUiSmallMarginBegin` ).
@@ -83,7 +83,7 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
     grid->button( text  = `Select`
                   press = client->_event( val   = `LIST_OPEN`
                                           t_arg = VALUE #( ( `${NAME}` ) ) ) ).
-    grid->button( icon  = 'sap-icon://delete'
+    grid->button( icon  = `sap-icon://delete`
                   type  = `Transparent`
                   text  = `Clear`
                   press = client->_event( val   = `LIST_DELETE`
@@ -91,14 +91,14 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
 
     lo_popup->buttons(
         )->button( text  = `Clear All`
-                   icon  = 'sap-icon://delete'
+                   icon  = `sap-icon://delete`
                    type  = `Transparent`
                    press = client->_event( val = `POPUP_DELETE_ALL` )
-       )->button( text  = 'Cancel'
-                  press = client->_event( 'BUTTON_CANCEL' )
-       )->button( text  = 'OK'
-                  press = client->_event( 'BUTTON_CONFIRM' )
-                  type  = 'Emphasized' ).
+       )->button( text  = `Cancel`
+                  press = client->_event( `BUTTON_CANCEL` )
+       )->button( text  = `OK`
+                  press = client->_event( `BUTTON_CONFIRM` )
+                  type  = `Emphasized` ).
 
     client->popup_display( lo_popup->stringify( ) ).
   ENDMETHOD.
@@ -129,14 +129,14 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
 
     CASE client->get( )-event.
 
-      WHEN 'LIST_DELETE'.
+      WHEN `LIST_DELETE`.
         DATA(lt_event) = client->get( )-t_event_arg.
         ASSIGN ms_result-t_filter[ name = lt_event[ 1 ] ] TO <tab>.
         CLEAR <tab>-t_token.
         CLEAR <tab>-t_range.
         client->popup_model_update( ).
 
-      WHEN 'LIST_OPEN'.
+      WHEN `LIST_OPEN`.
         lt_event = client->get( )-t_event_arg.
         mv_popup_name = lt_event[ 1 ].
         DATA(ls_sql) = ms_result-t_filter[ name = mv_popup_name ].

--- a/src/02/01/z2ui5_cl_pop_image_editor.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_image_editor.clas.abap
@@ -80,14 +80,14 @@ CLASS z2ui5_cl_pop_image_editor IMPLEMENTATION.
     ENDIF.
 
     CASE client->get( )-event.
-      WHEN 'SAVE'.
+      WHEN `SAVE`.
 
         mv_confirmed = abap_true.
         DATA(args) = client->get( )-t_event_arg.
         mv_image = args[ 1 ].
         client->nav_app_leave( ).
 
-      WHEN 'CANCEL'.
+      WHEN `CANCEL`.
 
         mv_confirmed = abap_false.
         client->popup_destroy( ).
@@ -101,13 +101,13 @@ CLASS z2ui5_cl_pop_image_editor IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup(
                                   )->dialog( title         = mv_title
-                                             icon          = 'sap-icon://edit'
+                                             icon          = `sap-icon://edit`
                                              contentheight = `80%`
                                              contentwidth  = `80%` ).
 
     popup->image_editor_container( enabledbuttons = mv_enabledbuttons
                                    mode           = mv_mode
-        )->image_editor( id                    = 'imageEditor'
+        )->image_editor( id                    = `imageEditor`
                          src                   = mv_image
                          customshapesrc        = mv_customshapesrc
                          keepcropaspectratio   = mv_keepcropaspectratio
@@ -117,10 +117,10 @@ CLASS z2ui5_cl_pop_image_editor IMPLEMENTATION.
 
     popup->buttons(
         )->button( text  = mv_cancel_text
-                   type  = 'Reject'
+                   type  = `Reject`
                    press = client->_event( `CANCEL` )
         )->button( text  = mv_save_text
-                   type  = 'Emphasized'
+                   type  = `Emphasized`
                    press = client->_event_client( client->cs_event-image_editor_popup_close ) ).
 
     client->popup_display( popup->stringify( ) ).

--- a/src/02/01/z2ui5_cl_pop_input_val.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_input_val.clas.abap
@@ -66,19 +66,19 @@ CLASS z2ui5_cl_pop_input_val IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
-                                                               afterclose = client->_event( 'BUTTON_CANCEL' )
+                                                               afterclose = client->_event( `BUTTON_CANCEL` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                   )->label( question_text
                   )->input( value  = client->_bind_edit( ms_result-value )
-                            submit = client->_event( 'BUTTON_CONFIRM' )
+                            submit = client->_event( `BUTTON_CONFIRM` )
               )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = button_text_cancel
-                             press = client->_event( 'BUTTON_CANCEL' )
+                             press = client->_event( `BUTTON_CANCEL` )
                   )->button( text  = button_text_confirm
-                             press = client->_event( 'BUTTON_CONFIRM' )
-                             type  = 'Emphasized' ).
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_js_loader.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_js_loader.clas.abap
@@ -61,7 +61,7 @@ CLASS z2ui5_cl_pop_js_loader IMPLEMENTATION.
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( `Setup UI...` )->content( ).
 
     IF js IS NOT INITIAL.
-      popup->_z2ui5( )->timer( client->_event( 'TIMER_FINISHED' )
+      popup->_z2ui5( )->timer( client->_event( `TIMER_FINISHED` )
         )->_generic( ns   = `html`
                      name = `script` )->_cc_plain_xml( js ).
     ENDIF.

--- a/src/02/01/z2ui5_cl_pop_messages.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_messages.clas.abap
@@ -68,10 +68,10 @@ CLASS z2ui5_cl_pop_messages IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
     popup = popup->dialog( title             = `Messages`
-                           contentheight     = '50%'
-                           contentwidth      = '50%'
+                           contentheight     = `50%`
+                           contentwidth      = `50%`
                            verticalscrolling = abap_false
-                           afterclose        = client->_event( 'BUTTON_CONTINUE' ) ).
+                           afterclose        = client->_event( `BUTTON_CONTINUE` ) ).
 
     popup->message_view( items = client->_bind( mt_msg )
 *                         groupitems = abap_true
@@ -79,9 +79,9 @@ CLASS z2ui5_cl_pop_messages IMPLEMENTATION.
                          title    = `{TITLE}`
                          subtitle = `{SUBTITLE}` ).
 
-    popup->buttons( )->button( text  = 'continue'
-                               press = client->_event( 'BUTTON_CONTINUE' )
-                               type  = 'Emphasized' ).
+    popup->buttons( )->button( text  = `continue`
+                               press = client->_event( `BUTTON_CONTINUE` )
+                               type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_pdf.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_pdf.clas.abap
@@ -66,9 +66,9 @@ CLASS z2ui5_cl_pop_pdf IMPLEMENTATION.
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
                                                                stretch    = abap_true
-                                                               afterclose = client->_event( 'BUTTON_CANCEL' )
+                                                               afterclose = client->_event( `BUTTON_CANCEL` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                   )->label( question_text
                   )->_generic( ns     = `html`
                                name   = `iframe`
@@ -79,10 +79,10 @@ CLASS z2ui5_cl_pop_pdf IMPLEMENTATION.
               )->get_parent( )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = button_text_cancel
-                             press = client->_event( 'BUTTON_CANCEL' )
+                             press = client->_event( `BUTTON_CANCEL` )
                   )->button( text  = button_text_confirm
-                             press = client->_event( 'BUTTON_CONFIRM' )
-                             type  = 'Emphasized' ).
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_table.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_table.clas.abap
@@ -27,7 +27,7 @@ CLASS z2ui5_cl_pop_table DEFINITION
     DATA mr_tab TYPE REF TO data.
 
   PROTECTED SECTION.
-    DATA title  TYPE string VALUE 'Table View'.
+    DATA title  TYPE string VALUE `Table View`.
     DATA client TYPE REF TO z2ui5_if_client.
 
     METHODS on_event.
@@ -46,10 +46,10 @@ CLASS z2ui5_cl_pop_table IMPLEMENTATION.
 
     ASSIGN mr_tab->* TO <tab_out>.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( afterclose = client->_event( 'BUTTON_CONFIRM' )
+    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( afterclose = client->_event( `BUTTON_CONFIRM` )
                                                                stretch    = abap_true
                                                                title      = title
-*                                                               icon       = 'sap-icon://edit'
+*                                                               icon       = `sap-icon://edit`
           )->content( ).
 
     DATA(tab) = popup->table( client->_bind( <tab_out> ) ).
@@ -65,14 +65,14 @@ CLASS z2ui5_cl_pop_table IMPLEMENTATION.
 
     DATA(columns) = tab->columns( ).
     LOOP AT lt_comp INTO ls_comp.
-      columns->column( '8rem' )->header( `` )->text( ls_comp-name ).
+      columns->column( `8rem` )->header( `` )->text( ls_comp-name ).
     ENDLOOP.
 
     popup->get_parent(
         )->buttons(
-            )->button( text  = 'OK'
-                       press = client->_event( 'BUTTON_CONFIRM' )
-                       type  = 'Emphasized' ).
+            )->button( text  = `OK`
+                       press = client->_event( `BUTTON_CONFIRM` )
+                       type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -97,11 +97,11 @@ CLASS z2ui5_cl_pop_table IMPLEMENTATION.
 
     CASE client->get( )-event.
 
-      WHEN 'BUTTON_CONFIRM'.
+      WHEN `BUTTON_CONFIRM`.
         ms_result-check_confirmed = abap_true.
         on_event_confirm( ).
 
-      WHEN 'CANCEL'.
+      WHEN `CANCEL`.
         client->popup_destroy( ).
         client->nav_app_leave( ).
 

--- a/src/02/01/z2ui5_cl_pop_textedit.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_textedit.clas.abap
@@ -54,21 +54,21 @@ CLASS z2ui5_cl_pop_textedit IMPLEMENTATION.
 
   METHOD display.
 
-    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( afterclose = client->_event( 'BUTTON_TEXTAREA_CANCEL' )
+    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( afterclose = client->_event( `BUTTON_TEXTAREA_CANCEL` )
                                                                stretch    = mv_stretch_active
                                                                title      = mv_title
-                                                               icon       = 'sap-icon://edit'
+                                                               icon       = `sap-icon://edit`
           )->content(
               )->text_area( growing  = abap_true
                             editable = mv_check_editable
                             value    = client->_bind_edit( ms_result-text )
           )->get_parent(
           )->buttons(
-              )->button( text  = 'Cancel'
-                         press = client->_event( 'BUTTON_TEXTAREA_CANCEL' )
-              )->button( text  = 'Confirm'
-                         press = client->_event( 'BUTTON_TEXTAREA_CONFIRM' )
-                         type  = 'Emphasized' ).
+              )->button( text  = `Cancel`
+                         press = client->_event( `BUTTON_TEXTAREA_CANCEL` )
+              )->button( text  = `Confirm`
+                         press = client->_event( `BUTTON_TEXTAREA_CONFIRM` )
+                         type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_to_confirm.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_confirm.clas.abap
@@ -7,15 +7,15 @@ CLASS z2ui5_cl_pop_to_confirm DEFINITION
 
     CONSTANTS:
       BEGIN OF cs_event,
-        confirmed TYPE string VALUE 'z2ui5_cl_pop_to_confirm_confirmed',
-        canceled  TYPE string VALUE 'z2ui5_cl_pop_to_confirm_canceled',
+        confirmed TYPE string VALUE `z2ui5_cl_pop_to_confirm_confirmed`,
+        canceled  TYPE string VALUE `z2ui5_cl_pop_to_confirm_canceled`,
       END OF cs_event.
 
     CLASS-METHODS factory
       IMPORTING
         i_question_text       TYPE string
         i_title               TYPE string DEFAULT `Popup To Confirm`
-        i_icon                TYPE string DEFAULT 'sap-icon://question-mark'
+        i_icon                TYPE string DEFAULT `sap-icon://question-mark`
         i_button_text_confirm TYPE string DEFAULT `OK`
         i_button_text_cancel  TYPE string DEFAULT `Cancel`
         i_event_confirm       TYPE string DEFAULT  cs_event-confirmed
@@ -71,17 +71,17 @@ CLASS z2ui5_cl_pop_to_confirm IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
-                                                               afterclose = client->_event( 'BUTTON_CANCEL' )
+                                                               afterclose = client->_event( `BUTTON_CANCEL` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                       )->text( question_text
               )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = button_text_cancel
-                             press = client->_event( 'BUTTON_CANCEL' )
+                             press = client->_event( `BUTTON_CANCEL` )
                   )->button( text  = button_text_confirm
-                             press = client->_event( 'BUTTON_CONFIRM' )
-                             type  = 'Emphasized' ).
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_to_inform.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_inform.clas.abap
@@ -9,7 +9,7 @@ CLASS z2ui5_cl_pop_to_inform DEFINITION
       IMPORTING
         i_text          TYPE string
         i_title         TYPE string DEFAULT `Title`
-        i_icon          TYPE string DEFAULT 'sap-icon://question-mark'
+        i_icon          TYPE string DEFAULT `sap-icon://question-mark`
         i_button_text   TYPE string DEFAULT `OK`
       RETURNING
         VALUE(r_result) TYPE REF TO z2ui5_cl_pop_to_inform.
@@ -43,15 +43,15 @@ CLASS z2ui5_cl_pop_to_inform IMPLEMENTATION.
 
     DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog( title      = title
                                                                icon       = icon
-                                                               afterclose = client->_event( 'BUTTON_CONFIRM' )
+                                                               afterclose = client->_event( `BUTTON_CONFIRM` )
               )->content(
-                  )->vbox( 'sapUiMediumMargin'
+                  )->vbox( `sapUiMediumMargin`
                       )->text( question_text
               )->get_parent( )->get_parent(
               )->buttons(
                   )->button( text  = button_text_confirm
-                             press = client->_event( 'BUTTON_CONFIRM' )
-                             type  = 'Emphasized' ).
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -102,11 +102,11 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
                           && |', sorter : \{ path : '{ to_upper( sort_field ) }', descending : |
                           && z2ui5_cl_util=>boolean_abap_2_json( me->descending )
                           && | \} \}|
-        cancel           = client->_event( 'CANCEL' )
+        cancel           = client->_event( `CANCEL` )
         search           = client->_event(
-                               val   = 'SEARCH'
+                               val   = `SEARCH`
                                t_arg = VALUE #( ( `${$parameters>/value}` ) ( `${$parameters>/clearButtonPressed}` ) ) )
-        confirm          = client->_event( val   = 'CONFIRM'
+        confirm          = client->_event( val   = `CONFIRM`
                                            t_arg = VALUE #( ( `${$parameters>/selectedContexts[0]/sPath}` ) ) )
         growing          = abap_true
         contentwidth     = content_width
@@ -116,7 +116,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
         multiselect      = multiselect ).
 
     DATA(lt_comp) = z2ui5_cl_util=>rtti_get_t_attri_by_any( <tab_out> ).
-    DELETE lt_comp WHERE name = 'ZZSELKZ'.
+    DELETE lt_comp WHERE name = `ZZSELKZ`.
 
     DATA(list) = tab->column_list_item( valign   = `Top`
                                         selected = `{ZZSELKZ}` ).
@@ -131,12 +131,12 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
       DATA(text) = COND #(
                      LET data_element_name = substring_after(
                                                  val = CAST cl_abap_elemdescr( ls_comp-type )->absolute_name
-                                                 sub = '\TYPE=' )
+                                                 sub = `\TYPE=` )
                          medium_label = z2ui5_cl_util=>rtti_get_data_element_texts( data_element_name )-medium IN
                      WHEN medium_label IS NOT INITIAL
                      THEN medium_label
                      ELSE ls_comp-name ).
-      columns->column( '8rem' )->header( `` )->text( text ).
+      columns->column( `8rem` )->header( `` )->text( text ).
     ENDLOOP.
 
     client->popup_display( popup->stringify( ) ).
@@ -161,16 +161,16 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
     CASE client->get( )-event.
 
-      WHEN 'CONFIRM'.
+      WHEN `CONFIRM`.
         ms_result-check_confirmed = abap_true.
         on_event_confirm( ).
 
-      WHEN 'CANCEL'.
+      WHEN `CANCEL`.
         client->popup_destroy( ).
         client->nav_app_leave( ).
         client->follow_up_action( client->_event( event_canceled ) ).
 
-      WHEN 'SEARCH'.
+      WHEN `SEARCH`.
         on_event_search( ).
 
     ENDCASE.
@@ -204,12 +204,12 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
       CATCH cx_root.
         check_table_line = abap_true.
         DATA(lo_elem) = CAST cl_abap_elemdescr( lo_table->get_table_line_type( ) ).
-        INSERT VALUE #( name = 'TAB_LINE'
+        INSERT VALUE #( name = `TAB_LINE`
                         type = CAST #( lo_elem ) ) INTO TABLE lt_comp.
     ENDTRY.
 
     IF NOT line_exists( lt_comp[ name = `ZZSELKZ` ] ).
-      DATA(lo_type_bool) = cl_abap_structdescr=>describe_by_name( 'ABAP_BOOL' ).
+      DATA(lo_type_bool) = cl_abap_structdescr=>describe_by_name( `ABAP_BOOL` ).
       INSERT VALUE #( name = `ZZSELKZ`
                       type = CAST #( lo_type_bool ) ) INTO TABLE lt_comp.
     ENDIF.
@@ -227,7 +227,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
       CREATE DATA lr_row LIKE LINE OF <tab_out>.
       ASSIGN lr_row->* TO <row2>.
       IF check_table_line = abap_true.
-        ASSIGN lr_row->('TAB_LINE') TO <field>.
+        ASSIGN lr_row->(`TAB_LINE`) TO <field>.
         ASSERT sy-subrc = 0.
         <field> = <row>.
       ELSE.
@@ -256,7 +256,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
     LOOP AT <tab> ASSIGNING <row_selected>.
 
-      ASSIGN ('<ROW_SELECTED>-ZZSELKZ') TO <selkz>.
+      ASSIGN (`<ROW_SELECTED>-ZZSELKZ`) TO <selkz>.
       ASSERT sy-subrc = 0.
       IF <selkz> = abap_false.
         CONTINUE.
@@ -264,7 +264,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
       ASSIGN ms_result-row->* TO <row_result>.
       IF check_table_line = abap_true.
-        ASSIGN ('<ROW_SELECTED>-TAB_LINE') TO <table_line_selected>.
+        ASSIGN (`<ROW_SELECTED>-TAB_LINE`) TO <table_line_selected>.
         ASSERT sy-subrc = 0.
         <row_result> = <table_line_selected>.
       ELSE.

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -86,10 +86,10 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
       )->button( text  = `System`
                  icon  = `sap-icon://information`
                  press = client->_event( `OPEN_INFO` ) ).
-    IF z2ui5_cl_util=>rtti_check_class_exists( 'z2ui5_cl_app_icf_config' ).
-      toolbar->button( text  = 'Config'
-                       icon  = 'sap-icon://settings'
-                       press = client->_event( 'SET_CONFIG' ) ).
+    IF z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_app_icf_config` ).
+      toolbar->button( text  = `Config`
+                       icon  = `sap-icon://settings`
+                       press = client->_event( `SET_CONFIG` ) ).
     ENDIF.
 
     DATA(simple_form) = page->simple_form( editable                = abap_true
@@ -128,7 +128,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
                           enabled          = client->_bind( ms_home-class_editable )
                           value            = client->_bind_edit( ms_home-classname )
                           submit           = client->_event( ms_home-btn_event_id )
-                          valuehelprequest = client->_event( 'VALUE_HELP' )
+                          valuehelprequest = client->_event( `VALUE_HELP` )
                           showvaluehelp    = abap_true
                           width            = `70%` ).
 
@@ -148,7 +148,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
                enabled = |\{= ${ client->_bind( val = ms_home-class_editable ) } === false \}| ).
 
     DATA(lv_url_samples2) = z2ui5_cl_core_srv_util=>app_get_url( client    = client
-                                                                 classname = 'z2ui5_cl_demo_app_000' ).
+                                                                 classname = `z2ui5_cl_demo_app_000` ).
 
     simple_form->toolbar( )->title( `What's next?` ).
 
@@ -267,9 +267,9 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     simple_form2->label( `Draft Entries ` ).
     simple_form2->text( lv_count ).
 
-    page2->end_button( )->button( text  = 'close'
-                                  press = client->_event( 'CLOSE' )
-                                  type  = 'Emphasized' ).
+    page2->end_button( )->button( text  = `close`
+                                  press = client->_event( `CLOSE` )
+                                  type  = `Emphasized` ).
 
     client->popup_display( page2->stringify( ) ).
 
@@ -283,7 +283,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     CASE client->get( )-event.
 
       WHEN `SET_CONFIG`.
-        CREATE OBJECT lo_app TYPE ('Z2UI5_CL_APP_ICF_CONFIG').
+        CREATE OBJECT lo_app TYPE (`Z2UI5_CL_APP_ICF_CONFIG`).
         client->nav_app_call( lo_app ).
 
       WHEN `CLOSE`.
@@ -307,7 +307,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
         ENDIF.
         client->view_model_update( ).
 
-      WHEN 'VALUE_HELP'.
+      WHEN `VALUE_HELP`.
         TRY.
             mt_classes = z2ui5_cl_util=>rtti_get_classes_impl_intf( z2ui5_cl_util=>rtti_get_intfname_by_ref( li_app ) ).
           CATCH cx_root.

--- a/src/02/z2ui5_cl_exit.clas.abap
+++ b/src/02/z2ui5_cl_exit.clas.abap
@@ -49,8 +49,8 @@ CLASS z2ui5_cl_exit IMPLEMENTATION.
 
   METHOD get_user_exit_class.
 
-    DATA(exit_classes) = z2ui5_cl_util=>rtti_get_classes_impl_intf( 'Z2UI5_IF_EXIT' ).
-    DELETE exit_classes WHERE classname = 'Z2UI5_CL_EXIT'.
+    DATA(exit_classes) = z2ui5_cl_util=>rtti_get_classes_impl_intf( `Z2UI5_IF_EXIT` ).
+    DELETE exit_classes WHERE classname = `Z2UI5_CL_EXIT`.
 
     IF exit_classes IS NOT INITIAL.
       r_class_name = exit_classes[ 1 ]-classname.
@@ -105,13 +105,13 @@ CLASS z2ui5_cl_exit IMPLEMENTATION.
     IF cs_config-t_security_header IS INITIAL.
 
       cs_config-t_security_header = VALUE #(
-          ( n = 'cache-control'          v = 'no-cache, no-store, must-revalidate' )
-          ( n = 'Pragma'                 v = 'no-cache' )
-          ( n = 'Expires'                v = '0' )
-          ( n = 'X-Content-Type-Options' v = 'nosniff' )
-          ( n = 'X-Frame-Options'        v = 'SAMEORIGIN' )
-          ( n = 'Referrer-Policy'        v = 'strict-origin-when-cross-origin' )
-          ( n = 'Permissions-Policy'     v = 'geolocation=(self), microphone=(self), camera=(self), payment=(), usb=()' ) ).
+          ( n = `cache-control`          v = `no-cache, no-store, must-revalidate` )
+          ( n = `Pragma`                 v = `no-cache` )
+          ( n = `Expires`                v = `0` )
+          ( n = `X-Content-Type-Options` v = `nosniff` )
+          ( n = `X-Frame-Options`        v = `SAMEORIGIN` )
+          ( n = `Referrer-Policy`        v = `strict-origin-when-cross-origin` )
+          ( n = `Permissions-Policy`     v = `geolocation=(self), microphone=(self), camera=(self), payment=(), usb=()` ) ).
 
     ENDIF.
 

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -208,18 +208,18 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     " transform cookie to header based contextid handling
     IF ms_res-s_stateful-switched = abap_true.
       mo_server->set_session_stateful( ms_res-s_stateful-active ).
-      IF mo_server->get_header_field( 'sap-contextid-accept' ) = 'header'.
-        DATA(lv_contextid) = mo_server->get_response_cookie( 'sap-contextid' ).
+      IF mo_server->get_header_field( `sap-contextid-accept` ) = `header`.
+        DATA(lv_contextid) = mo_server->get_response_cookie( `sap-contextid` ).
         IF lv_contextid IS NOT INITIAL.
-          mo_server->delete_response_cookie( 'sap-contextid' ).
-          mo_server->set_header_field( n = 'sap-contextid'
+          mo_server->delete_response_cookie( `sap-contextid` ).
+          mo_server->set_header_field( n = `sap-contextid`
                                        v = lv_contextid ).
         ENDIF.
       ENDIF.
     ELSE.
-      lv_contextid = mo_server->get_header_field( 'sap-contextid' ).
+      lv_contextid = mo_server->get_header_field( `sap-contextid` ).
       IF lv_contextid IS NOT INITIAL.
-        mo_server->set_header_field( n = 'sap-contextid'
+        mo_server->set_header_field( n = `sap-contextid`
                                      v = lv_contextid ).
       ENDIF.
     ENDIF.

--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -2154,7 +2154,7 @@ CLASS z2ui5_cl_xml_view DEFINITION
       IMPORTING
         label         TYPE clike
         template      TYPE clike OPTIONAL
-        halign        TYPE clike DEFAULT 'Begin'
+        halign        TYPE clike DEFAULT `Begin`
       RETURNING
         VALUE(result) TYPE REF TO z2ui5_cl_xml_view.
 
@@ -2168,7 +2168,7 @@ CLASS z2ui5_cl_xml_view DEFINITION
 
     METHODS filter_bar
       IMPORTING
-        usetoolbar                   TYPE clike DEFAULT 'false'
+        usetoolbar                   TYPE clike DEFAULT `false`
         search                       TYPE clike OPTIONAL
         id                           TYPE clike OPTIONAL
         persistencykey               TYPE clike OPTIONAL
@@ -5303,17 +5303,17 @@ CLASS z2ui5_cl_xml_view DEFINITION
         id                   TYPE clike OPTIONAL
         entityset            TYPE clike OPTIONAL
         value                TYPE clike OPTIONAL
-        supportranges        TYPE clike DEFAULT 'false'
-        enableodataselect    TYPE clike DEFAULT 'false'
+        supportranges        TYPE clike DEFAULT `false`
+        enableodataselect    TYPE clike DEFAULT `false`
         requestatleastfields TYPE clike OPTIONAL
-        singletokenmode      TYPE clike DEFAULT 'false'
-        supportmultiselect   TYPE clike DEFAULT 'true'
+        singletokenmode      TYPE clike DEFAULT `false`
+        supportmultiselect   TYPE clike DEFAULT `true`
         textseparator        TYPE clike OPTIONAL
         textlabel            TYPE clike OPTIONAL
         tooltiplabel         TYPE clike OPTIONAL
-        textineditmodesource TYPE clike DEFAULT 'None'
-        mandatory            TYPE clike DEFAULT 'false'
-        maxlength            TYPE clike DEFAULT '0'
+        textineditmodesource TYPE clike DEFAULT `None`
+        mandatory            TYPE clike DEFAULT `false`
+        maxlength            TYPE clike DEFAULT `0`
       RETURNING
         VALUE(result)        TYPE REF TO z2ui5_cl_xml_view.
 
@@ -5382,7 +5382,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD action_buttons.
     result = _generic( name = `actionButtons`
-                       ns   = SWITCH #( ns WHEN '' THEN `networkgraph` ELSE ns ) ).
+                       ns   = SWITCH #( ns WHEN `` THEN `networkgraph` ELSE ns ) ).
   ENDMETHOD.
 
   METHOD action_sheet.
@@ -5453,7 +5453,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD attributes.
     result = _generic( name = `attributes`
-                       ns   = SWITCH #( ns WHEN '' THEN `networkgraph` ELSE ns ) ).
+                       ns   = SWITCH #( ns WHEN `` THEN `networkgraph` ELSE ns ) ).
   ENDMETHOD.
 
   METHOD avatar.
@@ -5539,7 +5539,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD barcode_scanner_button.
     result = _generic( name   = `BarcodeScannerButton`
-                       ns     = 'ndc'
+                       ns     = `ndc`
                        t_prop = VALUE #( ( n = `id`                        v = id )
                                          ( n = `scanSuccess`               v = scansuccess )
                                          ( n = `scanFail`                  v = scanfail )
@@ -5563,7 +5563,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
     result = _generic(
         name   = `BaseRectangle`
-        ns     = 'gantt'
+        ns     = `gantt`
         t_prop = VALUE #( ( n = `time`                      v = time )
                           ( n = `endTime`                   v = endtime )
                           ( n = `selectable`                v = z2ui5_cl_util=>boolean_abap_2_json( selectable ) )
@@ -6164,7 +6164,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD currency.
     result = _generic( name   = `Currency`
-                       ns     = 'u'
+                       ns     = `u`
                        t_prop = VALUE #( ( n = `value`        v = value )
                                          ( n = `currency`     v = currency )
                                          ( n = `useSymbol`    v = z2ui5_cl_util=>boolean_abap_2_json( usesymbol ) )
@@ -6358,7 +6358,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD dynamic_side_content.
     result = _generic( name   = `DynamicSideContent`
-                       ns     = 'layout'
+                       ns     = `layout`
                        t_prop = VALUE #( ( n = `id`                              v = id )
                                          ( n = `class`                           v = class )
                                          ( n = `sideContentVisibility`           v = sidecontentvisibility )
@@ -6369,7 +6369,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD element_attribute.
     result = _generic( name   = `ElementAttribute`
-                       ns     = SWITCH #( ns WHEN '' THEN `networkgraph` ELSE ns )
+                       ns     = SWITCH #( ns WHEN `` THEN `networkgraph` ELSE ns )
                        t_prop = VALUE #( ( n = `label`  v = label )
                                          ( n = `value`  v = value ) ) ).
   ENDMETHOD.
@@ -6511,8 +6511,8 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
     ENDIF.
 
     result->mt_prop   = VALUE #( BASE result->mt_prop
-                                 (  n = 'displayBlock'   v = 'true' )
-                                 (  n = 'height'         v = '100%' ) ).
+                                 (  n = `displayBlock`   v = `true` )
+                                 (  n = `height`         v = `100%` ) ).
 
     result->mv_name   = `View`.
     result->mv_ns     = `mvc`.
@@ -6625,73 +6625,73 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
     result = _generic(
         name   = `FilterBar`
-        ns     = 'fb'
+        ns     = `fb`
         t_prop = VALUE #(
-            ( n = 'useToolbar'     v = z2ui5_cl_util=>boolean_abap_2_json( usetoolbar ) )
-            ( n = 'search'         v = search )
-            ( n = 'id'             v = id )
-            ( n = 'persistencyKey' v = persistencykey )
-            ( n = 'afterVariantLoad' v = aftervariantload )
-            ( n = 'afterVariantSave' v = aftervariantsave )
-            ( n = 'assignedFiltersChanged' v = assignedfilterschanged )
-            ( n = 'beforeVariantFetch' v = beforevariantfetch )
-            ( n = 'cancel' v = cancel )
-            ( n = 'clear' v = clear )
-            ( n = 'filtersDialogBeforeOpen' v = filtersdialogbeforeopen )
-            ( n = 'filtersDialogCancel' v = filtersdialogcancel )
-            ( n = 'filtersDialogClosed' v = filtersdialogclosed )
-            ( n = 'initialise' v = initialise )
-            ( n = 'initialized' v = initialized )
-            ( n = 'reset' v = reset )
-            ( n = 'filterContainerWidth' v = filtercontainerwidth )
-            ( n = 'header' v = header )
-            ( n = 'advancedMode' v = z2ui5_cl_util=>boolean_abap_2_json( advancedmode ) )
-            ( n = 'isRunningInValueHelpDialog' v = z2ui5_cl_util=>boolean_abap_2_json( isrunninginvaluehelpdialog ) )
-            ( n = 'showAllFilters' v = z2ui5_cl_util=>boolean_abap_2_json( showallfilters ) )
-            ( n = 'showClearOnFB' v = z2ui5_cl_util=>boolean_abap_2_json( showclearonfb ) )
-            ( n = 'showFilterConfiguration' v = z2ui5_cl_util=>boolean_abap_2_json( showfilterconfiguration ) )
-            ( n = 'showGoOnFB' v = z2ui5_cl_util=>boolean_abap_2_json( showgoonfb ) )
-            ( n = 'showRestoreButton' v = z2ui5_cl_util=>boolean_abap_2_json( showrestorebutton ) )
-            ( n = 'showRestoreOnFB' v = z2ui5_cl_util=>boolean_abap_2_json( showrestoreonfb ) )
-            ( n = 'useSnapshot' v = z2ui5_cl_util=>boolean_abap_2_json( usesnapshot ) )
-            ( n = 'searchEnabled' v = z2ui5_cl_util=>boolean_abap_2_json( searchenabled ) )
-            ( n = 'considerGroupTitle' v = z2ui5_cl_util=>boolean_abap_2_json( considergrouptitle ) )
-            ( n = 'deltaVariantMode' v = z2ui5_cl_util=>boolean_abap_2_json( deltavariantmode ) )
-            ( n = 'disableSearchMatchesPatternWarning'
+            ( n = `useToolbar`     v = z2ui5_cl_util=>boolean_abap_2_json( usetoolbar ) )
+            ( n = `search`         v = search )
+            ( n = `id`             v = id )
+            ( n = `persistencyKey` v = persistencykey )
+            ( n = `afterVariantLoad` v = aftervariantload )
+            ( n = `afterVariantSave` v = aftervariantsave )
+            ( n = `assignedFiltersChanged` v = assignedfilterschanged )
+            ( n = `beforeVariantFetch` v = beforevariantfetch )
+            ( n = `cancel` v = cancel )
+            ( n = `clear` v = clear )
+            ( n = `filtersDialogBeforeOpen` v = filtersdialogbeforeopen )
+            ( n = `filtersDialogCancel` v = filtersdialogcancel )
+            ( n = `filtersDialogClosed` v = filtersdialogclosed )
+            ( n = `initialise` v = initialise )
+            ( n = `initialized` v = initialized )
+            ( n = `reset` v = reset )
+            ( n = `filterContainerWidth` v = filtercontainerwidth )
+            ( n = `header` v = header )
+            ( n = `advancedMode` v = z2ui5_cl_util=>boolean_abap_2_json( advancedmode ) )
+            ( n = `isRunningInValueHelpDialog` v = z2ui5_cl_util=>boolean_abap_2_json( isrunninginvaluehelpdialog ) )
+            ( n = `showAllFilters` v = z2ui5_cl_util=>boolean_abap_2_json( showallfilters ) )
+            ( n = `showClearOnFB` v = z2ui5_cl_util=>boolean_abap_2_json( showclearonfb ) )
+            ( n = `showFilterConfiguration` v = z2ui5_cl_util=>boolean_abap_2_json( showfilterconfiguration ) )
+            ( n = `showGoOnFB` v = z2ui5_cl_util=>boolean_abap_2_json( showgoonfb ) )
+            ( n = `showRestoreButton` v = z2ui5_cl_util=>boolean_abap_2_json( showrestorebutton ) )
+            ( n = `showRestoreOnFB` v = z2ui5_cl_util=>boolean_abap_2_json( showrestoreonfb ) )
+            ( n = `useSnapshot` v = z2ui5_cl_util=>boolean_abap_2_json( usesnapshot ) )
+            ( n = `searchEnabled` v = z2ui5_cl_util=>boolean_abap_2_json( searchenabled ) )
+            ( n = `considerGroupTitle` v = z2ui5_cl_util=>boolean_abap_2_json( considergrouptitle ) )
+            ( n = `deltaVariantMode` v = z2ui5_cl_util=>boolean_abap_2_json( deltavariantmode ) )
+            ( n = `disableSearchMatchesPatternWarning`
               v = z2ui5_cl_util=>boolean_abap_2_json( disablesearchmatchespatternw ) )
-            ( n = 'filterBarExpanded' v = z2ui5_cl_util=>boolean_abap_2_json( filterbarexpanded ) )
-            ( n = 'filterChange'   v = filterchange ) ) ).
+            ( n = `filterBarExpanded` v = z2ui5_cl_util=>boolean_abap_2_json( filterbarexpanded ) )
+            ( n = `filterChange`   v = filterchange ) ) ).
   ENDMETHOD.
 
   METHOD filter_control.
     result = _generic( name = `control`
-                       ns   = 'fb' ).
+                       ns   = `fb` ).
   ENDMETHOD.
 
   METHOD filter_group_item.
     result = _generic(
         name   = `FilterGroupItem`
-        ns     = 'fb'
-        t_prop = VALUE #( ( n = 'name'                v  = name )
-                          ( n = 'label'               v  = label )
-                          ( n = 'groupName'           v  = groupname )
-                          ( n = 'controlTooltip'           v  = controltooltip )
-                          ( n = 'entitySetName'           v  = entitysetname )
-                          ( n = 'entityTypeName'           v  = entitytypename )
-                          ( n = 'groupTitle'           v  = grouptitle )
-                          ( n = 'labelTooltip'           v  = labeltooltip )
-                          ( n = 'change'           v  = change )
-                          ( n = 'visibleInFilterBar'  v  = z2ui5_cl_util=>boolean_abap_2_json( visibleinfilterbar ) )
-                          ( n = 'mandatory'  v  = z2ui5_cl_util=>boolean_abap_2_json( mandatory ) )
-                          ( n = 'hiddenFilter'  v  = z2ui5_cl_util=>boolean_abap_2_json( hiddenfilter ) )
-                          ( n = 'visible'  v  = z2ui5_cl_util=>boolean_abap_2_json( visible ) )
+        ns     = `fb`
+        t_prop = VALUE #( ( n = `name`                v  = name )
+                          ( n = `label`               v  = label )
+                          ( n = `groupName`           v  = groupname )
+                          ( n = `controlTooltip`           v  = controltooltip )
+                          ( n = `entitySetName`           v  = entitysetname )
+                          ( n = `entityTypeName`           v  = entitytypename )
+                          ( n = `groupTitle`           v  = grouptitle )
+                          ( n = `labelTooltip`           v  = labeltooltip )
+                          ( n = `change`           v  = change )
+                          ( n = `visibleInFilterBar`  v  = z2ui5_cl_util=>boolean_abap_2_json( visibleinfilterbar ) )
+                          ( n = `mandatory`  v  = z2ui5_cl_util=>boolean_abap_2_json( mandatory ) )
+                          ( n = `hiddenFilter`  v  = z2ui5_cl_util=>boolean_abap_2_json( hiddenfilter ) )
+                          ( n = `visible`  v  = z2ui5_cl_util=>boolean_abap_2_json( visible ) )
                         ) ).
 
   ENDMETHOD.
 
   METHOD filter_group_items.
     result = _generic( name = `filterGroupItems`
-                       ns   = 'fb' ).
+                       ns   = `fb` ).
   ENDMETHOD.
 
   METHOD filter_items.
@@ -6841,7 +6841,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD gantt_toolbar.
     result = _generic( name = `toolbar`
-                       ns   = 'gantt' ).
+                       ns   = `gantt` ).
   ENDMETHOD.
 
   METHOD generic_tag.
@@ -7172,18 +7172,18 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
     result = _generic( name   = `HTML`
                        ns     = `core`
                        t_prop = VALUE #(
-                           ( n = 'id' v = id )
-                           ( n = 'content' v = content )
-                           ( n = 'afterRendering' v = afterrendering )
-                           ( n = 'preferDOM' v = z2ui5_cl_util=>boolean_abap_2_json( preferdom ) )
-                           ( n = 'sanitizeContent' v = z2ui5_cl_util=>boolean_abap_2_json( sanitizecontent ) )
-                           ( n = 'visible' v = z2ui5_cl_util=>boolean_abap_2_json( visible ) ) ) ).
+                           ( n = `id` v = id )
+                           ( n = `content` v = content )
+                           ( n = `afterRendering` v = afterrendering )
+                           ( n = `preferDOM` v = z2ui5_cl_util=>boolean_abap_2_json( preferdom ) )
+                           ( n = `sanitizeContent` v = z2ui5_cl_util=>boolean_abap_2_json( sanitizecontent ) )
+                           ( n = `visible` v = z2ui5_cl_util=>boolean_abap_2_json( visible ) ) ) ).
 
   ENDMETHOD.
 
   METHOD html_area.
     result = _generic( name   = `area`
-                       ns     = 'html'
+                       ns     = `html`
                        t_prop = VALUE #( ( n = `id`  v = id )
                                          ( n = `shape`  v = shape )
                                          ( n = `coords`  v = coords )
@@ -7205,7 +7205,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD html_map.
     result = _generic( name   = `map`
-                       ns     = 'html'
+                       ns     = `html`
                        t_prop = VALUE #( ( n = `id`  v = id )
                                          ( n = `class`  v = class )
                                          ( n = `name`  v = name ) ) ).
@@ -7363,7 +7363,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD info_label.
     result = _generic( name   = `InfoLabel`
-                       ns     = 'tnt'
+                       ns     = `tnt`
                        t_prop = VALUE #(
                            ( n = `id`               v = id )
                            ( n = `class`               v = class )
@@ -7665,7 +7665,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD lines.
     result = _generic( name = `lines`
-                       ns   = SWITCH #( ns WHEN '' THEN `networkgraph` ELSE ns ) ).
+                       ns   = SWITCH #( ns WHEN `` THEN `networkgraph` ELSE ns ) ).
   ENDMETHOD.
 
   METHOD line_micro_chart.
@@ -8829,7 +8829,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD process_flow.
     result = _generic(
                  name   = `ProcessFlow`
-                 ns     = 'commons'
+                 ns     = `commons`
                  t_prop = VALUE #( ( n = `id`               v = id )
                                    ( n = `foldedCorners`    v = z2ui5_cl_util=>boolean_abap_2_json( foldedcorners ) )
                                    ( n = `scrollable`       v = z2ui5_cl_util=>boolean_abap_2_json( scrollable ) )
@@ -8847,7 +8847,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD process_flow_lane_header.
 
     result = _generic( name   = `ProcessFlowLaneHeader`
-                       ns     = 'commons'
+                       ns     = `commons`
                        t_prop = VALUE #( ( n = `iconSrc`          v = iconsrc )
                                          ( n = `laneId`           v = laneid )
                                          ( n = `position`         v = position )
@@ -8859,7 +8859,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD process_flow_node.
     result = _generic(
                  name   = `ProcessFlowNode`
-                 ns     = 'commons'
+                 ns     = `commons`
                  t_prop = VALUE #( ( n = `laneId`               v = laneid )
                                    ( n = `nodeId`               v = nodeid )
                                    ( n = `title`                v = title )
@@ -9269,20 +9269,20 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
                            ( n = `showProductSwitcher`  v = z2ui5_cl_util=>boolean_abap_2_json( showproductswitcher ) )
                            ( n = `showSearch`  v = z2ui5_cl_util=>boolean_abap_2_json( showsearch ) )
                            ( n = `notificationsNumber`  v = notificationsnumber )
-                           ( n = 'avatarPressed' v = avatarpressed )
-                           ( n = 'copilotPressed' v = copilotpressed )
-                           ( n = 'homeIconPressed' v = homeiconpressed )
-                           ( n = 'menuButtonPressed' v = menubuttonpressed )
-                           ( n = 'navButtonPressed' v = navbuttonpressed )
-                           ( n = 'notificationsPressed' v = notificationspressed )
-                           ( n = 'productSwitcherPressed' v = productswitcherpressed )
-                           ( n = 'searchButtonPressed' v = searchbuttonpressed ) ) ).
+                           ( n = `avatarPressed` v = avatarpressed )
+                           ( n = `copilotPressed` v = copilotpressed )
+                           ( n = `homeIconPressed` v = homeiconpressed )
+                           ( n = `menuButtonPressed` v = menubuttonpressed )
+                           ( n = `navButtonPressed` v = navbuttonpressed )
+                           ( n = `notificationsPressed` v = notificationspressed )
+                           ( n = `productSwitcherPressed` v = productswitcherpressed )
+                           ( n = `searchButtonPressed` v = searchbuttonpressed ) ) ).
 
   ENDMETHOD.
 
   METHOD side_content.
     result = _generic( name   = `sideContent`
-                       ns     = 'layout'
+                       ns     = `layout`
                        t_prop = VALUE #( ( n = `width`                           v = width ) ) ).
 
   ENDMETHOD.
@@ -9563,7 +9563,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD statuses.
     result = _generic( name = `statuses`
-                       ns   = SWITCH #( ns WHEN '' THEN `networkgraph` ELSE ns ) ).
+                       ns   = SWITCH #( ns WHEN `` THEN `networkgraph` ELSE ns ) ).
   ENDMETHOD.
 
   METHOD status_indicator.
@@ -9870,65 +9870,65 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
     result = _generic(
         name   = `Timeline`
-        ns     = 'commons'
-        t_prop = VALUE #( ( n = 'id'                 v = id )
-                          ( n = 'enableDoubleSided'  v = z2ui5_cl_util=>boolean_abap_2_json( enabledoublesided ) )
-                          ( n = 'groupBy'            v = groupby )
-                          ( n = 'growingThreshold'   v = growingthreshold )
-                          ( n = 'filterTitle'        v = filtertitle )
-                          ( n = 'sortOldestFirst'    v = z2ui5_cl_util=>boolean_abap_2_json( sortoldestfirst ) )
-                          ( n = 'enableModelFilter'  v = z2ui5_cl_util=>boolean_abap_2_json( enablemodelfilter ) )
-                          ( n = 'enableScroll'       v = z2ui5_cl_util=>boolean_abap_2_json( enablescroll ) )
-                          ( n = 'forceGrowing'       v = z2ui5_cl_util=>boolean_abap_2_json( forcegrowing ) )
-                          ( n = 'group'              v = z2ui5_cl_util=>boolean_abap_2_json( group ) )
-                          ( n = 'lazyLoading'        v = z2ui5_cl_util=>boolean_abap_2_json( lazyloading ) )
-                          ( n = 'showHeaderBar'      v = z2ui5_cl_util=>boolean_abap_2_json( showheaderbar ) )
-                          ( n = 'showIcons'          v = z2ui5_cl_util=>boolean_abap_2_json( showicons ) )
-                          ( n = 'showItemFilter'     v = z2ui5_cl_util=>boolean_abap_2_json( showitemfilter ) )
-                          ( n = 'showSearch'         v = z2ui5_cl_util=>boolean_abap_2_json( showsearch ) )
-                          ( n = 'showSort'           v = z2ui5_cl_util=>boolean_abap_2_json( showsort ) )
-                          ( n = 'showTimeFilter'     v = z2ui5_cl_util=>boolean_abap_2_json( showtimefilter ) )
-                          ( n = 'sort'               v = z2ui5_cl_util=>boolean_abap_2_json( sort ) )
-                          ( n = 'groupByType'        v = groupbytype )
-                          ( n = 'textHeight'         v = textheight )
-                          ( n = 'width'              v = width )
-                          ( n = 'height'             v = height )
-                          ( n = 'noDataText'         v = nodatatext )
-                          ( n = 'alignment'          v = alignment )
-                          ( n = 'axisOrientation'    v = axisorientation )
-                          ( n = 'filterList'         v = filterlist )
-                          ( n = 'customFilter'       v = customfilter )
-                          ( n = 'content'            v = content ) ) ).
+        ns     = `commons`
+        t_prop = VALUE #( ( n = `id`                 v = id )
+                          ( n = `enableDoubleSided`  v = z2ui5_cl_util=>boolean_abap_2_json( enabledoublesided ) )
+                          ( n = `groupBy`            v = groupby )
+                          ( n = `growingThreshold`   v = growingthreshold )
+                          ( n = `filterTitle`        v = filtertitle )
+                          ( n = `sortOldestFirst`    v = z2ui5_cl_util=>boolean_abap_2_json( sortoldestfirst ) )
+                          ( n = `enableModelFilter`  v = z2ui5_cl_util=>boolean_abap_2_json( enablemodelfilter ) )
+                          ( n = `enableScroll`       v = z2ui5_cl_util=>boolean_abap_2_json( enablescroll ) )
+                          ( n = `forceGrowing`       v = z2ui5_cl_util=>boolean_abap_2_json( forcegrowing ) )
+                          ( n = `group`              v = z2ui5_cl_util=>boolean_abap_2_json( group ) )
+                          ( n = `lazyLoading`        v = z2ui5_cl_util=>boolean_abap_2_json( lazyloading ) )
+                          ( n = `showHeaderBar`      v = z2ui5_cl_util=>boolean_abap_2_json( showheaderbar ) )
+                          ( n = `showIcons`          v = z2ui5_cl_util=>boolean_abap_2_json( showicons ) )
+                          ( n = `showItemFilter`     v = z2ui5_cl_util=>boolean_abap_2_json( showitemfilter ) )
+                          ( n = `showSearch`         v = z2ui5_cl_util=>boolean_abap_2_json( showsearch ) )
+                          ( n = `showSort`           v = z2ui5_cl_util=>boolean_abap_2_json( showsort ) )
+                          ( n = `showTimeFilter`     v = z2ui5_cl_util=>boolean_abap_2_json( showtimefilter ) )
+                          ( n = `sort`               v = z2ui5_cl_util=>boolean_abap_2_json( sort ) )
+                          ( n = `groupByType`        v = groupbytype )
+                          ( n = `textHeight`         v = textheight )
+                          ( n = `width`              v = width )
+                          ( n = `height`             v = height )
+                          ( n = `noDataText`         v = nodatatext )
+                          ( n = `alignment`          v = alignment )
+                          ( n = `axisOrientation`    v = axisorientation )
+                          ( n = `filterList`         v = filterlist )
+                          ( n = `customFilter`       v = customfilter )
+                          ( n = `content`            v = content ) ) ).
   ENDMETHOD.
 
   METHOD timeline_item.
 
     result = _generic(
         name   = `TimelineItem`
-        ns     = 'commons'
-        t_prop = VALUE #( ( n = 'id'                     v = id )
-                          ( n = 'dateTime'               v = datetime )
-                          ( n = 'title'                  v = title )
-                          ( n = 'userNameClickable'      v = z2ui5_cl_util=>boolean_abap_2_json( usernameclickable ) )
-                          ( n = 'useIconTooltip'         v = z2ui5_cl_util=>boolean_abap_2_json( useicontooltip ) )
-                          ( n = 'userNameClicked'        v = usernameclicked )
-                          ( n = 'userPicture'            v = userpicture )
-                          ( n = 'select'                 v = select )
-                          ( n = 'text'                   v = text )
-                          ( n = 'userName'               v = username )
-                          ( n = 'filterValue'            v = filtervalue )
-                          ( n = 'iconDisplayShape'       v = icondisplayshape )
-                          ( n = 'iconInitials'           v = iconinitials )
-                          ( n = 'iconSize'               v = iconsize )
-                          ( n = 'iconTooltip'            v = icontooltip )
-                          ( n = 'maxCharacters'          v = maxcharacters )
-                          ( n = 'replyCount'             v = replycount )
-                          ( n = 'status'                 v = status )
-                          ( n = 'customActionClicked'    v = customactionclicked )
-                          ( n = 'press'                  v = press )
-                          ( n = 'replyListOpen'          v = replylistopen )
-                          ( n = 'replyPost'              v = replypost )
-                          ( n = 'icon'                   v = icon ) ) ).
+        ns     = `commons`
+        t_prop = VALUE #( ( n = `id`                     v = id )
+                          ( n = `dateTime`               v = datetime )
+                          ( n = `title`                  v = title )
+                          ( n = `userNameClickable`      v = z2ui5_cl_util=>boolean_abap_2_json( usernameclickable ) )
+                          ( n = `useIconTooltip`         v = z2ui5_cl_util=>boolean_abap_2_json( useicontooltip ) )
+                          ( n = `userNameClicked`        v = usernameclicked )
+                          ( n = `userPicture`            v = userpicture )
+                          ( n = `select`                 v = select )
+                          ( n = `text`                   v = text )
+                          ( n = `userName`               v = username )
+                          ( n = `filterValue`            v = filtervalue )
+                          ( n = `iconDisplayShape`       v = icondisplayshape )
+                          ( n = `iconInitials`           v = iconinitials )
+                          ( n = `iconSize`               v = iconsize )
+                          ( n = `iconTooltip`            v = icontooltip )
+                          ( n = `maxCharacters`          v = maxcharacters )
+                          ( n = `replyCount`             v = replycount )
+                          ( n = `status`                 v = status )
+                          ( n = `customActionClicked`    v = customactionclicked )
+                          ( n = `press`                  v = press )
+                          ( n = `replyListOpen`          v = replylistopen )
+                          ( n = `replyPost`              v = replypost )
+                          ( n = `icon`                   v = icon ) ) ).
   ENDMETHOD.
 
   METHOD time_horizon.
@@ -9976,7 +9976,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD title.
-    DATA(lv_name) = COND #( WHEN ns = 'f' THEN 'title' ELSE `Title` ).
+    DATA(lv_name) = COND #( WHEN ns = `f` THEN `title` ELSE `Title` ).
 
     result = me.
     _generic( ns     = ns
@@ -10027,8 +10027,8 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD toolbar.
     DATA(lv_name) = COND #(
-        WHEN ns = 'table' THEN 'toolbar'
-        WHEN ns = 'form'  THEN 'toolbar'
+        WHEN ns = `table` THEN `toolbar`
+        WHEN ns = `form`  THEN `toolbar`
         ELSE `Toolbar` ).
     result = _generic( name   = lv_name
                        ns     = ns
@@ -10172,7 +10172,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD ui_column.
     result = _generic( name   = `Column`
-                       ns     = 'table'
+                       ns     = `table`
                        t_prop = VALUE #(
                            ( n = `id` v = id )
                            ( n = `width` v = width )
@@ -10191,18 +10191,18 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD ui_columns.
     result = _generic( name = `columns`
-                       ns   = 'table' ).
+                       ns   = `table` ).
   ENDMETHOD.
 
   METHOD ui_custom_data.
     result = _generic( name = `customData`
-                       ns   = 'table' ).
+                       ns   = `table` ).
   ENDMETHOD.
 
   METHOD ui_extension.
 
     result = _generic( name = `extension`
-                       ns   = 'table' ).
+                       ns   = `table` ).
   ENDMETHOD.
 
   METHOD ui_row_action.
@@ -10268,14 +10268,14 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD ui_template.
 
     result = _generic( name = `template`
-                       ns   = 'table' ).
+                       ns   = `table` ).
 
   ENDMETHOD.
 
   METHOD upload_set.
     result = _generic(
                  name   = `UploadSet`
-                 ns     = 'upload'
+                 ns     = `upload`
                  t_prop = VALUE #(
                      ( n = `id`                       v = id )
                      ( n = `instantUpload`            v = z2ui5_cl_util=>boolean_abap_2_json( instantupload ) )
@@ -10320,7 +10320,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD upload_set_item.
     result = _generic( name   = `UploadSetItem`
-                       ns     = 'upload'
+                       ns     = `upload`
                        t_prop = VALUE #( ( n = `fileName`      v = filename )
                                          ( n = `mediaType`     v = mediatype )
                                          ( n = `url`           v = url )
@@ -11069,18 +11069,18 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD viz_dataset.
-    result = _generic( name = 'dataset'
-                       ns   = 'viz' ).
+    result = _generic( name = `dataset`
+                       ns   = `viz` ).
   ENDMETHOD.
 
   METHOD viz_dimensions.
-    result = _generic( name = 'dimensions'
-                       ns   = 'viz.data' ).
+    result = _generic( name = `dimensions`
+                       ns   = `viz.data` ).
   ENDMETHOD.
 
   METHOD viz_dimension_definition.
-    result = _generic( name   = 'DimensionDefinition'
-                       ns     = 'viz.data'
+    result = _generic( name   = `DimensionDefinition`
+                       ns     = `viz.data`
                        t_prop = VALUE #( ( n = `axis`          v = axis )
                                          ( n = `dataType`      v = datatype )
                                          ( n = `displayValue`  v = displayvalue )
@@ -11091,13 +11091,13 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD viz_feeds.
-    result = _generic( name = 'feeds'
-                       ns   = 'viz' ).
+    result = _generic( name = `feeds`
+                       ns   = `viz` ).
   ENDMETHOD.
 
   METHOD viz_feed_item.
-    result = _generic( name   = 'FeedItem'
-                       ns     = 'viz.feeds'
+    result = _generic( name   = `FeedItem`
+                       ns     = `viz.feeds`
                        t_prop = VALUE #( ( n = `id`      v = id )
                                          ( n = `uid`     v = uid )
                                          ( n = `type`    v = type )
@@ -11105,8 +11105,8 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD viz_flattened_dataset.
-    result = _generic( name   = 'FlattenedDataset'
-                       ns     = 'viz.data'
+    result = _generic( name   = `FlattenedDataset`
+                       ns     = `viz.data`
                        t_prop = VALUE #( ( n = `data` v = data ) ) ).
   ENDMETHOD.
 
@@ -11142,8 +11142,8 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
       lv_vizproperties = vizproperties.
     ENDIF.
 
-    result = _generic( name   = 'VizFrame'
-                       ns     = 'viz'
+    result = _generic( name   = `VizFrame`
+                       ns     = `viz`
                        t_prop = VALUE #( ( n = `id`                v = id )
                                          ( n = `legendVisible`     v = legendvisible )
                                          ( n = `vizCustomizations` v = vizcustomizations )
@@ -11159,13 +11159,13 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD viz_measures.
-    result = _generic( name = 'measures'
-                       ns   = 'viz.data' ).
+    result = _generic( name = `measures`
+                       ns   = `viz.data` ).
   ENDMETHOD.
 
   METHOD viz_measure_definition.
-    result = _generic( name   = 'MeasureDefinition'
-                       ns     = 'viz.data'
+    result = _generic( name   = `MeasureDefinition`
+                       ns     = `viz.data`
                        t_prop = VALUE #( ( n = `format`    v = format )
                                          ( n = `group`     v = group )
                                          ( n = `identity`  v = identity )
@@ -11177,22 +11177,22 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
   METHOD smart_multi_input.
 
-    result = _generic( name   = 'SmartMultiInput'
-                       ns     = 'smi'
-                       t_prop = VALUE #( ( n = 'id'                   v = id )
-                                         ( n = 'value'                v = value )
-                                         ( n = 'entitySet'            v = entityset )
-                                         ( n = 'supportRanges'        v = supportranges )
-                                         ( n = 'enableODataSelect'    v = enableodataselect )
-                                         ( n = 'requestAtLeastFields' v = requestatleastfields )
-                                         ( n = 'singleTokenMode'      v = singletokenmode )
-                                         ( n = 'supportMultiSelect'   v = supportmultiselect )
-                                         ( n = 'textSeparator'        v = textseparator )
-                                         ( n = 'textLabel'            v = textlabel )
-                                         ( n = 'tooltipLabel'         v = tooltiplabel )
-                                         ( n = 'textInEditModeSource' v = textineditmodesource )
-                                         ( n = 'mandatory'         v = mandatory )
-                                         ( n = 'maxLength'         v = maxlength ) ) ).
+    result = _generic( name   = `SmartMultiInput`
+                       ns     = `smi`
+                       t_prop = VALUE #( ( n = `id`                   v = id )
+                                         ( n = `value`                v = value )
+                                         ( n = `entitySet`            v = entityset )
+                                         ( n = `supportRanges`        v = supportranges )
+                                         ( n = `enableODataSelect`    v = enableodataselect )
+                                         ( n = `requestAtLeastFields` v = requestatleastfields )
+                                         ( n = `singleTokenMode`      v = singletokenmode )
+                                         ( n = `supportMultiSelect`   v = supportmultiselect )
+                                         ( n = `textSeparator`        v = textseparator )
+                                         ( n = `textLabel`            v = textlabel )
+                                         ( n = `tooltipLabel`         v = tooltiplabel )
+                                         ( n = `textInEditModeSource` v = textineditmodesource )
+                                         ( n = `mandatory`         v = mandatory )
+                                         ( n = `maxLength`         v = maxlength ) ) ).
 
   ENDMETHOD.
 
@@ -11221,7 +11221,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
                  name   = `ImageEditor`
                  ns     = `ie`
                  t_prop = VALUE #(
-                     ( n = 'id'                    v = id )
+                     ( n = `id`                    v = id )
                      ( n = `customShapeSrc`        v = customshapesrc )
                      ( n = `keepCropAspectRatio`   v = z2ui5_cl_util=>boolean_abap_2_json( keepcropaspectratio ) )
                      ( n = `keepResizeAspectRatio` v = z2ui5_cl_util=>boolean_abap_2_json( keepresizeaspectratio ) )
@@ -11233,7 +11233,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD image_editor_container.
     result = _generic( name   = `ImageEditorContainer`
                        ns     = `ie`
-                       t_prop = VALUE #( ( n = 'id'             v = id )
+                       t_prop = VALUE #( ( n = `id`             v = id )
                                          ( n = `enabledButtons` v = enabledbuttons )
                                          ( n = `mode`           v = mode ) ) ).
   ENDMETHOD.

--- a/src/02/z2ui5_cl_xml_view_cc.clas.abap
+++ b/src/02/z2ui5_cl_xml_view_cc.clas.abap
@@ -396,8 +396,8 @@ CLASS z2ui5_cl_xml_view_cc IMPLEMENTATION.
     mo_view->_generic( ns   = `html`
                        name = `style` ).
 
-    DATA(lv_class) = 'Z2UI5_CL_CC_DEMO_OUT'.
-    CALL METHOD (lv_class)=>('GET_STYLE')
+    DATA(lv_class) = `Z2UI5_CL_CC_DEMO_OUT`.
+    CALL METHOD (lv_class)=>(`GET_STYLE`)
       RECEIVING result = lv_style.
     result = mo_view->_cc_plain_xml( lv_style )->html( val ).
 

--- a/src/02/z2ui5_if_app.intf.abap
+++ b/src/02/z2ui5_if_app.intf.abap
@@ -1,10 +1,10 @@
 INTERFACE z2ui5_if_app PUBLIC.
   INTERFACES if_serializable_object.
 
-  CONSTANTS version TYPE string VALUE '1.141.0'.
-  CONSTANTS origin  TYPE string VALUE 'https://github.com/abap2UI5/abap2UI5'.
-  CONSTANTS authors TYPE string VALUE 'https://github.com/abap2UI5/abap2UI5/graphs/contributors'.
-  CONSTANTS license TYPE string VALUE 'MIT'.
+  CONSTANTS version TYPE string VALUE `1.141.0`.
+  CONSTANTS origin  TYPE string VALUE `https://github.com/abap2UI5/abap2UI5`.
+  CONSTANTS authors TYPE string VALUE `https://github.com/abap2UI5/abap2UI5/graphs/contributors`.
+  CONSTANTS license TYPE string VALUE `MIT`.
 
   DATA id_draft          TYPE string.
   DATA id_app            TYPE string.


### PR DESCRIPTION
- Convert ABAP string literals from ' ' to ` ` syntax
- Updated 61 files across the codebase
- Excluded JavaScript/HTML/CSS files to preserve embedded code
- abaplint checks now pass with 0 errors