### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ABAP_702.yaml
+++ b/.github/workflows/ABAP_702.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: 702
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/ABAP_CLOUD.yaml
+++ b/.github/workflows/ABAP_CLOUD.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/ABAP_STANDARD.yaml
+++ b/.github/workflows/ABAP_STANDARD.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/UI5.yaml
+++ b/.github/workflows/UI5.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/auto_abaplint_fix.yaml
+++ b/.github/workflows/auto_abaplint_fix.yaml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -31,7 +31,7 @@ jobs:
           npm run auto_abaplint
 
       - name: Open PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: abaplint-auto-fixes-formatting
           branch: abaplint-auto-fixes-formatting

--- a/.github/workflows/auto_abaplint_fix_pr.yaml
+++ b/.github/workflows/auto_abaplint_fix_pr.yaml
@@ -17,11 +17,11 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -33,6 +33,6 @@ jobs:
           npm run auto_abaplint
 
       - name: Commit and push fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "auto app2abap + abaplint autofix formatting"

--- a/.github/workflows/auto_downport.yaml
+++ b/.github/workflows/auto_downport.yaml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/check_app.yaml
+++ b/.github/workflows/check_app.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check_frontend.yaml
+++ b/.github/workflows/check_frontend.yaml
@@ -18,8 +18,8 @@ jobs:
       run:
         working-directory: ./app
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/create_app2abap.yaml
+++ b/.github/workflows/create_app2abap.yaml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -31,7 +31,7 @@ jobs:
           npm run auto_abaplint
 
       - name: Open PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: auto-app2abap
           branch: auto-app2abap

--- a/.github/workflows/create_frontend.yaml
+++ b/.github/workflows/create_frontend.yaml
@@ -7,13 +7,18 @@ on:
 permissions:
   contents: read
 
+env:
+  # peaceiris/actions-gh-pages@v4 still ships with node20; force the runner to
+  # execute it on node24 until upstream publishes a node24-based release.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   create_frontend:
     if: github.repository == 'abap2UI5/abap2UI5'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: send to bsp repository
       uses: peaceiris/actions-gh-pages@v4
       with:

--- a/.github/workflows/mirror_ajson.yaml
+++ b/.github/workflows/mirror_ajson.yaml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: run
       run: |
         git clone https://github.com/abap2UI5/ajson_mirror.git
@@ -29,7 +29,7 @@ jobs:
         rm -rf ajson_mirror
         git status
     - name: Open PR
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         title: mirror-ajson-update
         branch: mirror-ajson-update

--- a/.github/workflows/mirror_srtti.yaml
+++ b/.github/workflows/mirror_srtti.yaml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: run
       run: |
         git clone https://github.com/abap2UI5/srtti_mirror.git
@@ -29,7 +29,7 @@ jobs:
         rm -rf srtti_mirror
         git status
     - name: Open PR
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         title: mirror-srtti-update
         branch: mirror-srtti-update

--- a/.github/workflows/test_browser.yaml
+++ b/.github/workflows/test_browser.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/test_node.yaml
+++ b/.github/workflows/test_node.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/test_rename.yaml
+++ b/.github/workflows/test_rename.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
## Summary
This PR updates all GitHub Actions used across the workflow files to their latest major versions to ensure compatibility with modern Node.js runtimes and receive the latest features and security updates.

## Key Changes
- **actions/checkout**: v4 → v5
- **actions/setup-node**: v4 → v5
- **peter-evans/create-pull-request**: v7 → v8
- **stefanzweifel/git-auto-commit-action**: v5 → v7
- **Added Node.js 24 compatibility**: Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable in `create_frontend.yaml` workflow to ensure `peaceiris/actions-gh-pages@v4` executes on Node.js 24 until upstream publishes a Node.js 24-based release

## Implementation Details
- Updated 16 workflow files across the repository
- All Node.js-related actions upgraded to v5, which provides better compatibility with Node.js 20 and newer runtimes
- The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable is a temporary workaround for the `peaceiris/actions-gh-pages` action that hasn't yet released a Node.js 24-compatible version

https://claude.ai/code/session_013NVW6iWokq7cRLwBoSE8GU