### PR TITLE
Update CI/CD badge links and remove deprecated check_app workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <summary>🚦</summary>
 <br>
 
-[![ABAP_702](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_702.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_702.yaml)
+[![ABAP_702](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_702.yaml/badge.svg?branch=702)](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_702.yaml?query=branch%3A702)
 [![ABAP_STANDARD](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_STANDARD.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_STANDARD.yaml)
 [![ABAP_CLOUD](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_CLOUD.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/ABAP_CLOUD.yaml)
 [![UI5_2X](https://github.com/abap2UI5/abap2UI5/actions/workflows/UI5.yaml/badge.svg?branch=main)](https://github.com/abap2UI5/abap2UI5/actions/workflows/UI5.yaml)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 <br>
 [![mirror_ajson](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_ajson.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_ajson.yaml)
 [![mirror_srtti](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_srtti.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_srtti.yaml)
-<br>
-[![check_app](https://github.com/abap2UI5/abap2UI5/actions/workflows/check_app.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/check_app.yaml)
 
 </details>
 


### PR DESCRIPTION
## Summary
Updated the README.md CI/CD status badges to improve accuracy and remove outdated workflow references.

## Key Changes
- **ABAP_702 badge**: Added branch parameter (`?branch=702`) to the badge URL and updated the workflow link to filter results by the 702 branch, ensuring the badge reflects the correct branch status
- **Removed check_app workflow**: Deleted the deprecated `check_app` workflow badge and its associated line break, as this workflow is no longer in use

## Details
These changes improve the CI/CD status visibility by ensuring badges accurately represent the build status for their respective branches, and clean up the README by removing references to deprecated workflows.

https://claude.ai/code/session_01RN7cqVCn9MHurG66FsxZMy