### PR TITLE
fix: decouple Launchpad service init from Component lifecycle

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -20,7 +20,8 @@ sap.ui.define(
 
         z2ui5.oConfig.ComponentData = this.getComponentData();
 
-        this._initAsync();
+        this._initLaunchpad();
+        this._initVersionInfo();
 
         this._boundUnload = this._onUnload.bind(this);
         this._unloadEvent = /iPad|iPhone/.test(navigator.userAgent) ? 'pagehide' : 'beforeunload';
@@ -56,36 +57,33 @@ sap.ui.define(
         z2ui5.oRouter.stop();
       },
 
-      async _initAsync() {
-        const logLaunchpadError = (message, error) =>
+      _initLaunchpad() {
+        const logErr = (message, error) =>
           (z2ui5.errors ??= []).push({ message, error, ts: new Date().toISOString() });
-        try {
-          const Container = sap.ui.require('sap/ushell/Container');
-          if (Container) {
-            const launchpad = { Container };
-            try {
-              launchpad.ShellUIService = await this.getService('ShellUIService');
-            } catch (e) {
-              logLaunchpadError(`Component: ShellUIService init failed`, e);
-            }
-            try {
-              launchpad.CrossAppNavigator = await Container.getServiceAsync('CrossApplicationNavigation');
-            } catch (e) {
-              logLaunchpadError(`Component: CrossApplicationNavigation init failed`, e);
-            }
-            try {
-              launchpad.AppConfiguration = await new Promise((resolve, reject) =>
-                sap.ui.require(['sap/ushell/services/AppConfiguration'], resolve, reject),
-              );
-            } catch (e) {
-              logLaunchpadError(`Component: AppConfiguration init failed`, e);
-            }
-            if (!this.isDestroyed()) z2ui5.oLaunchpad = launchpad;
-          }
-        } catch (e) {
-          logLaunchpadError(`Component: Launchpad init failed`, e);
-        }
+        const Container = sap.ui.require('sap/ushell/Container');
+        if (!Container) return;
+        const launchpad = { Container };
+        z2ui5.oLaunchpad = launchpad;
+        Container.getServiceAsync('ShellUIService')
+          .then((s) => {
+            launchpad.ShellUIService = s;
+          })
+          .catch((e) => logErr(`Component: ShellUIService init failed`, e));
+        Container.getServiceAsync('CrossApplicationNavigation')
+          .then((s) => {
+            launchpad.CrossAppNavigator = s;
+          })
+          .catch((e) => logErr(`Component: CrossApplicationNavigation init failed`, e));
+        sap.ui.require(
+          ['sap/ushell/services/AppConfiguration'],
+          (ac) => {
+            launchpad.AppConfiguration = ac;
+          },
+          (e) => logErr(`Component: AppConfiguration init failed`, e),
+        );
+      },
 
+      async _initVersionInfo() {
         try {
           const { version, buildTimestamp, gav } = await VersionInfo.load();
           if (!this.isDestroyed()) z2ui5.oConfig.UI5VersionInfo = { version, buildTimestamp, gav };

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -40,7 +40,8 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `` && |\n| &&
              `        z2ui5.oConfig.ComponentData = this.getComponentData();` && |\n| &&
              `` && |\n| &&
-             `        this._initAsync();` && |\n| &&
+             `        this._initLaunchpad();` && |\n| &&
+             `        this._initVersionInfo();` && |\n| &&
              `` && |\n| &&
              `        this._boundUnload = this._onUnload.bind(this);` && |\n| &&
              `        this._unloadEvent = /iPad|iPhone/.test(navigator.userAgent) ? 'pagehide' : 'beforeunload';` && |\n| &&
@@ -76,36 +77,33 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        z2ui5.oRouter.stop();` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
-             `      async _initAsync() {` && |\n| &&
-             `        const logLaunchpadError = (message, error) =>` && |\n| &&
+             `      _initLaunchpad() {` && |\n| &&
+             `        const logErr = (message, error) =>` && |\n| &&
              `          (z2ui5.errors ??= []).push({ message, error, ts: new Date().toISOString() });` && |\n| &&
-             `        try {` && |\n| &&
-             `          const Container = sap.ui.require('sap/ushell/Container');` && |\n| &&
-             `          if (Container) {` && |\n| &&
-             `            const launchpad = { Container };` && |\n| &&
-             `            try {` && |\n| &&
-             `              launchpad.ShellUIService = await this.getService('ShellUIService');` && |\n| &&
-             `            } catch (e) {` && |\n| &&
-             `              logLaunchpadError(``Component: ShellUIService init failed``, e);` && |\n| &&
-             `            }` && |\n| &&
-             `            try {` && |\n| &&
-             `              launchpad.CrossAppNavigator = await Container.getServiceAsync('CrossApplicationNavigation');` && |\n| &&
-             `            } catch (e) {` && |\n| &&
-             `              logLaunchpadError(``Component: CrossApplicationNavigation init failed``, e);` && |\n| &&
-             `            }` && |\n| &&
-             `            try {` && |\n| &&
-             `              launchpad.AppConfiguration = await new Promise((resolve, reject) =>` && |\n| &&
-             `                sap.ui.require(['sap/ushell/services/AppConfiguration'], resolve, reject),` && |\n| &&
-             `              );` && |\n| &&
-             `            } catch (e) {` && |\n| &&
-             `              logLaunchpadError(``Component: AppConfiguration init failed``, e);` && |\n| &&
-             `            }` && |\n| &&
-             `            if (!this.isDestroyed()) z2ui5.oLaunchpad = launchpad;` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logLaunchpadError(``Component: Launchpad init failed``, e);` && |\n| &&
-             `        }` && |\n| &&
+             `        const Container = sap.ui.require('sap/ushell/Container');` && |\n| &&
+             `        if (!Container) return;` && |\n| &&
+             `        const launchpad = { Container };` && |\n| &&
+             `        z2ui5.oLaunchpad = launchpad;` && |\n| &&
+             `        Container.getServiceAsync('ShellUIService')` && |\n| &&
+             `          .then((s) => {` && |\n| &&
+             `            launchpad.ShellUIService = s;` && |\n| &&
+             `          })` && |\n| &&
+             `          .catch((e) => logErr(``Component: ShellUIService init failed``, e));` && |\n| &&
+             `        Container.getServiceAsync('CrossApplicationNavigation')` && |\n| &&
+             `          .then((s) => {` && |\n| &&
+             `            launchpad.CrossAppNavigator = s;` && |\n| &&
+             `          })` && |\n| &&
+             `          .catch((e) => logErr(``Component: CrossApplicationNavigation init failed``, e));` && |\n| &&
+             `        sap.ui.require(` && |\n| &&
+             `          ['sap/ushell/services/AppConfiguration'],` && |\n| &&
+             `          (ac) => {` && |\n| &&
+             `            launchpad.AppConfiguration = ac;` && |\n| &&
+             `          },` && |\n| &&
+             `          (e) => logErr(``Component: AppConfiguration init failed``, e),` && |\n| &&
+             `        );` && |\n| &&
+             `      },` && |\n| &&
              `` && |\n| &&
+             `      async _initVersionInfo() {` && |\n| &&
              `        try {` && |\n| &&
              `          const { version, buildTimestamp, gav } = await VersionInfo.load();` && |\n| &&
              `          if (!this.isDestroyed()) z2ui5.oConfig.UI5VersionInfo = { version, buildTimestamp, gav };` && |\n| &&


### PR DESCRIPTION
Splits _initAsync() into two methods:

- _initLaunchpad() — synchronous; sets z2ui5.oLaunchpad = { Container }
  immediately if running in the FLP, then resolves ShellUIService,
  CrossAppNavigator and AppConfiguration via fire-and-forget Promises
  that populate the same object as they become available. Consumer
  code already uses optional chaining, so a not-yet-resolved service
  is a no-op rather than an error.

- _initVersionInfo() — unchanged async load of UI5 VersionInfo.

This removes the await chain inside the component lifecycle that was
the most likely cause of the duplicate component id error on re-launch
from the FLP. The previous code called this.getService('ShellUIService')
which binds the FLP service to the component instance via a service
factory; that binding could survive component destroy and leak a
reference to the old component, so the next launch with the same id
would collide. We now only use the shell-global Container service via
Container.getServiceAsync(...), which has no such component binding.

Also reduces the FLP <-> app race window: init() now returns
synchronously after kicking off the background Promises, so the FLP
can destroy and re-create the component without waiting on us.

This is the underlying fix; the manifest flexEnabled=true revert
remains as a defense-in-depth so the bug does not depend on either
layer alone.