### PR TITLE
Implement persistent model size limits across view lifecycle

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -384,14 +384,20 @@ sap.ui.define(
 
         switch (args[0]) {
           case 'SET_SIZE_LIMIT': {
-            const viewKey = args[2];
-            const limit = +args[1];
-            (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;
-            const target = viewLookups[viewKey]?.();
-            if (target) {
-              const model = target.getModel();
+            const hasLimit = args[2] !== undefined && args[2] !== '';
+            const viewKey = hasLimit ? args[2] : args[1];
+            const limit = hasLimit ? Number(args[1]) : NaN;
+            const model = viewLookups[viewKey]?.()?.getModel();
+            if (Number.isFinite(limit) && limit > 0) {
+              (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;
               if (model) {
                 model.setSizeLimit(limit);
+                model.refresh(true);
+              }
+            } else {
+              if (z2ui5.viewSizeLimits) delete z2ui5.viewSizeLimits[viewKey];
+              if (model) {
+                model.setSizeLimit(100);
                 model.refresh(true);
               }
             }

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -145,6 +145,19 @@ sap.ui.define(
       POPOVER: () => z2ui5.oViewPopover,
     };
 
+    const paramToViewKey = {
+      S_VIEW: 'MAIN',
+      S_VIEW_NEST: 'NEST',
+      S_VIEW_NEST2: 'NEST2',
+      S_POPUP: 'POPUP',
+      S_POPOVER: 'POPOVER',
+    };
+
+    const applyStoredSizeLimit = (viewKey, oModel) => {
+      const limit = z2ui5.viewSizeLimits?.[viewKey];
+      if (limit !== undefined && oModel) oModel.setSizeLimit(limit);
+    };
+
     return Controller.extend('z2ui5.controller.View1', {
       _trackChanges(oModel) {
         oModel.attachPropertyChange((e) => {
@@ -242,6 +255,7 @@ sap.ui.define(
       },
       async displayFragment(xml, viewProp) {
         const oModel = this._createViewModel();
+        applyStoredSizeLimit('POPUP', oModel);
         const oFragment = await Fragment.load({
           definition: xml,
           controller: z2ui5.oControllerPopup,
@@ -259,6 +273,7 @@ sap.ui.define(
       async displayPopover(xml, viewProp, openById) {
         try {
           const oModel = this._createViewModel();
+          applyStoredSizeLimit('POPOVER', oModel);
           const oFragment = await Fragment.load({
             definition: xml,
             controller: z2ui5.oControllerPopover,
@@ -288,6 +303,7 @@ sap.ui.define(
       },
       async displayNestedView(xml, viewProp, viewNestId, controller) {
         const oModel = this._createViewModel();
+        applyStoredSizeLimit(paramToViewKey[viewNestId], oModel);
         const oView = await XMLView.create({
           definition: xml,
           controller,
@@ -368,11 +384,14 @@ sap.ui.define(
 
         switch (args[0]) {
           case 'SET_SIZE_LIMIT': {
-            const target = viewLookups[args[2]]?.();
+            const viewKey = args[2];
+            const limit = +args[1];
+            (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;
+            const target = viewLookups[viewKey]?.();
             if (target) {
               const model = target.getModel();
               if (model) {
-                model.setSizeLimit(+args[1]);
+                model.setSizeLimit(limit);
                 model.refresh(true);
               }
             }
@@ -563,7 +582,10 @@ sap.ui.define(
       },
 
       updateModelIfRequired(paramKey, oView) {
-        if (z2ui5.oResponse?.PARAMS?.[paramKey]?.CHECK_UPDATE_MODEL) oView?.setModel(this._createViewModel());
+        if (!z2ui5.oResponse?.PARAMS?.[paramKey]?.CHECK_UPDATE_MODEL) return;
+        const oModel = this._createViewModel();
+        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);
+        oView?.setModel(oModel);
       },
       async checkSDKcompatibility(err) {
         let gav;
@@ -623,6 +645,7 @@ sap.ui.define(
               annotationURI: sView.SWITCHDEFAULTMODELANNOURI ?? '',
             })
           : oViewModel;
+        applyStoredSizeLimit('MAIN', oModel);
         z2ui5.oView = await XMLView.create({
           definition: xml,
           models: oModel,

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -404,22 +404,28 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `        switch (args[0]) {` && |\n| &&
              `          case 'SET_SIZE_LIMIT': {` && |\n| &&
-             `            const viewKey = args[2];` && |\n| &&
-             `            const limit = +args[1];` && |\n| &&
-             `            (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;` && |\n| &&
-             `            const target = viewLookups[viewKey]?.();` && |\n| &&
-             `            if (target) {` && |\n| &&
-             `              const model = target.getModel();` && |\n| &&
+             `            const hasLimit = args[2] !== undefined && args[2] !== '';` && |\n| &&
+             `            const viewKey = hasLimit ? args[2] : args[1];` && |\n| &&
+             `            const limit = hasLimit ? Number(args[1]) : NaN;` && |\n| &&
+             `            const model = viewLookups[viewKey]?.()?.getModel();` && |\n| &&
+             `            if (Number.isFinite(limit) && limit > 0) {` && |\n| &&
+             `              (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;` && |\n| &&
              `              if (model) {` && |\n| &&
              `                model.setSizeLimit(limit);` && |\n| &&
+             `                model.refresh(true);` && |\n| &&
+             `              }` && |\n| &&
+             `            } else {` && |\n| &&
+             `              if (z2ui5.viewSizeLimits) delete z2ui5.viewSizeLimits[viewKey];` && |\n| &&
+             `              if (model) {` && |\n| &&
+             `                model.setSizeLimit(100);` && |\n| &&
+             |\n|.
+    result = result &&
              `                model.refresh(true);` && |\n| &&
              `              }` && |\n| &&
              `            }` && |\n| &&
              `            break;` && |\n| &&
              `          }` && |\n| &&
              `          case 'HISTORY_BACK':` && |\n| &&
-             |\n|.
-    result = result &&
              `            history.back();` && |\n| &&
              `            break;` && |\n| &&
              `          case 'CLIPBOARD_COPY':` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -165,6 +165,19 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      POPOVER: () => z2ui5.oViewPopover,` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
+             `    const paramToViewKey = {` && |\n| &&
+             `      S_VIEW: 'MAIN',` && |\n| &&
+             `      S_VIEW_NEST: 'NEST',` && |\n| &&
+             `      S_VIEW_NEST2: 'NEST2',` && |\n| &&
+             `      S_POPUP: 'POPUP',` && |\n| &&
+             `      S_POPOVER: 'POPOVER',` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
+             `    const applyStoredSizeLimit = (viewKey, oModel) => {` && |\n| &&
+             `      const limit = z2ui5.viewSizeLimits?.[viewKey];` && |\n| &&
+             `      if (limit !== undefined && oModel) oModel.setSizeLimit(limit);` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
              `    return Controller.extend('z2ui5.controller.View1', {` && |\n| &&
              `      _trackChanges(oModel) {` && |\n| &&
              `        oModel.attachPropertyChange((e) => {` && |\n| &&
@@ -262,6 +275,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `      async displayFragment(xml, viewProp) {` && |\n| &&
              `        const oModel = this._createViewModel();` && |\n| &&
+             `        applyStoredSizeLimit('POPUP', oModel);` && |\n| &&
              `        const oFragment = await Fragment.load({` && |\n| &&
              `          definition: xml,` && |\n| &&
              `          controller: z2ui5.oControllerPopup,` && |\n| &&
@@ -279,6 +293,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      async displayPopover(xml, viewProp, openById) {` && |\n| &&
              `        try {` && |\n| &&
              `          const oModel = this._createViewModel();` && |\n| &&
+             `          applyStoredSizeLimit('POPOVER', oModel);` && |\n| &&
              `          const oFragment = await Fragment.load({` && |\n| &&
              `            definition: xml,` && |\n| &&
              `            controller: z2ui5.oControllerPopover,` && |\n| &&
@@ -308,6 +323,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `      async displayNestedView(xml, viewProp, viewNestId, controller) {` && |\n| &&
              `        const oModel = this._createViewModel();` && |\n| &&
+             `        applyStoredSizeLimit(paramToViewKey[viewNestId], oModel);` && |\n| &&
              `        const oView = await XMLView.create({` && |\n| &&
              `          definition: xml,` && |\n| &&
              `          controller,` && |\n| &&
@@ -388,17 +404,22 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `        switch (args[0]) {` && |\n| &&
              `          case 'SET_SIZE_LIMIT': {` && |\n| &&
-             `            const target = viewLookups[args[2]]?.();` && |\n| &&
+             `            const viewKey = args[2];` && |\n| &&
+             `            const limit = +args[1];` && |\n| &&
+             `            (z2ui5.viewSizeLimits ??= {})[viewKey] = limit;` && |\n| &&
+             `            const target = viewLookups[viewKey]?.();` && |\n| &&
              `            if (target) {` && |\n| &&
              `              const model = target.getModel();` && |\n| &&
              `              if (model) {` && |\n| &&
-             `                model.setSizeLimit(+args[1]);` && |\n| &&
+             `                model.setSizeLimit(limit);` && |\n| &&
              `                model.refresh(true);` && |\n| &&
              `              }` && |\n| &&
              `            }` && |\n| &&
              `            break;` && |\n| &&
              `          }` && |\n| &&
              `          case 'HISTORY_BACK':` && |\n| &&
+             |\n|.
+    result = result &&
              `            history.back();` && |\n| &&
              `            break;` && |\n| &&
              `          case 'CLIPBOARD_COPY':` && |\n| &&
@@ -418,8 +439,6 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          }` && |\n| &&
              `          case 'STORE_DATA': {` && |\n| &&
              `            const { TYPE, PREFIX, VALUE, KEY } = args[1];` && |\n| &&
-             |\n|.
-    result = result &&
              `            try {` && |\n| &&
              `              const oStorage = new Storage(Storage.Type[TYPE] ?? Storage.Type.session, PREFIX);` && |\n| &&
              `              if (VALUE === '' || VALUE == null) {` && |\n| &&
@@ -585,7 +604,10 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `` && |\n| &&
              `      updateModelIfRequired(paramKey, oView) {` && |\n| &&
-             `        if (z2ui5.oResponse?.PARAMS?.[paramKey]?.CHECK_UPDATE_MODEL) oView?.setModel(this._createViewModel());` && |\n| &&
+             `        if (!z2ui5.oResponse?.PARAMS?.[paramKey]?.CHECK_UPDATE_MODEL) return;` && |\n| &&
+             `        const oModel = this._createViewModel();` && |\n| &&
+             `        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);` && |\n| &&
+             `        oView?.setModel(oModel);` && |\n| &&
              `      },` && |\n| &&
              `      async checkSDKcompatibility(err) {` && |\n| &&
              `        let gav;` && |\n| &&
@@ -645,6 +667,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `              annotationURI: sView.SWITCHDEFAULTMODELANNOURI ?? '',` && |\n| &&
              `            })` && |\n| &&
              `          : oViewModel;` && |\n| &&
+             `        applyStoredSizeLimit('MAIN', oModel);` && |\n| &&
              `        z2ui5.oView = await XMLView.create({` && |\n| &&
              `          definition: xml,` && |\n| &&
              `          models: oModel,` && |\n| &&


### PR DESCRIPTION
## Summary
This change introduces a mechanism to persist and apply model size limits across different views and fragments in the application. Previously, size limits were only applied at the moment of setting them, but were lost when views were recreated or updated. Now, size limits are stored globally and automatically reapplied whenever models are created.

## Key Changes

- **Added `paramToViewKey` mapping**: Maps parameter keys (S_VIEW, S_VIEW_NEST, etc.) to view identifiers (MAIN, NEST, POPUP, POPOVER) for consistent size limit management across the application.

- **Added `applyStoredSizeLimit()` helper function**: Retrieves and applies previously stored size limits to newly created models, ensuring persistence across view lifecycle events.

- **Enhanced `SET_SIZE_LIMIT` command handler**: 
  - Now stores size limits in `z2ui5.viewSizeLimits` for persistence
  - Improved argument parsing to support both legacy and new parameter formats
  - Added validation to ensure only positive finite numbers are accepted as limits
  - Implements reset functionality to restore default limit (100) when clearing a limit
  - Automatically refreshes models after applying size limits

- **Applied size limits to all model creation points**:
  - `displayFragment()` - applies POPUP limit
  - `displayPopover()` - applies POPOVER limit
  - `displayNestedView()` - applies dynamic limit based on view type
  - `updateModelIfRequired()` - reapplies limit when updating existing views
  - Main view initialization - applies MAIN limit

- **Refactored `updateModelIfRequired()`**: Improved readability with early return pattern and now properly applies stored size limits when updating models.

## Implementation Details

The solution uses a global `z2ui5.viewSizeLimits` object to store size limits by view key. When any model is created or updated, the `applyStoredSizeLimit()` function checks if a limit exists for that view and applies it. This ensures size limits persist across view recreation, model updates, and navigation events without requiring manual reapplication.

https://claude.ai/code/session_01Uhy4ZREJsaFr3VskFDwPrM