### PR TITLE
Fix timer event argument indices in View1 controller

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -820,8 +820,8 @@ sap.ui.define(
       },
 
       _evStartTimer(args) {
-        const eventName = args[1];
-        const delay = +args[2] || 0;
+        const eventName = args[0];
+        const delay = +args[3] || 0;
         if (!z2ui5.timers) z2ui5.timers = {};
         clearTimeout(z2ui5.timers[eventName]);
         z2ui5.timers[eventName] = setTimeout(() => {


### PR DESCRIPTION
## Summary
Corrects incorrect array index references when extracting timer event arguments in the `_evStartTimer` method of the View1 controller.

## Changes
- **Line 823:** Changed `eventName` extraction from `args[1]` to `args[0]` — the event name is the first argument, not the second
- **Line 824:** Changed `delay` extraction from `args[2]` to `args[3]` — the delay value is the fourth argument, not the third

## Details
The timer event handler was reading arguments from the wrong indices in the `args` array, causing the event name and delay values to be mismatched. This fix aligns the indices with the actual argument positions passed to the timer event handler.

https://claude.ai/code/session_011Srn6euDjFWxdAxXb2BNmo