### PR TITLE
fixes for ui5-legacy-free

### DIFF
--- a/app/webapp/controller/App.controller.js
+++ b/app/webapp/controller/App.controller.js
@@ -785,7 +785,7 @@ sap.ui.define(
               const value = oEvent.getSource().getProperty('value');
               oControl.setProperty('path', value);
               oControl.oUploadButton?.setEnabled(!!value);
-              oControl.oUploadButton?.rerender();
+              oControl.oUploadButton?.invalidate();
             },
             uploadComplete: (oEvent) => {
               if (!directUpload) return;

--- a/src/01/03/z2ui5_cl_app_app_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_js.clas.abap
@@ -807,7 +807,7 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `              const value = oEvent.getSource().getProperty('value');` && |\n| &&
              `              oControl.setProperty('path', value);` && |\n| &&
              `              oControl.oUploadButton?.setEnabled(!!value);` && |\n| &&
-             `              oControl.oUploadButton?.rerender();` && |\n| &&
+             `              oControl.oUploadButton?.invalidate();` && |\n| &&
              `            },` && |\n| &&
              `            uploadComplete: (oEvent) => {` && |\n| &&
              `              if (!directUpload) return;` && |\n| &&

--- a/src/02/z2ui5_cl_app_hello_world.clas.abap
+++ b/src/02/z2ui5_cl_app_hello_world.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_app_hello_world IMPLEMENTATION.
         )->page( `abap2UI5 - Hello World`
           )->simple_form( editable = abap_true
             )->content( `form`
-              )->title( `Make an input here and send it to the server...`
+              )->title( ns = `core` text = `Make an input here and send it to the server...`
               )->label( `Name`
               )->input( client->_bind_edit( name )
               )->button( text  = `Send`


### PR DESCRIPTION
## Summary
This PR addresses two UI rendering issues in the z2ui5 framework:
1. Replaces an incorrect `rerender()` method call with the proper `invalidate()` method for UI control updates
2. Adds explicit namespace specification to a form title control for better consistency

## Key Changes
- **App.controller.js & z2ui5_cl_app_app_js.clas.abap**: Changed `oControl.oUploadButton?.rerender()` to `oControl.oUploadButton?.invalidate()` in the file path input change handler. The `invalidate()` method is the correct SAP UI5 API for marking a control as needing re-rendering, whereas `rerender()` is not a standard UI5 method.

- **z2ui5_cl_app_hello_world.clas.abap**: Updated the form title control to explicitly specify the namespace parameter: `)->title( ns = `core` text = `Make an input here and send it to the server...` )`. This ensures the title uses the correct namespace context.

## Implementation Details
These changes ensure proper UI5 control lifecycle management and consistent namespace handling across form controls, improving the reliability of the upload button state updates and form rendering.

https://claude.ai/code/session_01LvBVD43pTWL9tKa3TaNcZZ