### PR TITLE
Add workflow_run trigger to ABAP_702 CI pipeline

### DIFF
--- a/.github/workflows/ABAP_702.yaml
+++ b/.github/workflows/ABAP_702.yaml
@@ -3,6 +3,9 @@ name: ABAP_702
 on:
   push:
     branches: [702]
+  workflow_run:
+    workflows: [auto_downport]
+    types: [completed]
 
 concurrency:
   group: ABAP_702-${{ github.ref }}
@@ -13,6 +16,7 @@ permissions:
 
 jobs:
   ABAP_702:
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
Updated the ABAP_702 workflow to be triggered by the completion of the `auto_downport` workflow in addition to direct pushes to the 702 branch.

## Key Changes
- Added `workflow_run` trigger that listens for successful completions of the `auto_downport` workflow
- Added conditional check to the ABAP_702 job to ensure it runs only on direct pushes or when the upstream workflow completes successfully

## Implementation Details
The workflow now supports two trigger scenarios:
1. **Direct push**: Triggered when code is pushed directly to the 702 branch
2. **Workflow completion**: Triggered when the `auto_downport` workflow completes successfully, enabling automated downport validation

The job condition `if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}` ensures the job only executes in these valid scenarios, preventing unnecessary runs on workflow failures.

https://claude.ai/code/session_011k1fBMBot95Xp29U715SG2