### PR TITLE
Remove unused sap.ui.unified library dependency

### DIFF
--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -62,7 +62,7 @@
       "libs": {
         "sap.m": {},
         "sap.ui.core": {},
-        "sap.ui.unified": {}
+        "sap.ui.unified": { "lazy": true }
       }
     },
     "contentDensities": {

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -61,8 +61,7 @@
       "minUI5Version": "1.136.0",
       "libs": {
         "sap.m": {},
-        "sap.ui.core": {},
-        "sap.ui.unified": { "lazy": true }
+        "sap.ui.core": {}
       }
     },
     "contentDensities": {

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -82,7 +82,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "libs": {` &&
              `        "sap.m": {},` &&
              `        "sap.ui.core": {},` &&
-             `        "sap.ui.unified": {}` &&
+             `        "sap.ui.unified": { "lazy": true }` &&
              `      }` &&
              `    },` &&
              `    "contentDensities": {` &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -81,8 +81,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "minUI5Version": "1.136.0",` &&
              `      "libs": {` &&
              `        "sap.m": {},` &&
-             `        "sap.ui.core": {},` &&
-             `        "sap.ui.unified": { "lazy": true }` &&
+             `        "sap.ui.core": {}` &&
              `      }` &&
              `    },` &&
              `    "contentDensities": {` &&


### PR DESCRIPTION
## Summary
Removed the unused `sap.ui.unified` library dependency from the UI5 manifest configuration.

## Changes
- Removed `"sap.ui.unified": {}` from the libs section in `manifest.json`
- Updated the corresponding manifest JSON generation class to reflect this change in `z2ui5_cl_app_manifest_json.clas.abap`

## Details
The `sap.ui.unified` library was declared as a dependency but is not being utilized by the application. This cleanup reduces unnecessary dependencies and keeps the manifest configuration lean and maintainable.

https://claude.ai/code/session_011tHZ3stLSSmGhm9doDg5ac