### PR TITLE
Add event handlers for expand, wizard, and audio playback

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -617,6 +617,15 @@ sap.ui.define(
           case "Z2UI5":
             this._evZ2ui5Custom(args);
             break;
+          case "EXPAND_TO_LEVEL":
+            this._evExpandToLevel(args);
+            break;
+          case "WIZARD_SET_NEXT_STEP":
+            this._evWizardSetNextStep(args);
+            break;
+          case "PLAY_AUDIO":
+            this._evPlayAudio(args);
+            break;
         }
       },
 
@@ -916,6 +925,35 @@ sap.ui.define(
           if (fn) fn(args.slice(2));
         } catch (e) {
           logError(`Z2UI5: '${args[1]}' failed`, e);
+        }
+      },
+
+      _evExpandToLevel(args) {
+        try {
+          const ctrl = z2ui5.oView && z2ui5.oView.byId(args[1]);
+          if (ctrl && ctrl.expandToLevel) ctrl.expandToLevel(+args[2]);
+        } catch (e) {
+          logError(`EXPAND_TO_LEVEL: failed for '${args[1]}'`, e);
+        }
+      },
+
+      _evWizardSetNextStep(args) {
+        try {
+          const wiz = z2ui5.oView && z2ui5.oView.byId(args[1]);
+          const step = z2ui5.oView && z2ui5.oView.byId(args[2]);
+          const nextStep = z2ui5.oView && z2ui5.oView.byId(args[3]);
+          if (wiz && step) wiz.discardProgress(step);
+          if (step && nextStep) step.setNextStep(nextStep);
+        } catch (e) {
+          logError(`WIZARD_SET_NEXT_STEP: failed for wizard '${args[1]}'`, e);
+        }
+      },
+
+      _evPlayAudio(args) {
+        try {
+          new Audio(args[1]).play();
+        } catch (e) {
+          logError(`PLAY_AUDIO: failed for '${args[1]}'`, e);
         }
       },
 

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -30,6 +30,10 @@ INTERFACE z2ui5_if_client
       start_timer               TYPE string VALUE `START_TIMER`,
       keyboard_keep_open        TYPE string VALUE `KEYBOARD_KEEP_OPEN`,
       keyboard_set_mode         TYPE string VALUE `KEYBOARD_SET_MODE`,
+      z2ui5                TYPE string VALUE `Z2UI5`,
+      expand_to_level      TYPE string VALUE `EXPAND_TO_LEVEL`,
+      wizard_set_next_step TYPE string VALUE `WIZARD_SET_NEXT_STEP`,
+      play_audio           TYPE string VALUE `PLAY_AUDIO`,
     END OF cs_event.
 
   CONSTANTS:


### PR DESCRIPTION
## Summary
Adds three new client-side event handlers to support tree expansion, wizard navigation, and audio playback functionality in UI5 applications.

## Changes
- **New event handlers in `View1.controller.js`:**
  - `_evExpandToLevel()` — Expands tree/table controls to a specified level via the `expandToLevel()` method
  - `_evWizardSetNextStep()` — Manages wizard step progression by discarding progress and setting the next step
  - `_evPlayAudio()` — Plays audio files from a given URL using the Web Audio API

- **New event constants in `z2ui5_if_client.intf.abap`:**
  - `EXPAND_TO_LEVEL`
  - `WIZARD_SET_NEXT_STEP`
  - `PLAY_AUDIO`
  - Also added missing `Z2UI5` constant

## Implementation Details
- All three handlers follow the existing error handling pattern with try-catch and `logError()` calls
- Event routing integrated into the main switch statement in `_eventHandler()`
- Handlers retrieve UI5 controls via `z2ui5.oView.byId()` and invoke appropriate methods with arguments passed from the backend
- Audio handler uses native `Audio` API for simplicity and broad browser compatibility

https://claude.ai/code/session_01644zuAPuFkd1GHsFU5P9xM