### PR TITLE
Remove startup parameters from config types

### DIFF
--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -75,9 +75,6 @@ sap.ui.define(
         if (!sFront.T_EVENT_ARG || sFront.T_EVENT_ARG.length === 0) {
           delete sFront.T_EVENT_ARG;
         }
-        if (sFront.T_STARTUP_PARAMETERS === undefined) {
-          delete sFront.T_STARTUP_PARAMETERS;
-        }
         if (sFront.SEARCH === "") delete sFront.SEARCH;
         if (!oBody.XX) delete oBody.XX;
 

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -189,10 +189,9 @@ INTERFACE z2ui5_if_core_types
 
   TYPES:
     BEGIN OF ty_s_config,
-      origin           TYPE string,
-      pathname         TYPE string,
-      search           TYPE string,
-      t_startup_params TYPE z2ui5_if_types=>ty_t_name_value,
+      origin   TYPE string,
+      pathname TYPE string,
+      search   TYPE string,
     END OF ty_s_config.
 
   TYPES:

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -95,9 +95,6 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        if (!sFront.T_EVENT_ARG || sFront.T_EVENT_ARG.length === 0) {` && |\n| &&
              `          delete sFront.T_EVENT_ARG;` && |\n| &&
              `        }` && |\n| &&
-             `        if (sFront.T_STARTUP_PARAMETERS === undefined) {` && |\n| &&
-             `          delete sFront.T_STARTUP_PARAMETERS;` && |\n| &&
-             `        }` && |\n| &&
              `        if (sFront.SEARCH === "") delete sFront.SEARCH;` && |\n| &&
              `        if (!oBody.XX) delete oBody.XX;` && |\n| &&
              `` && |\n| &&

--- a/src/02/z2ui5_if_types.intf.abap
+++ b/src/02/z2ui5_if_types.intf.abap
@@ -42,11 +42,10 @@ INTERFACE z2ui5_if_types
 
   TYPES:
     BEGIN OF ty_s_config,
-      origin           TYPE string,
-      pathname         TYPE string,
-      search           TYPE string,
-      hash             TYPE string,
-      t_startup_params TYPE ty_t_name_value,
+      origin   TYPE string,
+      pathname TYPE string,
+      search   TYPE string,
+      hash     TYPE string,
     END OF ty_s_config.
 
   TYPES:


### PR DESCRIPTION
## Summary
Removes the `t_startup_params` / `T_STARTUP_PARAMETERS` field from the config type definitions and related frontend handling code. This field was unused in the framework and has been deprecated.

## Changes
- **Type definitions:** Removed `t_startup_params` field from `ty_s_config` in both `z2ui5_if_types` and `z2ui5_if_core_types`
- **Frontend cleanup:** Removed the conditional deletion logic for `T_STARTUP_PARAMETERS` from `Server.js`
- **Backend cleanup:** Removed the corresponding embedded JavaScript code from `z2ui5_cl_app_server_js` that generated the deletion logic
- **Code formatting:** Aligned field declarations in type structures for improved readability

## Implementation Details
The removal is straightforward — the startup parameters field was not being populated or used by the framework. The frontend code that conditionally deleted undefined `T_STARTUP_PARAMETERS` is no longer needed. Both ABAP type interfaces and the embedded JavaScript frontend code have been synchronized to remove all references.

https://claude.ai/code/session_01R6fahM5T3NAgnsvNvi9zA9