### PR TITLE
Add refresh button to server error dialog

### DIFF
--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -190,6 +190,13 @@ sap.ui.define(['sap/ui/core/BusyIndicator', 'sap/m/MessageBox'], (BusyIndicator,
       const h3 = Object.assign(document.createElement('h3'), { textContent: 'Server Error - Please Restart The App' });
       h3.style.cssText = 'margin: 0';
       headerDiv.appendChild(h3);
+
+      const refreshBtn = Object.assign(document.createElement('button'), { type: 'button', textContent: 'Refresh' });
+      refreshBtn.style.cssText =
+        'padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;';
+      refreshBtn.addEventListener('click', () => window.location.reload());
+      headerDiv.appendChild(refreshBtn);
+
       errorContainer.appendChild(headerDiv);
 
       const iframe = Object.assign(document.createElement('iframe'), { id: 'errorIframe' });

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -210,6 +210,13 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `      const h3 = Object.assign(document.createElement('h3'), { textContent: 'Server Error - Please Restart The App' });` && |\n| &&
              `      h3.style.cssText = 'margin: 0';` && |\n| &&
              `      headerDiv.appendChild(h3);` && |\n| &&
+             `` && |\n| &&
+             `      const refreshBtn = Object.assign(document.createElement('button'), { type: 'button', textContent: 'Refresh' });` && |\n| &&
+             `      refreshBtn.style.cssText =` && |\n| &&
+             `        'padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;';` && |\n| &&
+             `      refreshBtn.addEventListener('click', () => window.location.reload());` && |\n| &&
+             `      headerDiv.appendChild(refreshBtn);` && |\n| &&
+             `` && |\n| &&
              `      errorContainer.appendChild(headerDiv);` && |\n| &&
              `` && |\n| &&
              `      const iframe = Object.assign(document.createElement('iframe'), { id: 'errorIframe' });` && |\n| &&


### PR DESCRIPTION
## Summary
Added a "Refresh" button to the server error dialog that allows users to reload the application without manually refreshing the page.

## Changes
- Added a styled refresh button to the error header in the server error dialog
- Button triggers `window.location.reload()` when clicked
- Applied consistent styling with white background, red text (#d32f2f), and rounded corners to match the application's error UI design
- Updated both the JavaScript source file and the ABAP class that generates this code

## Implementation Details
- The refresh button is created as a standard HTML button element with inline styles
- Styling includes: 6px 14px padding, white background, bold red text, no border, 3px border-radius, and pointer cursor
- Button is appended to the error header div alongside the error message
- Changes are synchronized across both the webapp source and the ABAP code generator

https://claude.ai/code/session_01QncoeCXevwAKAWtqCjNdZV