### PR TITLE
Use optional chaining for isDestroyed method call

### DIFF
--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -101,7 +101,7 @@ sap.ui.define(['sap/ui/core/BusyIndicator', 'sap/m/MessageBox'], (BusyIndicator,
         const customJs = params?.S_FOLLOW_UP_ACTION?.CUSTOM_JS;
         if (customJs) {
           queueMicrotask(() => {
-            if (oController.isDestroyed()) return;
+            if (oController.isDestroyed?.()) return;
             for (const item of customJs) {
               try {
                 const mParams = item.split("'");

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -121,7 +121,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        const customJs = params?.S_FOLLOW_UP_ACTION?.CUSTOM_JS;` && |\n| &&
              `        if (customJs) {` && |\n| &&
              `          queueMicrotask(() => {` && |\n| &&
-             `            if (oController.isDestroyed()) return;` && |\n| &&
+             `            if (oController.isDestroyed?.()) return;` && |\n| &&
              `            for (const item of customJs) {` && |\n| &&
              `              try {` && |\n| &&
              `                const mParams = item.split("'");` && |\n| &&


### PR DESCRIPTION
## Summary
Updated the controller destruction check to use optional chaining syntax, making the code more defensive against cases where `isDestroyed` might not be defined.

## Key Changes
- Changed `oController.isDestroyed()` to `oController.isDestroyed?.()` in the custom JS execution handler
- Applied the same change in both the JavaScript source file and the ABAP template that generates it
- This uses optional chaining to safely call the method only if it exists, preventing potential runtime errors

## Implementation Details
The optional chaining operator (`?.`) ensures that if `isDestroyed` is undefined or null, the expression short-circuits and returns undefined rather than throwing a TypeError. This is particularly useful in the `queueMicrotask` callback where the controller state may have changed by the time the callback executes.

https://claude.ai/code/session_01Mn3qWcd44oRX2GGJ8gZnVY