### PR TITLE
feat: add client->action method for queued frontend events

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -43,6 +43,14 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD z2ui5_if_client~action.
+
+    INSERT mo_srv_event->get_event_client( val   = val
+                                           t_arg = t_arg )
+           INTO TABLE mo_action->ms_next-s_set-s_follow_up_action-custom_js.
+
+  ENDMETHOD.
+
   METHOD z2ui5_if_client~check_on_event.
 
     IF val IS NOT INITIAL.

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -45,6 +45,15 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~action.
 
+    DATA lv_val TYPE string.
+    lv_val = val.
+
+    IF lv_val IS INITIAL OR lv_val CN `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_`.
+      RAISE EXCEPTION TYPE z2ui5_cx_util_error
+        EXPORTING
+          val = |action: invalid event name '{ val }' - only A-Z, a-z, 0-9 and _ allowed|.
+    ENDIF.
+
     INSERT mo_srv_event->get_event_client( val   = val
                                            t_arg = t_arg )
            INTO TABLE mo_action->ms_next-s_set-s_follow_up_action-custom_js.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -37,6 +37,7 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_message_box_type     FOR TESTING RAISING cx_static_check.
     METHODS test_message_toast        FOR TESTING RAISING cx_static_check.
     METHODS test_follow_up_action     FOR TESTING RAISING cx_static_check.
+    METHODS test_action               FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init        FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init_done   FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_event       FOR TESTING RAISING cx_static_check.
@@ -332,6 +333,24 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = 1
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
+
+  ENDMETHOD.
+
+  METHOD test_action.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    li_client ?= mo_client.
+
+    li_client->action( val   = z2ui5_if_client=>cs_event-set_title
+                       t_arg = VALUE #( ( `My Title` ) ) ).
+    li_client->action( z2ui5_if_client=>cs_event-history_back ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 2
+                                        act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `.eF('SET_TITLE', 'My Title')`
+                                        act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
+    cl_abap_unit_assert=>assert_equals( exp = `.eF('HISTORY_BACK')`
+                                        act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -38,6 +38,8 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_message_toast        FOR TESTING RAISING cx_static_check.
     METHODS test_follow_up_action     FOR TESTING RAISING cx_static_check.
     METHODS test_action               FOR TESTING RAISING cx_static_check.
+    METHODS test_action_reject_js     FOR TESTING RAISING cx_static_check.
+    METHODS test_action_reject_empty  FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init        FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init_done   FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_event       FOR TESTING RAISING cx_static_check.
@@ -351,6 +353,42 @@ CLASS ltcl_test_client IMPLEMENTATION.
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
     cl_abap_unit_assert=>assert_equals( exp = `.eF('HISTORY_BACK')`
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
+
+  ENDMETHOD.
+
+  METHOD test_action_reject_js.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lv_raised TYPE abap_bool.
+    li_client ?= mo_client.
+
+    TRY.
+        li_client->action( `EVT'); alert(1);//` ).
+      CATCH z2ui5_cx_util_error.
+        lv_raised = abap_true.
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lv_raised ).
+    cl_abap_unit_assert=>assert_equals( exp = 0
+                                        act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
+
+  ENDMETHOD.
+
+  METHOD test_action_reject_empty.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lv_raised TYPE abap_bool.
+    li_client ?= mo_client.
+
+    TRY.
+        li_client->action( `` ).
+      CATCH z2ui5_cx_util_error.
+        lv_raised = abap_true.
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lv_raised ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -217,6 +217,11 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val TYPE string.
 
+  METHODS action
+    IMPORTING
+      val   TYPE clike
+      t_arg TYPE string_table OPTIONAL.
+
   METHODS check_on_event
     IMPORTING
       val           TYPE clike OPTIONAL


### PR DESCRIPTION
## Summary

Adds a new method `action( val, t_arg )` to `z2ui5_if_client` as a slimmer alternative to the existing `follow_up_action( _event_client( … ) )` combo.

- The method queues a frontend event call (`.eF(...)`) into the existing `s_follow_up_action-custom_js` table, so it is auto-executed on the client right after the view/model is updated.
- API is constrained to event names only — no arbitrary JS. Multiple calls accumulate and are dispatched on the frontend in insertion order.
- Defensive validation rejects any `val` outside `[A-Za-z0-9_]` (raises `z2ui5_cx_util_error`), so quotes, semicolons, parentheses etc. can never end up in the queued JS payload.
- Purely additive — no existing public API is touched.

### Before / after

```abap
" before
client->follow_up_action(
    client->_event_client(
        val   = z2ui5_if_client=>cs_event-set_title
        t_arg = VALUE #( ( title ) ) ) ).

" after
client->action(
    val   = z2ui5_if_client=>cs_event-set_title
    t_arg = VALUE #( ( title ) ) ).
```

A matching refactor PR for [`abap2UI5/samples`](https://github.com/abap2UI5/samples) converts 23 call sites in 19 demo apps (-18 LOC net).

## Test plan

- [x] `npx abaplint` — 0 issues
- [x] New unit tests: `test_action` (queue length + exact JS string for two consecutive calls), `test_action_reject_js` (rejects `EVT'); alert(1);//`), `test_action_reject_empty` (rejects empty event name)
- [ ] Merge framework PR first, then merge samples PR (samples will lint clean once this is on `main`)

https://claude.ai/code/session_01GaCj1cQU8kZRRmkL7qno6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaCj1cQU8kZRRmkL7qno6A)_