### PR TITLE
Optimize model service by caching mapper and improving table lookups

### DIFF
--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -137,6 +137,9 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     TRY.
 
         DATA(ajson_result) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty( ) ).
+        DATA(lo_upper_mapper) = z2ui5_cl_ajson_mapping=>create_upper_case( ).
+        DATA(ajson_default) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty( ii_custom_mapping = lo_upper_mapper ) ).
+
         LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri) "#EC CI_SORTSEQ
              WHERE bind_type <> ``
                    AND type_kind <> cl_abap_datadescr=>typekind_dref
@@ -146,8 +149,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
             DATA(ajson) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty(
                                                    ii_custom_mapping = lr_attri->custom_mapper ) ).
           ELSE.
-            ajson = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty(
-                                             ii_custom_mapping = z2ui5_cl_ajson_mapping=>create_upper_case( ) ) ).
+            ajson = ajson_default.
           ENDIF.
 
           TRY.
@@ -666,11 +668,11 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     dissolve( ).
 
     LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri).
-      DATA(lv_name) = lr_attri->name.
-      IF line_exists( lt_attri[ name = lv_name ] ).
-        lr_attri->bind_type   = lt_attri[ name = lv_name ]-bind_type.
-        lr_attri->name_client = lt_attri[ name = lv_name ]-name_client.
-        lr_attri->view        = lt_attri[ name = lv_name ]-view.
+      READ TABLE lt_attri REFERENCE INTO DATA(lr_old) WITH KEY name = lr_attri->name. "#EC CI_SORTSEQ
+      IF sy-subrc = 0.
+        lr_attri->bind_type   = lr_old->bind_type.
+        lr_attri->name_client = lr_old->name_client.
+        lr_attri->view        = lr_old->view.
       ENDIF.
     ENDLOOP.
 


### PR DESCRIPTION
## Summary
This PR improves performance and code maintainability in the core model service by introducing mapper caching and replacing inefficient table lookup patterns with direct READ TABLE operations.

## Key Changes
- **Mapper Caching**: Extract the upper case mapper creation outside the loop and reuse it for all attributes without custom mappers, eliminating redundant object instantiation
- **Optimized Table Lookups**: Replace `line_exists()` checks followed by indexed table access with a single `READ TABLE` statement using `REFERENCE INTO`, reducing redundant lookups and improving readability
- **Code Simplification**: Consolidate mapper initialization logic by storing the default mapper in a variable for reuse

## Implementation Details
- The upper case mapper (`lo_upper_mapper`) is now created once before the attribute loop and assigned to `ajson_default`, which is then used for all attributes without custom mappers
- The attribute synchronization logic now uses a single `READ TABLE` with `REFERENCE INTO` to fetch the old attribute data, eliminating the need for separate `line_exists()` and indexed access calls
- Both changes maintain the same functional behavior while reducing CPU cycles and improving code clarity