### PR TITLE
Fix conditional method implementations in XML utility class

### DIFF
--- a/src/00/03/z2ui5_cl_util_xml.clas.abap
+++ b/src/00/03/z2ui5_cl_util_xml.clas.abap
@@ -153,6 +153,19 @@ CLASS z2ui5_cl_util_xml IMPLEMENTATION.
   METHOD _if.
 
     IF when = abap_true.
+      __( n  = n
+          ns = ns
+          a  = a
+          v  = v
+          p  = p ).
+    ENDIF.
+    result = me.
+
+  ENDMETHOD.
+
+  METHOD __if.
+
+    IF when = abap_true.
       result = __( n  = n
                    ns = ns
                    a  = a
@@ -161,19 +174,6 @@ CLASS z2ui5_cl_util_xml IMPLEMENTATION.
     ELSE.
       result = me.
     ENDIF.
-
-  ENDMETHOD.
-
-  METHOD __if.
-
-    IF when = abap_true.
-      _( n  = n
-         ns = ns
-         a  = a
-         v  = v
-         p  = p ).
-    ENDIF.
-    result = me.
 
   ENDMETHOD.
 

--- a/src/00/03/z2ui5_cl_util_xml.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_util_xml.clas.testclasses.abap
@@ -332,10 +332,10 @@ CLASS ltcl_unit_test IMPLEMENTATION.
     DATA(lv_xml) = z2ui5_cl_util_xml=>factory(
       )->__( n = `View` ns = `mvc`
       )->__( `Page`
-      )->_if( when = abap_true
-              n    = `Panel`
-              a    = `headerText`
-              v    = `Admin`
+      )->__if( when = abap_true
+               n    = `Panel`
+               a    = `headerText`
+               v    = `Admin`
       )->_( n = `Text` a = `text` v = `Secret`
       )->n( `Page`
       )->stringify( ).
@@ -350,10 +350,10 @@ CLASS ltcl_unit_test IMPLEMENTATION.
     DATA(lv_xml) = z2ui5_cl_util_xml=>factory(
       )->__( n = `View` ns = `mvc`
       )->__( `Page`
-      )->_if( when = abap_false
-              n    = `Panel`
-              a    = `headerText`
-              v    = `Admin`
+      )->__if( when = abap_false
+               n    = `Panel`
+               a    = `headerText`
+               v    = `Admin`
       )->_( n = `Button` a = `text` v = `Visible`
       )->stringify( ).
 
@@ -367,10 +367,10 @@ CLASS ltcl_unit_test IMPLEMENTATION.
     DATA(lv_xml) = z2ui5_cl_util_xml=>factory(
       )->__( n = `View` ns = `mvc`
       )->__( `Page`
-      )->__if( when = abap_true
-               n    = `Button`
-               a    = `text`
-               v    = `Admin Only`
+      )->_if( when = abap_true
+              n    = `Button`
+              a    = `text`
+              v    = `Admin Only`
       )->stringify( ).
 
     cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `Admin Only` ) ).
@@ -382,10 +382,10 @@ CLASS ltcl_unit_test IMPLEMENTATION.
     DATA(lv_xml) = z2ui5_cl_util_xml=>factory(
       )->__( n = `View` ns = `mvc`
       )->__( `Page`
-      )->__if( when = abap_false
-               n    = `Button`
-               a    = `text`
-               v    = `Hidden`
+      )->_if( when = abap_false
+              n    = `Button`
+              a    = `text`
+              v    = `Hidden`
       )->_( n = `Text` a = `text` v = `Visible`
       )->stringify( ).
 

--- a/src/02/z2ui5_cl_app_hello_world.clas.abap
+++ b/src/02/z2ui5_cl_app_hello_world.clas.abap
@@ -14,17 +14,28 @@ CLASS z2ui5_cl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(view) = z2ui5_cl_xml_view=>factory(
-        )->shell(
-        )->page( `abap2UI5 - Hello World`
-          )->simple_form( editable = abap_true
-            )->content( `form`
-              )->title( ns   = `core`
-                        text = `Make an input here and send it to the server...`
-              )->label( `Name`
-              )->input( client->_bind_edit( name )
-              )->button( text  = `Send`
-                         press = client->_event( `BUTTON_POST` ) ).
+      DATA(view) = z2ui5_cl_util_xml=>factory(
+        )->__( n  = `View`
+               ns = `mvc`
+               p  = VALUE #( ( n = `xmlns`        v = `sap.m` )
+                             ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
+                             ( n = `xmlns:core`   v = `sap.ui.core` )
+                             ( n = `xmlns:form`   v = `sap.ui.layout.form` )
+                             ( n = `displayBlock` v = `true` )
+                             ( n = `height`       v = `100%` ) )
+          )->__( `Shell`
+            )->__( n = `Page` a = `title` v = `abap2UI5 - Hello World`
+              )->__( n = `SimpleForm` ns = `form` a = `editable` v = `true`
+                )->__( n = `content` ns = `form`
+                  )->_( n  = `Title`
+                        ns = `core`
+                        a  = `text`
+                        v  = `Make an input here and send it to the server...`
+                  )->_( n = `Label` a = `text`  v = `Name`
+                  )->_( n = `Input` a = `value` v = client->_bind_edit( name )
+                  )->_( n = `Button`
+                        p = VALUE #( ( n = `text`  v = `Send` )
+                                     ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `BUTTON_POST` ).

--- a/src/02/z2ui5_cl_app_hello_world.clas.abap
+++ b/src/02/z2ui5_cl_app_hello_world.clas.abap
@@ -14,28 +14,17 @@ CLASS z2ui5_cl_app_hello_world IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     IF client->check_on_init( ).
-      DATA(view) = z2ui5_cl_util_xml=>factory(
-        )->__( n  = `View`
-               ns = `mvc`
-               p  = VALUE #( ( n = `xmlns`        v = `sap.m` )
-                             ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
-                             ( n = `xmlns:core`   v = `sap.ui.core` )
-                             ( n = `xmlns:form`   v = `sap.ui.layout.form` )
-                             ( n = `displayBlock` v = `true` )
-                             ( n = `height`       v = `100%` ) )
-          )->__( `Shell`
-            )->__( n = `Page` a = `title` v = `abap2UI5 - Hello World`
-              )->__( n = `SimpleForm` ns = `form` a = `editable` v = `true`
-                )->__( n = `content` ns = `form`
-                  )->_( n  = `Title`
-                        ns = `core`
-                        a  = `text`
-                        v  = `Make an input here and send it to the server...`
-                  )->_( n = `Label` a = `text`  v = `Name`
-                  )->_( n = `Input` a = `value` v = client->_bind_edit( name )
-                  )->_( n = `Button`
-                        p = VALUE #( ( n = `text`  v = `Send` )
-                                     ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
+      DATA(view) = z2ui5_cl_xml_view=>factory(
+        )->shell(
+        )->page( `abap2UI5 - Hello World`
+          )->simple_form( editable = abap_true
+            )->content( `form`
+              )->title( ns   = `core`
+                        text = `Make an input here and send it to the server...`
+              )->label( `Name`
+              )->input( client->_bind_edit( name )
+              )->button( text  = `Send`
+                         press = client->_event( `BUTTON_POST` ) ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `BUTTON_POST` ).


### PR DESCRIPTION
## Summary
This PR corrects the implementation of conditional methods (`_if` and `__if`) in the XML utility class to properly handle method chaining and conditional logic.

## Key Changes
- **`_if` method**: Changed to always return `me` for proper method chaining, regardless of the condition. When `when = abap_true`, it calls `__()` to add a node; otherwise it skips the node addition.
- **`__if` method**: Swapped the logic to match the intended behavior - when `when = abap_true`, it calls `__()` and returns the result; when false, it returns `me` without adding a node.
- **Test cases**: Updated all test method calls to use the correct method names (`_if` vs `__if`) based on the intended conditional behavior.

## Implementation Details
The fix ensures that:
1. Both conditional methods maintain the fluent interface by always returning a reference to continue chaining
2. The `_if` method (single underscore) conditionally adds nodes using `__()` 
3. The `__if` method (double underscore) conditionally adds nodes using `__()` with proper return value handling
4. Test cases now correctly invoke the appropriate conditional method for their use case

https://claude.ai/code/session_01Fv46d84HhZDCDubBdBcm2g