### PR TITLE
Remove unused event handlers and Rendering dependency

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -617,9 +617,6 @@ sap.ui.define(
           case "Z2UI5":
             this._evZ2ui5Custom(args);
             break;
-          case "EXPAND_TO_LEVEL":
-            this._evExpandToLevel(args);
-            break;
           case "WIZARD_SET_NEXT_STEP":
             this._evWizardSetNextStep(args);
             break;
@@ -926,15 +923,6 @@ sap.ui.define(
           if (fn) fn(args.slice(2));
         } catch (e) {
           logError(`Z2UI5: '${args[1]}' failed`, e);
-        }
-      },
-
-      _evExpandToLevel(args) {
-        try {
-          const ctrl = z2ui5.oView && z2ui5.oView.byId(args[1]);
-          if (ctrl && ctrl.expandToLevel) ctrl.expandToLevel(+args[2]);
-        } catch (e) {
-          logError(`EXPAND_TO_LEVEL: failed for '${args[1]}'`, e);
         }
       },
 

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -600,9 +600,6 @@ sap.ui.define(
           case "SET_FOCUS":
             this._evSetFocus(args);
             break;
-          case "SET_FOCUS_CELL":
-            this._evSetCellFocus(args);
-            break;
           case "START_TIMER":
             this._evStartTimer(args);
             break;
@@ -852,25 +849,6 @@ sap.ui.define(
           oElement.applyFocusInfo(info);
         } catch (e) {
           logError(`SET_FOCUS: failed for '${args[1]}'`, e);
-        }
-      },
-
-      _evSetCellFocus(args) {
-        try {
-          // args[1] = column view-relative ID, args[2] = row index (0-based)
-          const oColumn = z2ui5.oView && z2ui5.oView.byId(args[1]);
-          if (!oColumn) return;
-          const oTable = oColumn.getParent();
-          if (!oTable) return;
-          const colIdx = oTable.indexOfColumn(oColumn);
-          const rows = oTable.getItems ? oTable.getItems() : oTable.getRows();
-          const oRow = rows[+args[2]];
-          if (!oRow) return;
-          const oCell = oRow.getCells()[colIdx];
-          if (!oCell) return;
-          oCell.applyFocusInfo(oCell.getFocusInfo());
-        } catch (e) {
-          logError(`SET_FOCUS_CELL: failed for column '${args[1]}'`, e);
         }
       },
 

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -15,7 +15,6 @@ sap.ui.define(
     "sap/ui/core/routing/HashChanger",
     "sap/ui/util/Storage",
     "sap/ui/core/Element",
-    "sap/ui/core/Rendering",
   ],
   (
     Controller,
@@ -33,7 +32,6 @@ sap.ui.define(
     HashChanger,
     Storage,
     Element,
-    Rendering,
   ) => {
     "use strict";
 
@@ -605,9 +603,6 @@ sap.ui.define(
           case "SET_FOCUS_CELL":
             this._evSetCellFocus(args);
             break;
-          case "KEYBOARD_KEEP_OPEN":
-            this._evFocusActiveInput();
-            break;
           case "START_TIMER":
             this._evStartTimer(args);
             break;
@@ -877,25 +872,6 @@ sap.ui.define(
         } catch (e) {
           logError(`SET_FOCUS_CELL: failed for column '${args[1]}'`, e);
         }
-      },
-
-      _evFocusActiveInput() {
-        const onAfterRendering = () => {
-          Rendering.detachAfterRendering(onAfterRendering);
-          try {
-            const el = document.activeElement;
-            if (!el) return;
-            const input = el.matches("input, textarea")
-              ? el
-              : el.querySelector("input, textarea");
-            if (!input) return;
-            input.focus();
-            input.select();
-          } catch (e) {
-            logError("FOCUS_ACTIVE_INPUT: failed", e);
-          }
-        };
-        Rendering.attachAfterRendering(onAfterRendering);
       },
 
       _evSetTitle(args) {

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -26,7 +26,6 @@ INTERFACE z2ui5_if_client
       system_logout             TYPE string VALUE `SYSTEM_LOGOUT`,
       set_title                 TYPE string VALUE `SET_TITLE`,
       set_focus                 TYPE string VALUE `SET_FOCUS`,
-      set_focus_cell            TYPE string VALUE `SET_FOCUS_CELL`,
       start_timer               TYPE string VALUE `START_TIMER`,
       keyboard_set_mode         TYPE string VALUE `KEYBOARD_SET_MODE`,
       z2ui5                TYPE string VALUE `Z2UI5`,

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -28,7 +28,6 @@ INTERFACE z2ui5_if_client
       set_focus                 TYPE string VALUE `SET_FOCUS`,
       set_focus_cell            TYPE string VALUE `SET_FOCUS_CELL`,
       start_timer               TYPE string VALUE `START_TIMER`,
-      keyboard_keep_open        TYPE string VALUE `KEYBOARD_KEEP_OPEN`,
       keyboard_set_mode         TYPE string VALUE `KEYBOARD_SET_MODE`,
       z2ui5                TYPE string VALUE `Z2UI5`,
       wizard_set_next_step TYPE string VALUE `WIZARD_SET_NEXT_STEP`,

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -31,7 +31,6 @@ INTERFACE z2ui5_if_client
       keyboard_keep_open        TYPE string VALUE `KEYBOARD_KEEP_OPEN`,
       keyboard_set_mode         TYPE string VALUE `KEYBOARD_SET_MODE`,
       z2ui5                TYPE string VALUE `Z2UI5`,
-      expand_to_level      TYPE string VALUE `EXPAND_TO_LEVEL`,
       wizard_set_next_step TYPE string VALUE `WIZARD_SET_NEXT_STEP`,
       play_audio           TYPE string VALUE `PLAY_AUDIO`,
     END OF cs_event.


### PR DESCRIPTION
## Summary
This PR removes three unused event handlers and their associated infrastructure from the View1 controller and the client interface. These handlers were not being utilized and their removal simplifies the codebase.

## Key Changes

**Frontend (View1.controller.js):**
- Removed `sap/ui/core/Rendering` module dependency and its parameter binding
- Removed `SET_FOCUS_CELL` event handler (`_evSetCellFocus`) — focused individual table cells
- Removed `KEYBOARD_KEEP_OPEN` event handler (`_evFocusActiveInput`) — re-focused active input after rendering
- Removed `EXPAND_TO_LEVEL` event handler (`_evExpandToLevel`) — expanded tree controls to a specific level
- Removed corresponding case statements from the main event switch block

**Backend (z2ui5_if_client.intf.abap):**
- Removed `set_focus_cell` constant from the event type structure
- Removed `keyboard_keep_open` constant from the event type structure
- Removed `expand_to_level` constant from the event type structure

## Implementation Details
The removed handlers were defensive implementations with error logging, but no ABAP-side code was invoking these events. Removing them eliminates dead code and reduces the maintenance surface of the framework without affecting any active functionality.

https://claude.ai/code/session_01RJwNZ23z9vqWrD6Uu6q5iS