### PR TITLE
Add trailing whitespace cleanup to auto_downport script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "description": "Developing UI5 Apps Purely in ABAP.",
   "scripts": {
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
+    "strip_trailing_ws": "find src -type f -name '*.abap' -exec sed -i 's/[[:space:]]\\+$//' {} +",
     "abaplintpathfix": "sed -i 's|\"files\": \"/\\.\\.\\/\\.\\.\\/src\\/\\*\\*\\/\\*\\.\\*\"|\"files\": \"/src/**/*.*\"|g' abaplint.jsonc",
-    "auto_downport": "abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && cp -r src node/downport && cp -f .github/abaplint/abap_702.jsonc abaplint.jsonc && npm run abaplintpathfix",
+    "auto_downport": "abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && npm run strip_trailing_ws && cp -r src node/downport && cp -f .github/abaplint/abap_702.jsonc abaplint.jsonc && npm run abaplintpathfix",
     "auto_app2abap": "node .github/app2abap/trans2abap.js",
     "auto_abaplint": "npx abaplint .github/abaplint/auto_abaplint_fix.jsonc --fix",
     "auto_transpile": "rm -rf node/output && cp node/srv/*.abap node/downport && abap_transpile ./node/setup/abap_transpile.json",


### PR DESCRIPTION
## Summary
Added a new npm script to strip trailing whitespace from ABAP source files and integrated it into the `auto_downport` workflow.

## Changes
- Added new `strip_trailing_ws` npm script that removes trailing whitespace from all `.abap` files in the `src` directory
- Integrated the `strip_trailing_ws` script into the `auto_downport` pipeline, executing it after `syfixes` and before copying files to the downport directory

## Details
This ensures that the downported ABAP code maintains consistent formatting by removing any trailing whitespace, which helps keep the codebase clean and prevents whitespace-related diffs in version control.

https://claude.ai/code/session_01NwVQSvWjc74e3vmbyXMUrf