### PR TITLE
Fix type declarations and renderer context binding

### DIFF
--- a/app/webapp/controller/App.controller.js
+++ b/app/webapp/controller/App.controller.js
@@ -786,7 +786,7 @@ sap.ui.define("z2ui5/MultiInputExt", ["sap/ui/core/Control", "sap/m/Token", "sap
       this.fireChange();
     },
     renderer(oRm, oControl) {
-      z2ui5.onAfterRendering.push(this.setControl.bind(oControl));
+      z2ui5.onAfterRendering.push(oControl.setControl.bind(oControl));
     },
     setControl() {
       let table = z2ui5.oView.byId(this.getProperty("MultiInputId"));

--- a/src/01/03/z2ui5_cl_app_app_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_js.clas.abap
@@ -808,7 +808,7 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `      this.fireChange();` && |\n| &&
              `    },` && |\n| &&
              `    renderer(oRm, oControl) {` && |\n| &&
-             `      z2ui5.onAfterRendering.push(this.setControl.bind(oControl));` && |\n| &&
+             `      z2ui5.onAfterRendering.push(oControl.setControl.bind(oControl));` && |\n| &&
              `    },` && |\n| &&
              `    setControl() {` && |\n| &&
              `      let table = z2ui5.oView.byId(this.getProperty("MultiInputId"));` && |\n| &&


### PR DESCRIPTION
## Summary
This PR fixes type declarations in UI5 control metadata and corrects a context binding issue in the MultiInputExt renderer function.

## Key Changes
- **Type declarations**: Changed type declarations from capitalized (`"String"`, `"Boolean"`) to lowercase (`"string"`, `"boolean"`) in metadata properties across three custom controls:
  - MultiInputExt: `MultiInputId`, `MultiInputName`, and `checkInit` properties
  - SmartMultiInputExt: `multiInputId` and `checkInit` properties
  - UITableExt: `tableId` property

- **Renderer context binding**: Fixed the `MultiInputExt` renderer function to use the correct context when binding `setControl`:
  - Changed from `this.setControl.bind(oControl)` to `oControl.setControl.bind(oControl)`
  - This ensures the method is called with the proper control instance context

## Implementation Details
The type declaration changes align with SAP UI5 conventions where primitive type names should be lowercase. The renderer binding fix prevents potential context issues where `this` might not refer to the expected control instance in the renderer function scope.

Both the JavaScript controller file and the corresponding ABAP class file were updated to maintain consistency across the codebase.

https://claude.ai/code/session_01CewhSiywoyWY5AeSLGaKPm