### PR TITLE
Fix scroll info retrieval and improve timer cleanup in roundtrips

### DIFF
--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -105,49 +105,79 @@ sap.ui.define(
       },
 
       _getScrollInfo() {
-        // For each visible view, find the first scrollable descendant
-        // (typically a sap.m.Page) and return its current scroll offsets.
-        // X = scrollLeft (horizontal), Y = scrollTop (vertical).
-        // Only views that exist and have a scrollable target are included;
-        // empty slots are omitted to keep the request payload small.
+        // For each visible view, find the scrollable descendant that is
+        // actually scrolled (typically a sap.m.Page) and return its current
+        // scroll offsets. X = scrollLeft, Y = scrollTop.
+        //
+        // Multiple controls in the tree expose getScrollDelegate (App,
+        // NavContainer, Page, ScrollContainer, ...). findAggregatedObjects
+        // returns them in pre-order, so the outer App/NavContainer comes
+        // first - but its delegate never scrolls visible content. We pick
+        // the first candidate whose container is actually scrolled, with
+        // the deepest overflowing container as a fallback.
+        //
+        // Reading the position directly from the container's DOM avoids
+        // relying on the delegate's cached _scrollY/_scrollX which can lag
+        // until a scroll event fires.
+        const containerOf = (control) => {
+          try {
+            const d = control.getScrollDelegate();
+            if (d && d.getContainerDomRef) {
+              const dom = d.getContainerDomRef();
+              if (dom) return dom;
+            }
+          } catch (e) {
+            // ignored
+          }
+          // Fallback to known ID suffixes for common controls.
+          const id = control.getId();
+          return (
+            document.getElementById(`${id}-cont`) || // sap.m.Page
+            document.getElementById(`${id}-scroll`) || // sap.m.ScrollContainer
+            null
+          );
+        };
         const getOne = (view) => {
           if (!view || !view.findAggregatedObjects) return null;
-          let target = null;
+          let candidates;
           try {
-            const candidates = view.findAggregatedObjects(true, (c) => {
+            candidates = view.findAggregatedObjects(true, (c) => {
               try {
                 return c.getScrollDelegate && c.getScrollDelegate();
               } catch (e) {
                 return false;
               }
             });
-            target = candidates && candidates[0];
           } catch (e) {
             return null;
           }
-          if (!target) return null;
-          let x = 0;
-          let y = 0;
-          try {
-            const d = target.getScrollDelegate();
-            if (d) {
-              if (d.getScrollTop) y = d.getScrollTop() || 0;
-              if (d.getScrollLeft) x = d.getScrollLeft() || 0;
+          if (!candidates || !candidates.length) return null;
+
+          let chosen = null;
+          let fallback = null;
+          for (const c of candidates) {
+            const dom = containerOf(c);
+            if (!dom) continue;
+            const x = dom.scrollLeft || 0;
+            const y = dom.scrollTop || 0;
+            if (x || y) {
+              chosen = { control: c, x, y };
+              break;
             }
-          } catch (e) {
-            // ignored - fall through to DOM lookup
-          }
-          if (!x || !y) {
-            const el = document.getElementById(`${target.getId()}-inner`);
-            if (el) {
-              if (!y) y = el.scrollTop || 0;
-              if (!x) x = el.scrollLeft || 0;
+            // Prefer the deepest container that actually overflows.
+            const overflows =
+              dom.scrollHeight > dom.clientHeight ||
+              dom.scrollWidth > dom.clientWidth;
+            if (overflows || !fallback) {
+              fallback = { control: c, x, y };
             }
           }
-          let id = target.getId();
+          const pick = chosen || fallback;
+          if (!pick) return null;
+          let id = pick.control.getId();
           const prefix = view.getId() + "--";
           if (id.startsWith(prefix)) id = id.slice(prefix.length);
-          return { ID: id, X: x, Y: y };
+          return { ID: id, X: pick.x, Y: pick.y };
         };
         const out = {};
         const slots = [

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -1028,6 +1028,16 @@ sap.ui.define(
           return;
         }
 
+        // A new roundtrip overrides any pending timer - timers that fired
+        // already removed themselves before calling eB, so this only cancels
+        // timers that are still waiting.
+        if (z2ui5.timers) {
+          for (const key in z2ui5.timers) {
+            clearTimeout(z2ui5.timers[key]);
+            delete z2ui5.timers[key];
+          }
+        }
+
         z2ui5.isBusy = true;
         BusyIndicator.show();
         z2ui5.oBody = { VIEWNAME: "MAIN" };

--- a/src/01/03/z2ui5_cl_app_app_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_js.clas.abap
@@ -18,1775 +18,1775 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `// Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `function _logError(message, error) {` && |\n| &&
-             `  if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `  const entry = { message: message, ts: new Date().toISOString() };` && |\n| &&
-             `  if (error !== undefined) entry.error = error;` && |\n| &&
-             `  z2ui5.errors.push(entry);` && |\n| &&
-             `}` && |\n| &&
-             `` && |\n| &&
-             `// Helpers for managing z2ui5 callback arrays (onBeforeRoundtrip,` && |\n| &&
-             `// onAfterRendering, ...). Several custom controls register hooks here in` && |\n| &&
-             `// init() and remove them in exit().` && |\n| &&
-             `function _registerCallback(name, fn) {` && |\n| &&
-             `  if (!z2ui5[name]) z2ui5[name] = [];` && |\n| &&
-             `  z2ui5[name].push(fn);` && |\n| &&
-             `}` && |\n| &&
-             `function _unregisterCallback(name, fn) {` && |\n| &&
-             `  if (!z2ui5[name]) return;` && |\n| &&
-             `  z2ui5[name] = z2ui5[name].filter((f) => f !== fn);` && |\n| &&
-             `}` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/mvc/Controller",` && |\n| &&
-             `    "z2ui5/controller/View1.controller",` && |\n| &&
-             `    "z2ui5/cc/Server",` && |\n| &&
-             `    "sap/ui/core/routing/HashChanger",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (BaseController, Controller, Server, HashChanger) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `    return BaseController.extend("z2ui5.controller.App", {` && |\n| &&
-             `      onInit() {` && |\n| &&
-             `        const oOwnerComponent = this.getOwnerComponent();` && |\n| &&
-             `        z2ui5.oOwnerComponent = oOwnerComponent;` && |\n| &&
-             `` && |\n| &&
-             `        // Read the backend URI from the manifest, falling back step by step` && |\n| &&
-             `        // so a missing entry doesn't blow up.` && |\n| &&
-             `        const manifest = oOwnerComponent.getManifest();` && |\n| &&
-             `        const sapApp = manifest && manifest["sap.app"];` && |\n| &&
-             `        const dataSources = sapApp && sapApp.dataSources;` && |\n| &&
-             `        const http = dataSources && dataSources.http;` && |\n| &&
-             `        const uri = http && http.uri;` && |\n| &&
-             `        z2ui5.url = z2ui5.checkLocal ? window.location.href : uri;` && |\n| &&
-             `` && |\n| &&
-             `        // Set up the shared z2ui5 state used by the whole app.` && |\n| &&
-             `        z2ui5.oController = new Controller();` && |\n| &&
-             `        z2ui5.oApp = this.getView().byId("app");` && |\n| &&
-             `        z2ui5.oControllerNest = new Controller();` && |\n| &&
-             `        z2ui5.oControllerNest2 = new Controller();` && |\n| &&
-             `        z2ui5.oControllerPopup = new Controller();` && |\n| &&
-             `        z2ui5.oControllerPopover = new Controller();` && |\n| &&
-             `        z2ui5.onBeforeRoundtrip = [];` && |\n| &&
-             `        z2ui5.onAfterRendering = [];` && |\n| &&
-             `        z2ui5.onBeforeEventFrontend = [];` && |\n| &&
-             `        z2ui5.onAfterRoundtrip = [];` && |\n| &&
-             `        z2ui5.errors = [];` && |\n| &&
-             `        z2ui5.checkNestAfter = false;` && |\n| &&
-             `        z2ui5.checkNestAfter2 = false;` && |\n| &&
-             `` && |\n| &&
-             `        // If the URL already contains a hash, kick off the initial roundtrip` && |\n| &&
-             `        // so the backend can restore that state.` && |\n| &&
-             `        if (HashChanger.getInstance().getHash()) {` && |\n| &&
-             `          z2ui5.checkInit = true;` && |\n| &&
-             `          Server.Roundtrip();` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Timer", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.Timer", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        delayMS: {` && |\n| &&
-             `          type: "int",` && |\n| &&
-             `          defaultValue: 0,` && |\n| &&
-             `        },` && |\n| &&
-             `        checkActive: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: true,` && |\n| &&
-             `        },` && |\n| &&
-             `        checkRepeat: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: false,` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `      events: {` && |\n| &&
-             `        finished: {` && |\n| &&
-             `          allowPreventDefault: true,` && |\n| &&
-             `          parameters: {},` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    onAfterRendering() {` && |\n| &&
-             `      if (!this._pendingTimer) return;` && |\n| &&
-             `      this._pendingTimer = false;` && |\n| &&
-             `      this.delayedCall();` && |\n| &&
-             `    },` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      clearTimeout(this._timerId);` && |\n| &&
-             `    },` && |\n| &&
-             `    delayedCall() {` && |\n| &&
-             `      if (!this.getProperty("checkActive")) return;` && |\n| &&
-             `      clearTimeout(this._timerId);` && |\n| &&
-             `      const repeat = this.getProperty("checkRepeat");` && |\n| &&
-             `      const delay = this.getProperty("delayMS");` && |\n| &&
-             `      this._timerId = setTimeout(() => {` && |\n| &&
-             `        // The control might have been destroyed during the delay.` && |\n| &&
-             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `        if (!repeat) this.setProperty("checkActive", false, true);` && |\n| &&
-             `        this.fireFinished();` && |\n| &&
-             `        // For repeating timers, queue the next iteration. Re-check destroy` && |\n| &&
-             `        // again because fireFinished may have triggered teardown.` && |\n| &&
-             `        if (repeat && !(this.isDestroyed && this.isDestroyed())) {` && |\n| &&
-             `          this.delayedCall();` && |\n| &&
-             `        }` && |\n| &&
-             `      }, delay);` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(oRm, oControl) {` && |\n| &&
-             `        oRm.openStart("span", oControl);` && |\n| &&
-             `        oRm.style("display", "none");` && |\n| &&
-             `        oRm.openEnd();` && |\n| &&
-             `        oRm.close("span");` && |\n| &&
-             `        oControl._pendingTimer = oControl.getProperty("checkActive");` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Focus", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.Focus", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        setUpdate: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: true,` && |\n| &&
-             `        },` && |\n| &&
-             `        focusId: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        selectionStart: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "0",` && |\n| &&
-             `        },` && |\n| &&
-             `        selectionEnd: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "0",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setFocusId(val) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        this.setProperty("focusId", val);` && |\n| &&
-             `        const oElement = z2ui5.oView && z2ui5.oView.byId(val);` && |\n| &&
-             `        if (oElement) oElement.applyFocusInfo(oElement.getFocusInfo());` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Focus.setFocusId failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `    onAfterRendering() {` && |\n| &&
-             `      if (!this._pendingFocus) return;` && |\n| &&
-             `      this._pendingFocus = false;` && |\n| &&
-             `      const oElement =` && |\n| &&
-             `        z2ui5.oView && z2ui5.oView.byId(this.getProperty("focusId"));` && |\n| &&
-             `      if (!oElement) return;` && |\n| &&
-             `      try {` && |\n| &&
-             `        // Merge the additional selection info into the existing focus info,` && |\n| &&
-             `        // then apply both at once.` && |\n| &&
-             `        const info = oElement.getFocusInfo();` && |\n| &&
-             `        info.selectionStart = +this.getProperty("selectionStart");` && |\n| &&
-             `        info.selectionEnd = +this.getProperty("selectionEnd");` && |\n| &&
-             `        oElement.applyFocusInfo(info);` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Focus.onAfterRendering: applyFocusInfo failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(oRm, oControl) {` && |\n| &&
-             `        oRm.openStart("span", oControl);` && |\n| &&
-             `        oRm.style("display", "none");` && |\n| &&
-             `        oRm.openEnd();` && |\n| &&
-             `        oRm.close("span");` && |\n| &&
-             `        if (!oControl.getProperty("setUpdate")) return;` && |\n| &&
-             `        oControl.setProperty("setUpdate", false, true);` && |\n| &&
-             `        oControl._pendingFocus = true;` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Title", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.Title", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        title: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setTitle(val) {` && |\n| &&
-             `      this.setProperty("title", val);` && |\n| &&
-             `      document.title = val == null ? "" : String(val);` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/LPTitle", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.LPTitle", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        title: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        ApplicationFullWidth: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setTitle(val) {` && |\n| &&
-             `      this.setProperty("title", val);` && |\n| &&
-             `      try {` && |\n| &&
-             `        const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;` && |\n| &&
-             `        if (!shell || !shell.setTitle) return;` && |\n| &&
-             `        const result = shell.setTitle(val);` && |\n| &&
-             `        // setTitle may return a Promise; report any async failure.` && |\n| &&
-             `        if (result && result.catch) {` && |\n| &&
-             `          result.catch((e) =>` && |\n| &&
-             `            _logError("LPTitle: Launchpad Service setTitle failed", e),` && |\n| &&
-             `          );` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("LPTitle: Launchpad Service setTitle failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    setApplicationFullWidth(val) {` && |\n| &&
-             `      this.setProperty("ApplicationFullWidth", val);` && |\n| &&
-             `      try {` && |\n| &&
-             `        const config = z2ui5.oLaunchpad && z2ui5.oLaunchpad.AppConfiguration;` && |\n| &&
-             `        if (config && config.setApplicationFullWidth) {` && |\n| &&
-             `          config.setApplicationFullWidth(val);` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("LPTitle: setApplicationFullWidth failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/History", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.History", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        search: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setSearch(val) {` && |\n| &&
-             `      this.setProperty("search", val);` && |\n| &&
-             `      try {` && |\n| &&
-             `        const search = val == null ? "" : val;` && |\n| &&
-             `        history.replaceState(null, "", ``${window.location.pathname}${search}``);` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("History.setSearch: replaceState failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Tree", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.Tree", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        tree_id: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _getTreeBinding() {` && |\n| &&
-             `      if (!z2ui5.oView) return undefined;` && |\n| &&
-             `      const treeControl = z2ui5.oView.byId(this.getProperty("tree_id"));` && |\n| &&
-             `      if (!treeControl) return undefined;` && |\n| &&
-             `      return treeControl.getBinding("items");` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    setBackend() {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const binding = this._getTreeBinding();` && |\n| &&
-             `        z2ui5.treeState = binding ? binding.getCurrentTreeState() : undefined;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Tree.setBackend: failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    init() {` && |\n| &&
-             `      this._setBackendBound = this.setBackend.bind(this);` && |\n| &&
-             `      _registerCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      _unregisterCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    onAfterRendering() {` && |\n| &&
-             `      if (!this._pendingTreeState) return;` && |\n| &&
-             `      this._pendingTreeState = false;` && |\n| &&
-             `      try {` && |\n| &&
-             `        const binding = this._getTreeBinding();` && |\n| &&
-             `        if (binding) binding.setTreeState(z2ui5.treeState);` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Tree.onAfterRendering: setTreeState failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(oRm, oControl) {` && |\n| &&
-             `        oRm.openStart("span", oControl);` && |\n| &&
-             `        oRm.style("display", "none");` && |\n| &&
-             `        oRm.openEnd();` && |\n| &&
-             `        oRm.close("span");` && |\n| &&
-             `        if (!z2ui5.treeState) return;` && |\n| &&
-             `        oControl._pendingTreeState = true;` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Scrolling", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.Scrolling", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        setUpdate: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: true,` && |\n| &&
-             `        },` && |\n| &&
-             `        items: {` && |\n| &&
-             `          type: "object",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _getDomInnerElement(id) {` && |\n| &&
-             `      const control = z2ui5.oView && z2ui5.oView.byId(id);` && |\n| &&
-             `      if (!control) return null;` && |\n| &&
-             `      return document.getElementById(``${control.getId()}-inner``);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _getScrollTop(item) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n| &&
-             `        // Some controls expose a scroll delegate; prefer it when available.` && |\n| &&
-             `        if (control && control.getScrollDelegate) {` && |\n| &&
-             `          const delegate = control.getScrollDelegate();` && |\n| &&
-             `          if (delegate) return delegate.getScrollTop();` && |\n| &&
-             `        }` && |\n| &&
-             `        const element = this._getDomInnerElement(item.ID);` && |\n| &&
-             `        return element ? element.scrollTop : 0;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Scrolling._getScrollTop: failed", e);` && |\n| &&
-             `        return 0;` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    setBackend() {` && |\n| &&
-             `      const items = this.getProperty("items");` && |\n| &&
-             `      if (!items) return;` && |\n| &&
-             `      try {` && |\n| &&
-             `        // Resolve the binding path so we can mark only changed entries` && |\n| &&
-             `        // as dirty in xxChangedPaths.` && |\n| &&
-             `        const bindingInfo = this.getBindingInfo("items");` && |\n| &&
-             `        let bindingPath;` && |\n| &&
-             `        if (bindingInfo) {` && |\n| &&
-             `          const parts = bindingInfo.parts;` && |\n| &&
-             `          if (parts && parts[0]) bindingPath = parts[0].path;` && |\n| &&
-             `          if (!bindingPath) bindingPath = bindingInfo.path;` && |\n| &&
-             `        }` && |\n| &&
-             `        for (const [index, item] of items.entries()) {` && |\n| &&
-             `          const scrollTop = this._getScrollTop(item);` && |\n| &&
-             `          if (item.V !== scrollTop) {` && |\n| &&
-             `            item.V = scrollTop;` && |\n| &&
+    result =              `// Append an entry to the global error log. We create the array on first use.` && |\n|  &&
+             `function _logError(message, error) {` && |\n|  &&
+             `  if (!z2ui5.errors) z2ui5.errors = [];` && |\n|  &&
+             `  const entry = { message: message, ts: new Date().toISOString() };` && |\n|  &&
+             `  if (error !== undefined) entry.error = error;` && |\n|  &&
+             `  z2ui5.errors.push(entry);` && |\n|  &&
+             `}` && |\n|  &&
+             `` && |\n|  &&
+             `// Helpers for managing z2ui5 callback arrays (onBeforeRoundtrip,` && |\n|  &&
+             `// onAfterRendering, ...). Several custom controls register hooks here in` && |\n|  &&
+             `// init() and remove them in exit().` && |\n|  &&
+             `function _registerCallback(name, fn) {` && |\n|  &&
+             `  if (!z2ui5[name]) z2ui5[name] = [];` && |\n|  &&
+             `  z2ui5[name].push(fn);` && |\n|  &&
+             `}` && |\n|  &&
+             `function _unregisterCallback(name, fn) {` && |\n|  &&
+             `  if (!z2ui5[name]) return;` && |\n|  &&
+             `  z2ui5[name] = z2ui5[name].filter((f) => f !== fn);` && |\n|  &&
+             `}` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  [` && |\n|  &&
+             `    "sap/ui/core/mvc/Controller",` && |\n|  &&
+             `    "z2ui5/controller/View1.controller",` && |\n|  &&
+             `    "z2ui5/cc/Server",` && |\n|  &&
+             `    "sap/ui/core/routing/HashChanger",` && |\n|  &&
+             `  ],` && |\n|  &&
+             `  (BaseController, Controller, Server, HashChanger) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `    return BaseController.extend("z2ui5.controller.App", {` && |\n|  &&
+             `      onInit() {` && |\n|  &&
+             `        const oOwnerComponent = this.getOwnerComponent();` && |\n|  &&
+             `        z2ui5.oOwnerComponent = oOwnerComponent;` && |\n|  &&
+             `` && |\n|  &&
+             `        // Read the backend URI from the manifest, falling back step by step` && |\n|  &&
+             `        // so a missing entry doesn't blow up.` && |\n|  &&
+             `        const manifest = oOwnerComponent.getManifest();` && |\n|  &&
+             `        const sapApp = manifest && manifest["sap.app"];` && |\n|  &&
+             `        const dataSources = sapApp && sapApp.dataSources;` && |\n|  &&
+             `        const http = dataSources && dataSources.http;` && |\n|  &&
+             `        const uri = http && http.uri;` && |\n|  &&
+             `        z2ui5.url = z2ui5.checkLocal ? window.location.href : uri;` && |\n|  &&
+             `` && |\n|  &&
+             `        // Set up the shared z2ui5 state used by the whole app.` && |\n|  &&
+             `        z2ui5.oController = new Controller();` && |\n|  &&
+             `        z2ui5.oApp = this.getView().byId("app");` && |\n|  &&
+             `        z2ui5.oControllerNest = new Controller();` && |\n|  &&
+             `        z2ui5.oControllerNest2 = new Controller();` && |\n|  &&
+             `        z2ui5.oControllerPopup = new Controller();` && |\n|  &&
+             `        z2ui5.oControllerPopover = new Controller();` && |\n|  &&
+             `        z2ui5.onBeforeRoundtrip = [];` && |\n|  &&
+             `        z2ui5.onAfterRendering = [];` && |\n|  &&
+             `        z2ui5.onBeforeEventFrontend = [];` && |\n|  &&
+             `        z2ui5.onAfterRoundtrip = [];` && |\n|  &&
+             `        z2ui5.errors = [];` && |\n|  &&
+             `        z2ui5.checkNestAfter = false;` && |\n|  &&
+             `        z2ui5.checkNestAfter2 = false;` && |\n|  &&
+             `` && |\n|  &&
+             `        // If the URL already contains a hash, kick off the initial roundtrip` && |\n|  &&
+             `        // so the backend can restore that state.` && |\n|  &&
+             `        if (HashChanger.getInstance().getHash()) {` && |\n|  &&
+             `          z2ui5.checkInit = true;` && |\n|  &&
+             `          Server.Roundtrip();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Timer", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.Timer", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        delayMS: {` && |\n|  &&
+             `          type: "int",` && |\n|  &&
+             `          defaultValue: 0,` && |\n|  &&
+             `        },` && |\n|  &&
+             `        checkActive: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: true,` && |\n|  &&
+             `        },` && |\n|  &&
+             `        checkRepeat: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: false,` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `      events: {` && |\n|  &&
+             `        finished: {` && |\n|  &&
+             `          allowPreventDefault: true,` && |\n|  &&
+             `          parameters: {},` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    onAfterRendering() {` && |\n|  &&
+             `      if (!this._pendingTimer) return;` && |\n|  &&
+             `      this._pendingTimer = false;` && |\n|  &&
+             `      this.delayedCall();` && |\n|  &&
+             `    },` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      clearTimeout(this._timerId);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    delayedCall() {` && |\n|  &&
+             `      if (!this.getProperty("checkActive")) return;` && |\n|  &&
+             `      clearTimeout(this._timerId);` && |\n|  &&
+             `      const repeat = this.getProperty("checkRepeat");` && |\n|  &&
+             `      const delay = this.getProperty("delayMS");` && |\n|  &&
+             `      this._timerId = setTimeout(() => {` && |\n|  &&
+             `        // The control might have been destroyed during the delay.` && |\n|  &&
+             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `        if (!repeat) this.setProperty("checkActive", false, true);` && |\n|  &&
+             `        this.fireFinished();` && |\n|  &&
+             `        // For repeating timers, queue the next iteration. Re-check destroy` && |\n|  &&
+             `        // again because fireFinished may have triggered teardown.` && |\n|  &&
+             `        if (repeat && !(this.isDestroyed && this.isDestroyed())) {` && |\n|  &&
+             `          this.delayedCall();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      }, delay);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(oRm, oControl) {` && |\n|  &&
+             `        oRm.openStart("span", oControl);` && |\n|  &&
+             `        oRm.style("display", "none");` && |\n|  &&
+             `        oRm.openEnd();` && |\n|  &&
+             `        oRm.close("span");` && |\n|  &&
+             `        oControl._pendingTimer = oControl.getProperty("checkActive");` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Focus", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.Focus", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        setUpdate: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: true,` && |\n|  &&
+             `        },` && |\n|  &&
+             `        focusId: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        selectionStart: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "0",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        selectionEnd: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "0",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setFocusId(val) {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        this.setProperty("focusId", val);` && |\n|  &&
+             `        const oElement = z2ui5.oView && z2ui5.oView.byId(val);` && |\n|  &&
+             `        if (oElement) oElement.applyFocusInfo(oElement.getFocusInfo());` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Focus.setFocusId failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `    onAfterRendering() {` && |\n|  &&
+             `      if (!this._pendingFocus) return;` && |\n|  &&
+             `      this._pendingFocus = false;` && |\n|  &&
+             `      const oElement =` && |\n|  &&
+             `        z2ui5.oView && z2ui5.oView.byId(this.getProperty("focusId"));` && |\n|  &&
+             `      if (!oElement) return;` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        // Merge the additional selection info into the existing focus info,` && |\n|  &&
+             `        // then apply both at once.` && |\n|  &&
+             `        const info = oElement.getFocusInfo();` && |\n|  &&
+             `        info.selectionStart = +this.getProperty("selectionStart");` && |\n|  &&
+             `        info.selectionEnd = +this.getProperty("selectionEnd");` && |\n|  &&
+             `        oElement.applyFocusInfo(info);` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Focus.onAfterRendering: applyFocusInfo failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(oRm, oControl) {` && |\n|  &&
+             `        oRm.openStart("span", oControl);` && |\n|  &&
+             `        oRm.style("display", "none");` && |\n|  &&
+             `        oRm.openEnd();` && |\n|  &&
+             `        oRm.close("span");` && |\n|  &&
+             `        if (!oControl.getProperty("setUpdate")) return;` && |\n|  &&
+             `        oControl.setProperty("setUpdate", false, true);` && |\n|  &&
+             `        oControl._pendingFocus = true;` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Title", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.Title", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        title: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setTitle(val) {` && |\n|  &&
+             `      this.setProperty("title", val);` && |\n|  &&
+             `      document.title = val == null ? "" : String(val);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/LPTitle", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.LPTitle", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        title: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        ApplicationFullWidth: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setTitle(val) {` && |\n|  &&
+             `      this.setProperty("title", val);` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;` && |\n|  &&
+             `        if (!shell || !shell.setTitle) return;` && |\n|  &&
+             `        const result = shell.setTitle(val);` && |\n|  &&
+             `        // setTitle may return a Promise; report any async failure.` && |\n|  &&
+             `        if (result && result.catch) {` && |\n|  &&
+             `          result.catch((e) =>` && |\n|  &&
+             `            _logError("LPTitle: Launchpad Service setTitle failed", e),` && |\n|  &&
+             `          );` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("LPTitle: Launchpad Service setTitle failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    setApplicationFullWidth(val) {` && |\n|  &&
+             `      this.setProperty("ApplicationFullWidth", val);` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const config = z2ui5.oLaunchpad && z2ui5.oLaunchpad.AppConfiguration;` && |\n|  &&
+             `        if (config && config.setApplicationFullWidth) {` && |\n|  &&
+             `          config.setApplicationFullWidth(val);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("LPTitle: setApplicationFullWidth failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/History", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.History", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        search: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setSearch(val) {` && |\n|  &&
+             `      this.setProperty("search", val);` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const search = val == null ? "" : val;` && |\n|  &&
+             `        history.replaceState(null, "", ``${window.location.pathname}${search}``);` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("History.setSearch: replaceState failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Tree", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.Tree", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        tree_id: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _getTreeBinding() {` && |\n|  &&
+             `      if (!z2ui5.oView) return undefined;` && |\n|  &&
+             `      const treeControl = z2ui5.oView.byId(this.getProperty("tree_id"));` && |\n|  &&
+             `      if (!treeControl) return undefined;` && |\n|  &&
+             `      return treeControl.getBinding("items");` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    setBackend() {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const binding = this._getTreeBinding();` && |\n|  &&
+             `        z2ui5.treeState = binding ? binding.getCurrentTreeState() : undefined;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Tree.setBackend: failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    init() {` && |\n|  &&
+             `      this._setBackendBound = this.setBackend.bind(this);` && |\n|  &&
+             `      _registerCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      _unregisterCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    onAfterRendering() {` && |\n|  &&
+             `      if (!this._pendingTreeState) return;` && |\n|  &&
+             `      this._pendingTreeState = false;` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const binding = this._getTreeBinding();` && |\n|  &&
+             `        if (binding) binding.setTreeState(z2ui5.treeState);` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Tree.onAfterRendering: setTreeState failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(oRm, oControl) {` && |\n|  &&
+             `        oRm.openStart("span", oControl);` && |\n|  &&
+             `        oRm.style("display", "none");` && |\n|  &&
+             `        oRm.openEnd();` && |\n|  &&
+             `        oRm.close("span");` && |\n|  &&
+             `        if (!z2ui5.treeState) return;` && |\n|  &&
+             `        oControl._pendingTreeState = true;` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Scrolling", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.Scrolling", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        setUpdate: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: true,` && |\n|  &&
+             `        },` && |\n|  &&
+             `        items: {` && |\n|  &&
+             `          type: "object",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _getDomInnerElement(id) {` && |\n|  &&
+             `      const control = z2ui5.oView && z2ui5.oView.byId(id);` && |\n|  &&
+             `      if (!control) return null;` && |\n|  &&
+             `      return document.getElementById(``${control.getId()}-inner``);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _getScrollTop(item) {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n|  &&
+             `        // Some controls expose a scroll delegate; prefer it when available.` && |\n|  &&
+             `        if (control && control.getScrollDelegate) {` && |\n|  &&
+             `          const delegate = control.getScrollDelegate();` && |\n|  &&
+             `          if (delegate) return delegate.getScrollTop();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const element = this._getDomInnerElement(item.ID);` && |\n|  &&
+             `        return element ? element.scrollTop : 0;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Scrolling._getScrollTop: failed", e);` && |\n|  &&
+             `        return 0;` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    setBackend() {` && |\n|  &&
+             `      const items = this.getProperty("items");` && |\n|  &&
+             `      if (!items) return;` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        // Resolve the binding path so we can mark only changed entries` && |\n|  &&
+             `        // as dirty in xxChangedPaths.` && |\n|  &&
+             `        const bindingInfo = this.getBindingInfo("items");` && |\n|  &&
+             `        let bindingPath;` && |\n|  &&
+             `        if (bindingInfo) {` && |\n|  &&
+             `          const parts = bindingInfo.parts;` && |\n|  &&
+             `          if (parts && parts[0]) bindingPath = parts[0].path;` && |\n|  &&
+             `          if (!bindingPath) bindingPath = bindingInfo.path;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        for (const [index, item] of items.entries()) {` && |\n|  &&
+             `          const scrollTop = this._getScrollTop(item);` && |\n|  &&
+             `          if (item.V !== scrollTop) {` && |\n|  &&
+             `            item.V = scrollTop;` && |\n|  &&
              |\n|.
     result = result &&
-             `            if (bindingPath && z2ui5.xxChangedPaths) {` && |\n| &&
-             `              z2ui5.xxChangedPaths.add(``${bindingPath}/${index}/V``);` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Scrolling.setBackend: failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    init() {` && |\n| &&
-             `      this._setBackendBound = this.setBackend.bind(this);` && |\n| &&
-             `      _registerCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      _unregisterCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _restoreScrollPosition(item) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n| &&
-             `        if (control && control.scrollTo) {` && |\n| &&
-             `          control.scrollTo(item.V);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        const element = this._getDomInnerElement(item.ID);` && |\n| &&
-             `        if (element) element.scrollTop = item.V;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Scrolling._restoreScrollPosition: failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    onAfterRendering() {` && |\n| &&
-             `      if (!this._pendingScroll) return;` && |\n| &&
-             `      this._pendingScroll = false;` && |\n| &&
-             `` && |\n| &&
-             `      const items = this.getProperty("items");` && |\n| &&
-             `      if (!items) return;` && |\n| &&
-             `` && |\n| &&
-             `      try {` && |\n| &&
-             `        for (const item of items) {` && |\n| &&
-             `          const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n| &&
-             `          if (!control) continue;` && |\n| &&
-             `` && |\n| &&
-             `          if (control.getDomRef()) {` && |\n| &&
-             `            // The target control is already rendered -> restore immediately.` && |\n| &&
-             `            this._restoreScrollPosition(item);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            // Not rendered yet -> wait until it is, then restore once.` && |\n| &&
-             `            const delegate = {` && |\n| &&
-             `              onAfterRendering: () => {` && |\n| &&
-             `                control.removeEventDelegate(delegate);` && |\n| &&
-             `                if (!(this.isDestroyed && this.isDestroyed())) {` && |\n| &&
-             `                  this._restoreScrollPosition(item);` && |\n| &&
-             `                }` && |\n| &&
-             `              },` && |\n| &&
-             `            };` && |\n| &&
-             `            control.addEventDelegate(delegate);` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Scrolling.onAfterRendering: failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(oRm, oControl) {` && |\n| &&
-             `        oRm.openStart("span", oControl);` && |\n| &&
-             `        oRm.style("display", "none");` && |\n| &&
-             `        oRm.openEnd();` && |\n| &&
-             `        oRm.close("span");` && |\n| &&
-             `` && |\n| &&
-             `        if (!oControl.getProperty("setUpdate")) return;` && |\n| &&
-             `        oControl.setProperty("setUpdate", false, true);` && |\n| &&
-             `        oControl._pendingScroll = true;` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Info", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.Info", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        ui5_version: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_phone: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_desktop: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_tablet: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_combi: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_height: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_width: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        ui5_theme: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_os: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_systemtype: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        device_browser: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `      events: {` && |\n| &&
-             `        finished: {` && |\n| &&
-             `          allowPreventDefault: true,` && |\n| &&
-             `          parameters: {},` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(_, oControl) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          // The device model is created by Component.init(); it exposes` && |\n| &&
-             `          // system / resize / os / browser info.` && |\n| &&
-             `          const deviceModel = z2ui5.oView && z2ui5.oView.getModel("device");` && |\n| &&
-             `          const deviceData = deviceModel && deviceModel.getData();` && |\n| &&
-             `          if (!deviceData) return;` && |\n| &&
-             `` && |\n| &&
-             `          const { system, resize, os, browser } = deviceData;` && |\n| &&
-             `          const versionInfo = z2ui5.oConfig && z2ui5.oConfig.UI5VersionInfo;` && |\n| &&
-             `          const ui5Version = versionInfo ? versionInfo.version : "";` && |\n| &&
-             `` && |\n| &&
-             `          const props = [` && |\n| &&
-             `            ["ui5_version", ui5Version],` && |\n| &&
-             `            ["device_phone", system.phone],` && |\n| &&
-             `            ["device_desktop", system.desktop],` && |\n| &&
-             `            ["device_tablet", system.tablet],` && |\n| &&
-             `            ["device_combi", system.combi],` && |\n| &&
-             `            ["device_height", resize.height],` && |\n| &&
-             `            ["device_width", resize.width],` && |\n| &&
-             `            ["device_os", os.name],` && |\n| &&
-             `            ["device_browser", browser.name],` && |\n| &&
-             `          ];` && |\n| &&
-             `          for (const [prop, val] of props) {` && |\n| &&
-             `            const safe = val == null ? "" : String(val);` && |\n| &&
-             `            oControl.setProperty(prop, safe, true);` && |\n| &&
-             `          }` && |\n| &&
-             `          oControl.fireFinished();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("Info.renderer: failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Geolocation", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  const _GEO_PROPS = [` && |\n| &&
-             `    "longitude",` && |\n| &&
-             `    "latitude",` && |\n| &&
-             `    "altitude",` && |\n| &&
-             `    "accuracy",` && |\n| &&
-             `    "altitudeAccuracy",` && |\n| &&
-             `    "speed",` && |\n| &&
-             `    "heading",` && |\n| &&
-             `  ];` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.Geolocation", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        longitude: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        latitude: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        altitude: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        accuracy: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        altitudeAccuracy: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        speed: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        heading: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        enableHighAccuracy: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: false,` && |\n| &&
-             `        },` && |\n| &&
-             `        timeout: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "5000",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `      events: {` && |\n| &&
-             `        finished: {` && |\n| &&
-             `          allowPreventDefault: true,` && |\n| &&
-             `          parameters: {},` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    callbackPosition({ coords }) {` && |\n| &&
-             `      // The control could be torn down while the geolocation API was busy.` && |\n| &&
-             `      if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `      for (const prop of _GEO_PROPS) {` && |\n| &&
-             `        const raw = coords[prop];` && |\n| &&
-             `        const val = raw == null ? "" : raw.toString();` && |\n| &&
-             `        this.setProperty(prop, val, true);` && |\n| &&
-             `      }` && |\n| &&
-             `      this.fireFinished();` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    init() {` && |\n| &&
-             `      this._pendingGeolocate = true;` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      this._pendingGeolocate = false;` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    onAfterRendering() {` && |\n| &&
-             `      if (!this._pendingGeolocate) return;` && |\n| &&
-             `      this._pendingGeolocate = false;` && |\n| &&
-             `      try {` && |\n| &&
-             `        if (!navigator.geolocation) return;` && |\n| &&
-             `        navigator.geolocation.getCurrentPosition(` && |\n| &&
-             `          this.callbackPosition.bind(this),` && |\n| &&
-             `          (error) =>` && |\n| &&
-             `            _logError(``Geolocation error (${error.code}): ${error.message}``),` && |\n| &&
-             `          {` && |\n| &&
-             `            enableHighAccuracy: this.getProperty("enableHighAccuracy"),` && |\n| &&
-             `            timeout: +this.getProperty("timeout"),` && |\n| &&
-             `          },` && |\n| &&
-             `        );` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Geolocation.onAfterRendering: getCurrentPosition failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: {` && |\n| &&
-             `      apiVersion: 2,` && |\n| &&
-             `      render(oRm, oControl) {` && |\n| &&
-             `        oRm.openStart("span", oControl);` && |\n| &&
-             `        oRm.style("display", "none");` && |\n| &&
-             `        oRm.openEnd();` && |\n| &&
-             `        oRm.close("span");` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/Storage",` && |\n| &&
-             `  ["sap/ui/core/Control", "sap/ui/util/Storage"],` && |\n| &&
-             `  (Control, Storage) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    return Control.extend("z2ui5.Storage", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        properties: {` && |\n| &&
-             `          type: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "session",` && |\n| &&
-             `          },` && |\n| &&
-             `          prefix: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          key: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          value: {` && |\n| &&
-             `            type: "any",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `        events: {` && |\n| &&
-             `          finished: {` && |\n| &&
-             `            parameters: {` && |\n| &&
-             `              type: {` && |\n| &&
-             `                type: "string",` && |\n| &&
-             `              },` && |\n| &&
-             `              prefix: {` && |\n| &&
-             `                type: "string",` && |\n| &&
-             `              },` && |\n| &&
-             `              key: {` && |\n| &&
-             `                type: "string",` && |\n| &&
-             `              },` && |\n| &&
-             `              value: {` && |\n| &&
-             `                type: "any",` && |\n| &&
-             `              },` && |\n| &&
-             `            },` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      renderer: {` && |\n| &&
-             `        apiVersion: 2,` && |\n| &&
-             `        render(_, oControl) {` && |\n| &&
-             `          const type = oControl.getProperty("type");` && |\n| &&
-             `          const prefix = oControl.getProperty("prefix");` && |\n| &&
-             `          const key = oControl.getProperty("key");` && |\n| &&
-             `          const value = oControl.getProperty("value");` && |\n| &&
-             `` && |\n| &&
-             `          let stored;` && |\n| &&
-             `          try {` && |\n| &&
-             `            const storageType = Storage.Type[type] || Storage.Type.session;` && |\n| &&
-             `            const storage = new Storage(storageType, prefix);` && |\n| &&
-             `            const read = storage.get(key);` && |\n| &&
-             `            stored = read == null ? "" : read;` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            _logError(``Storage: read failed for key '${key}'``, e);` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          // Only fire "finished" when the stored value differs from the` && |\n| &&
-             `          // current property to avoid feedback loops.` && |\n| &&
-             `          if (stored !== value) {` && |\n| &&
-             `            oControl.setProperty("value", stored, true);` && |\n| &&
-             `            oControl.fireFinished({` && |\n| &&
-             `              type: type,` && |\n| &&
-             `              prefix: prefix,` && |\n| &&
-             `              key: key,` && |\n| &&
-             `              value: stored,` && |\n| &&
-             `            });` && |\n| &&
-             `          }` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/FileUploader",` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/Control",` && |\n| &&
-             `    "sap/m/Button",` && |\n| &&
-             `    "sap/ui/unified/FileUploader",` && |\n| &&
-             `    "sap/m/HBox",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (Control, Button, FileUploader, HBox) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    return Control.extend("z2ui5.FileUploader", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        properties: {` && |\n| &&
-             `          value: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          path: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          tooltip: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          fileType: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          placeholder: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          buttonText: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          style: {` && |\n| &&
+             `            if (bindingPath && z2ui5.xxChangedPaths) {` && |\n|  &&
+             `              z2ui5.xxChangedPaths.add(``${bindingPath}/${index}/V``);` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Scrolling.setBackend: failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    init() {` && |\n|  &&
+             `      this._setBackendBound = this.setBackend.bind(this);` && |\n|  &&
+             `      _registerCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      _unregisterCallback("onBeforeRoundtrip", this._setBackendBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _restoreScrollPosition(item) {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n|  &&
+             `        if (control && control.scrollTo) {` && |\n|  &&
+             `          control.scrollTo(item.V);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const element = this._getDomInnerElement(item.ID);` && |\n|  &&
+             `        if (element) element.scrollTop = item.V;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Scrolling._restoreScrollPosition: failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    onAfterRendering() {` && |\n|  &&
+             `      if (!this._pendingScroll) return;` && |\n|  &&
+             `      this._pendingScroll = false;` && |\n|  &&
+             `` && |\n|  &&
+             `      const items = this.getProperty("items");` && |\n|  &&
+             `      if (!items) return;` && |\n|  &&
+             `` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        for (const item of items) {` && |\n|  &&
+             `          const control = z2ui5.oView && z2ui5.oView.byId(item.N);` && |\n|  &&
+             `          if (!control) continue;` && |\n|  &&
+             `` && |\n|  &&
+             `          if (control.getDomRef()) {` && |\n|  &&
+             `            // The target control is already rendered -> restore immediately.` && |\n|  &&
+             `            this._restoreScrollPosition(item);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            // Not rendered yet -> wait until it is, then restore once.` && |\n|  &&
+             `            const delegate = {` && |\n|  &&
+             `              onAfterRendering: () => {` && |\n|  &&
+             `                control.removeEventDelegate(delegate);` && |\n|  &&
+             `                if (!(this.isDestroyed && this.isDestroyed())) {` && |\n|  &&
+             `                  this._restoreScrollPosition(item);` && |\n|  &&
+             `                }` && |\n|  &&
+             `              },` && |\n|  &&
+             `            };` && |\n|  &&
+             `            control.addEventDelegate(delegate);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Scrolling.onAfterRendering: failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(oRm, oControl) {` && |\n|  &&
+             `        oRm.openStart("span", oControl);` && |\n|  &&
+             `        oRm.style("display", "none");` && |\n|  &&
+             `        oRm.openEnd();` && |\n|  &&
+             `        oRm.close("span");` && |\n|  &&
+             `` && |\n|  &&
+             `        if (!oControl.getProperty("setUpdate")) return;` && |\n|  &&
+             `        oControl.setProperty("setUpdate", false, true);` && |\n|  &&
+             `        oControl._pendingScroll = true;` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Info", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.Info", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        ui5_version: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_phone: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_desktop: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_tablet: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_combi: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_height: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_width: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        ui5_theme: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_os: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_systemtype: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        device_browser: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `      events: {` && |\n|  &&
+             `        finished: {` && |\n|  &&
+             `          allowPreventDefault: true,` && |\n|  &&
+             `          parameters: {},` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(_, oControl) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          // The device model is created by Component.init(); it exposes` && |\n|  &&
+             `          // system / resize / os / browser info.` && |\n|  &&
+             `          const deviceModel = z2ui5.oView && z2ui5.oView.getModel("device");` && |\n|  &&
+             `          const deviceData = deviceModel && deviceModel.getData();` && |\n|  &&
+             `          if (!deviceData) return;` && |\n|  &&
+             `` && |\n|  &&
+             `          const { system, resize, os, browser } = deviceData;` && |\n|  &&
+             `          const versionInfo = z2ui5.oConfig && z2ui5.oConfig.UI5VersionInfo;` && |\n|  &&
+             `          const ui5Version = versionInfo ? versionInfo.version : "";` && |\n|  &&
+             `` && |\n|  &&
+             `          const props = [` && |\n|  &&
+             `            ["ui5_version", ui5Version],` && |\n|  &&
+             `            ["device_phone", system.phone],` && |\n|  &&
+             `            ["device_desktop", system.desktop],` && |\n|  &&
+             `            ["device_tablet", system.tablet],` && |\n|  &&
+             `            ["device_combi", system.combi],` && |\n|  &&
+             `            ["device_height", resize.height],` && |\n|  &&
+             `            ["device_width", resize.width],` && |\n|  &&
+             `            ["device_os", os.name],` && |\n|  &&
+             `            ["device_browser", browser.name],` && |\n|  &&
+             `          ];` && |\n|  &&
+             `          for (const [prop, val] of props) {` && |\n|  &&
+             `            const safe = val == null ? "" : String(val);` && |\n|  &&
+             `            oControl.setProperty(prop, safe, true);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          oControl.fireFinished();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("Info.renderer: failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Geolocation", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  const _GEO_PROPS = [` && |\n|  &&
+             `    "longitude",` && |\n|  &&
+             `    "latitude",` && |\n|  &&
+             `    "altitude",` && |\n|  &&
+             `    "accuracy",` && |\n|  &&
+             `    "altitudeAccuracy",` && |\n|  &&
+             `    "speed",` && |\n|  &&
+             `    "heading",` && |\n|  &&
+             `  ];` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.Geolocation", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        longitude: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        latitude: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        altitude: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        accuracy: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        altitudeAccuracy: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        speed: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        heading: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        enableHighAccuracy: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: false,` && |\n|  &&
+             `        },` && |\n|  &&
+             `        timeout: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "5000",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `      events: {` && |\n|  &&
+             `        finished: {` && |\n|  &&
+             `          allowPreventDefault: true,` && |\n|  &&
+             `          parameters: {},` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    callbackPosition({ coords }) {` && |\n|  &&
+             `      // The control could be torn down while the geolocation API was busy.` && |\n|  &&
+             `      if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `      for (const prop of _GEO_PROPS) {` && |\n|  &&
+             `        const raw = coords[prop];` && |\n|  &&
+             `        const val = raw == null ? "" : raw.toString();` && |\n|  &&
+             `        this.setProperty(prop, val, true);` && |\n|  &&
+             `      }` && |\n|  &&
+             `      this.fireFinished();` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    init() {` && |\n|  &&
+             `      this._pendingGeolocate = true;` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      this._pendingGeolocate = false;` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    onAfterRendering() {` && |\n|  &&
+             `      if (!this._pendingGeolocate) return;` && |\n|  &&
+             `      this._pendingGeolocate = false;` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        if (!navigator.geolocation) return;` && |\n|  &&
+             `        navigator.geolocation.getCurrentPosition(` && |\n|  &&
+             `          this.callbackPosition.bind(this),` && |\n|  &&
+             `          (error) =>` && |\n|  &&
+             `            _logError(``Geolocation error (${error.code}): ${error.message}``),` && |\n|  &&
+             `          {` && |\n|  &&
+             `            enableHighAccuracy: this.getProperty("enableHighAccuracy"),` && |\n|  &&
+             `            timeout: +this.getProperty("timeout"),` && |\n|  &&
+             `          },` && |\n|  &&
+             `        );` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Geolocation.onAfterRendering: getCurrentPosition failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: {` && |\n|  &&
+             `      apiVersion: 2,` && |\n|  &&
+             `      render(oRm, oControl) {` && |\n|  &&
+             `        oRm.openStart("span", oControl);` && |\n|  &&
+             `        oRm.style("display", "none");` && |\n|  &&
+             `        oRm.openEnd();` && |\n|  &&
+             `        oRm.close("span");` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/Storage",` && |\n|  &&
+             `  ["sap/ui/core/Control", "sap/ui/util/Storage"],` && |\n|  &&
+             `  (Control, Storage) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    return Control.extend("z2ui5.Storage", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        properties: {` && |\n|  &&
+             `          type: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "session",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          prefix: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          key: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          value: {` && |\n|  &&
+             `            type: "any",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `        events: {` && |\n|  &&
+             `          finished: {` && |\n|  &&
+             `            parameters: {` && |\n|  &&
+             `              type: {` && |\n|  &&
+             `                type: "string",` && |\n|  &&
+             `              },` && |\n|  &&
+             `              prefix: {` && |\n|  &&
+             `                type: "string",` && |\n|  &&
+             `              },` && |\n|  &&
+             `              key: {` && |\n|  &&
+             `                type: "string",` && |\n|  &&
+             `              },` && |\n|  &&
+             `              value: {` && |\n|  &&
+             `                type: "any",` && |\n|  &&
+             `              },` && |\n|  &&
+             `            },` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      renderer: {` && |\n|  &&
+             `        apiVersion: 2,` && |\n|  &&
+             `        render(_, oControl) {` && |\n|  &&
+             `          const type = oControl.getProperty("type");` && |\n|  &&
+             `          const prefix = oControl.getProperty("prefix");` && |\n|  &&
+             `          const key = oControl.getProperty("key");` && |\n|  &&
+             `          const value = oControl.getProperty("value");` && |\n|  &&
+             `` && |\n|  &&
+             `          let stored;` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const storageType = Storage.Type[type] || Storage.Type.session;` && |\n|  &&
+             `            const storage = new Storage(storageType, prefix);` && |\n|  &&
+             `            const read = storage.get(key);` && |\n|  &&
+             `            stored = read == null ? "" : read;` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            _logError(``Storage: read failed for key '${key}'``, e);` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          // Only fire "finished" when the stored value differs from the` && |\n|  &&
+             `          // current property to avoid feedback loops.` && |\n|  &&
+             `          if (stored !== value) {` && |\n|  &&
+             `            oControl.setProperty("value", stored, true);` && |\n|  &&
+             `            oControl.fireFinished({` && |\n|  &&
+             `              type: type,` && |\n|  &&
+             `              prefix: prefix,` && |\n|  &&
+             `              key: key,` && |\n|  &&
+             `              value: stored,` && |\n|  &&
+             `            });` && |\n|  &&
+             `          }` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/FileUploader",` && |\n|  &&
+             `  [` && |\n|  &&
+             `    "sap/ui/core/Control",` && |\n|  &&
+             `    "sap/m/Button",` && |\n|  &&
+             `    "sap/ui/unified/FileUploader",` && |\n|  &&
+             `    "sap/m/HBox",` && |\n|  &&
+             `  ],` && |\n|  &&
+             `  (Control, Button, FileUploader, HBox) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    return Control.extend("z2ui5.FileUploader", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        properties: {` && |\n|  &&
+             `          value: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          path: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          tooltip: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          fileType: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          placeholder: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          buttonText: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          style: {` && |\n|  &&
              |\n|.
     result = result &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "",` && |\n| &&
-             `          },` && |\n| &&
-             `          uploadButtonText: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "Upload",` && |\n| &&
-             `          },` && |\n| &&
-             `          enabled: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: true,` && |\n| &&
-             `          },` && |\n| &&
-             `          icon: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `            defaultValue: "sap-icon://browse-folder",` && |\n| &&
-             `          },` && |\n| &&
-             `          iconOnly: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `          buttonOnly: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `          multiple: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `          visible: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: true,` && |\n| &&
-             `          },` && |\n| &&
-             `          checkDirectUpload: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `` && |\n| &&
-             `        events: {` && |\n| &&
-             `          upload: {` && |\n| &&
-             `            allowPreventDefault: true,` && |\n| &&
-             `            parameters: {},` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _readFile(file) {` && |\n| &&
-             `        const reader = new FileReader();` && |\n| &&
-             `        reader.onload = () => {` && |\n| &&
-             `          if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `          this.setProperty("value", reader.result);` && |\n| &&
-             `          this.fireUpload();` && |\n| &&
-             `        };` && |\n| &&
-             `        reader.onerror = () =>` && |\n| &&
-             `          _logError("FileUploader: FileReader failed", reader.error);` && |\n| &&
-             `        reader.readAsDataURL(file);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      exit() {` && |\n| &&
-             `        if (this._oHBox) this._oHBox.destroy();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      renderer: {` && |\n| &&
-             `        apiVersion: 2,` && |\n| &&
-             `        render(oRm, oControl) {` && |\n| &&
-             `          const directUpload = oControl.getProperty("checkDirectUpload");` && |\n| &&
-             `          const path = oControl.getProperty("path");` && |\n| &&
-             `` && |\n| &&
-             `          // Clean up controls from a previous render pass.` && |\n| &&
-             `          if (oControl._oHBox) oControl._oHBox.destroy();` && |\n| &&
-             `          oControl._oHBox = null;` && |\n| &&
-             `          oControl.oUploadButton = null;` && |\n| &&
-             `          oControl.oFileUploader = null;` && |\n| &&
-             `` && |\n| &&
-             `          // Helper: read the first file from a FileUploader instance.` && |\n| &&
-             `          const getFirstFile = (uploader) => {` && |\n| &&
-             `            const fileUpload = uploader && uploader.oFileUpload;` && |\n| &&
-             `            const files = fileUpload && fileUpload.files;` && |\n| &&
-             `            return files && files[0];` && |\n| &&
-             `          };` && |\n| &&
-             `` && |\n| &&
-             `          if (!directUpload) {` && |\n| &&
-             `            oControl.oUploadButton = new Button({` && |\n| &&
-             `              text: oControl.getProperty("uploadButtonText"),` && |\n| &&
-             `              enabled: path !== "",` && |\n| &&
-             `              press: () => {` && |\n| &&
-             `                oControl.setProperty(` && |\n| &&
-             `                  "path",` && |\n| &&
-             `                  oControl.oFileUploader.getProperty("value"),` && |\n| &&
-             `                );` && |\n| &&
-             `                const file = getFirstFile(oControl.oFileUploader);` && |\n| &&
-             `                if (file) oControl._readFile(file);` && |\n| &&
-             `              },` && |\n| &&
-             `            });` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          oControl.oFileUploader = new FileUploader({` && |\n| &&
-             `            icon: oControl.getProperty("icon"),` && |\n| &&
-             `            iconOnly: oControl.getProperty("iconOnly"),` && |\n| &&
-             `            buttonOnly: oControl.getProperty("buttonOnly"),` && |\n| &&
-             `            buttonText: oControl.getProperty("buttonText"),` && |\n| &&
-             `            style: oControl.getProperty("style"),` && |\n| &&
-             `            fileType: oControl.getProperty("fileType"),` && |\n| &&
-             `            visible: oControl.getProperty("visible"),` && |\n| &&
-             `            uploadOnChange: directUpload,` && |\n| &&
-             `            multiple: oControl.getProperty("multiple"),` && |\n| &&
-             `            enabled: oControl.getProperty("enabled"),` && |\n| &&
-             `            value: path,` && |\n| &&
-             `            placeholder: oControl.getProperty("placeholder"),` && |\n| &&
-             `            change: (oEvent) => {` && |\n| &&
-             `              if (directUpload) return;` && |\n| &&
-             `              const value = oEvent.getSource().getProperty("value");` && |\n| &&
-             `              oControl.setProperty("path", value);` && |\n| &&
-             `              if (oControl.oUploadButton) {` && |\n| &&
-             `                oControl.oUploadButton.setEnabled(!!value);` && |\n| &&
-             `                oControl.oUploadButton.invalidate();` && |\n| &&
-             `              }` && |\n| &&
-             `            },` && |\n| &&
-             `            uploadComplete: (oEvent) => {` && |\n| &&
-             `              if (!directUpload) return;` && |\n| &&
-             `              const source = oEvent.getSource();` && |\n| &&
-             `              oControl.setProperty("path", source.getProperty("value"));` && |\n| &&
-             `              const file = getFirstFile(source);` && |\n| &&
-             `              if (file) oControl._readFile(file);` && |\n| &&
-             `            },` && |\n| &&
-             `          });` && |\n| &&
-             `` && |\n| &&
-             `          oControl._oHBox = new HBox().addItem(oControl.oFileUploader);` && |\n| &&
-             `          if (oControl.oUploadButton) {` && |\n| &&
-             `            oControl._oHBox.addItem(oControl.oUploadButton);` && |\n| &&
-             `          }` && |\n| &&
-             `          oRm.renderControl(oControl._oHBox);` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/MultiInputExt",` && |\n| &&
-             `  ["sap/ui/core/Control", "sap/m/Token"],` && |\n| &&
-             `  (Control, Token) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    return Control.extend("z2ui5.MultiInputExt", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        properties: {` && |\n| &&
-             `          MultiInputId: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `          },` && |\n| &&
-             `          MultiInputName: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `          },` && |\n| &&
-             `          addedTokens: {` && |\n| &&
-             `            type: "object",` && |\n| &&
-             `          },` && |\n| &&
-             `          checkInit: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `          removedTokens: {` && |\n| &&
-             `            type: "object",` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `        events: {` && |\n| &&
-             `          change: {` && |\n| &&
-             `            allowPreventDefault: true,` && |\n| &&
-             `            parameters: {},` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      init() {` && |\n| &&
-             `        this._setControlBound = this.setControl.bind(this);` && |\n| &&
-             `        _registerCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `      },` && |\n| &&
-             `      exit() {` && |\n| &&
-             `        _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onTokenUpdate(oEvent) {` && |\n| &&
-             `        const mParameters = oEvent.mParameters;` && |\n| &&
-             `        const isRemoved = mParameters.type === "removed";` && |\n| &&
-             `        const rawList =` && |\n| &&
-             `          mParameters[isRemoved ? "removedTokens" : "addedTokens"] || [];` && |\n| &&
-             `        const tokens = rawList.map((item) => ({` && |\n| &&
-             `          KEY: item.getKey(),` && |\n| &&
-             `          TEXT: item.getText(),` && |\n| &&
-             `        }));` && |\n| &&
-             `        this.setProperty("addedTokens", isRemoved ? [] : tokens);` && |\n| &&
-             `        this.setProperty("removedTokens", isRemoved ? tokens : []);` && |\n| &&
-             `        this.fireChange();` && |\n| &&
-             `      },` && |\n| &&
-             `      renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `      setControl() {` && |\n| &&
-             `        const table =` && |\n| &&
-             `          z2ui5.oView && z2ui5.oView.byId(this.getProperty("MultiInputId"));` && |\n| &&
-             `        if (!table || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
-             `        try {` && |\n| &&
-             `          table.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
-             `          // Custom validator: turn any free-text entry into a Token where` && |\n| &&
-             `          // both key and visible text equal the input string.` && |\n| &&
-             `          table.addValidator(({ text }) => new Token({ key: text, text }));` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("MultiInputExt.setControl: setup failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/UploadSetExt", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.UploadSetExt", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        uploadSetId: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `        fileData: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        fileName: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        mediaType: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        fileSize: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        removedFileName: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `          defaultValue: "",` && |\n| &&
-             `        },` && |\n| &&
-             `        checkInit: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: false,` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `      events: {` && |\n| &&
-             `        change: {` && |\n| &&
-             `          allowPreventDefault: true,` && |\n| &&
-             `          parameters: {},` && |\n| &&
-             `        },` && |\n| &&
-             `        remove: {` && |\n| &&
-             `          allowPreventDefault: true,` && |\n| &&
-             `          parameters: {},` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    init() {` && |\n| &&
-             `      this._setControlBound = this.setControl.bind(this);` && |\n| &&
-             `      _registerCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `    },` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _readFile(file) {` && |\n| &&
-             `      const reader = new FileReader();` && |\n| &&
-             `      reader.onload = () => {` && |\n| &&
-             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `        this.setProperty("fileData", reader.result);` && |\n| &&
-             `        this.setProperty("fileName", file.name);` && |\n| &&
-             `        this.setProperty("mediaType", file.type);` && |\n| &&
-             `        this.setProperty("fileSize", String(file.size));` && |\n| &&
-             `        this.fireChange();` && |\n| &&
-             `      };` && |\n| &&
-             `      reader.onerror = () =>` && |\n| &&
-             `        _logError("UploadSetExt: FileReader failed", reader.error);` && |\n| &&
-             `      reader.readAsDataURL(file);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    onItemAdded(oEvent) {` && |\n| &&
-             `      const item = oEvent.getParameter("item");` && |\n| &&
-             `      const file = item && item.getFileObject ? item.getFileObject() : null;` && |\n| &&
-             `      if (file) this._readFile(file);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    onItemRemoved(oEvent) {` && |\n| &&
-             `      const item = oEvent.getParameter("item");` && |\n| &&
-             `      const name = item && item.getFileName ? item.getFileName() : "";` && |\n| &&
-             `      this.setProperty("removedFileName", name);` && |\n| &&
-             `      this.fireRemove();` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `    setControl() {` && |\n| &&
-             `      const uploadSet =` && |\n| &&
-             `        z2ui5.oView && z2ui5.oView.byId(this.getProperty("uploadSetId"));` && |\n| &&
-             `      if (!uploadSet || this.getProperty("checkInit")) return;` && |\n| &&
-             `      this.setProperty("checkInit", true);` && |\n| &&
-             `      try {` && |\n| &&
-             `        uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));` && |\n| &&
-             `        uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("UploadSetExt.setControl: setup failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/SmartMultiInputExt",` && |\n| &&
-             `  ["sap/ui/core/Control"],` && |\n| &&
-             `  (Control) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    return Control.extend("z2ui5.SmartMultiInputExt", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        properties: {` && |\n| &&
-             `          multiInputId: {` && |\n| &&
-             `            type: "string",` && |\n| &&
-             `          },` && |\n| &&
-             `          addedTokens: {` && |\n| &&
-             `            type: "object",` && |\n| &&
-             `          },` && |\n| &&
-             `          removedTokens: {` && |\n| &&
-             `            type: "object",` && |\n| &&
-             `          },` && |\n| &&
-             `          rangeData: {` && |\n| &&
-             `            type: "object",` && |\n| &&
-             `            defaultValue: [],` && |\n| &&
-             `          },` && |\n| &&
-             `          checkInit: {` && |\n| &&
-             `            type: "boolean",` && |\n| &&
-             `            defaultValue: false,` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `        events: {` && |\n| &&
-             `          change: {` && |\n| &&
-             `            allowPreventDefault: true,` && |\n| &&
-             `            parameters: {},` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      init() {` && |\n| &&
-             `        this._setControlBound = this.setControl.bind(this);` && |\n| &&
-             `        this._oInput = null;` && |\n| &&
-             `        this._oPendingInnerControlsCreated = null;` && |\n| &&
-             `        this._bInnerControlsCreated = false;` && |\n| &&
-             `        _registerCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `      },` && |\n| &&
-             `      exit() {` && |\n| &&
-             `        _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n| &&
-             `        // Resolve any still-pending promise so awaiters don't hang.` && |\n| &&
-             `        if (this._oPendingInnerControlsCreated) {` && |\n| &&
-             `          this._oPendingInnerControlsCreated(null);` && |\n| &&
-             `        }` && |\n| &&
-             `        this._oPendingInnerControlsCreated = null;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onTokenUpdate(oEvent) {` && |\n| &&
-             `        const mParameters = oEvent.mParameters;` && |\n| &&
-             `        const isRemoved = mParameters.type === "removed";` && |\n| &&
-             `        const rawList =` && |\n| &&
-             `          mParameters[isRemoved ? "removedTokens" : "addedTokens"] || [];` && |\n| &&
-             `        const mappedTokens = rawList.map((item) => ({` && |\n| &&
-             `          KEY: item.getKey(),` && |\n| &&
-             `          TEXT: item.getText(),` && |\n| &&
-             `        }));` && |\n| &&
-             `        this.setProperty("addedTokens", isRemoved ? [] : mappedTokens);` && |\n| &&
-             `        this.setProperty("removedTokens", isRemoved ? mappedTokens : []);` && |\n| &&
-             `` && |\n| &&
-             `        // Mirror each range entry with the visible token text + long key` && |\n| &&
-             `        // so the backend has enough info to re-render the input later.` && |\n| &&
-             `        const source = oEvent.getSource();` && |\n| &&
-             `        const tokens = source.getTokens();` && |\n| &&
-             `        const rangeData = source.getRangeData() || [];` && |\n| &&
-             `        const enrichedRanges = rangeData.map((oRangeData, index) => {` && |\n| &&
-             `          const token = tokens[index];` && |\n| &&
-             `          oRangeData.tokenText = token ? token.getText() : "";` && |\n| &&
-             `          oRangeData.tokenLongKey = token ? token.data("longKey") : undefined;` && |\n| &&
-             `          return oRangeData;` && |\n| &&
-             `        });` && |\n| &&
-             `        this.setProperty("rangeData", enrichedRanges);` && |\n| &&
-             `        this.fireChange();` && |\n| &&
-             `      },` && |\n| &&
-             `      async setRangeData(aRangeData) {` && |\n| &&
-             `        this.setProperty("rangeData", aRangeData);` && |\n| &&
-             `        try {` && |\n| &&
-             `          const input = await this.inputInitialized();` && |\n| &&
-             `          if ((this.isDestroyed && this.isDestroyed()) || !input) return;` && |\n| &&
-             `` && |\n| &&
-             `          // Convert the ABAP-style uppercase keys to the camelCase property` && |\n| &&
-             `          // names the smart multi input expects. "keyField" needs its capital` && |\n| &&
-             `          // F preserved.` && |\n| &&
-             `          const normalizedRangeData = aRangeData.map((oRangeData) => {` && |\n| &&
-             `            const out = {};` && |\n| &&
-             `            for (const [key, value] of Object.entries(oRangeData)) {` && |\n| &&
-             `              const lower = key.toLowerCase();` && |\n| &&
-             `              const finalKey = lower === "keyfield" ? "keyField" : lower;` && |\n| &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          uploadButtonText: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "Upload",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          enabled: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: true,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          icon: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `            defaultValue: "sap-icon://browse-folder",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          iconOnly: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          buttonOnly: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          multiple: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          visible: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: true,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          checkDirectUpload: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `` && |\n|  &&
+             `        events: {` && |\n|  &&
+             `          upload: {` && |\n|  &&
+             `            allowPreventDefault: true,` && |\n|  &&
+             `            parameters: {},` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _readFile(file) {` && |\n|  &&
+             `        const reader = new FileReader();` && |\n|  &&
+             `        reader.onload = () => {` && |\n|  &&
+             `          if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `          this.setProperty("value", reader.result);` && |\n|  &&
+             `          this.fireUpload();` && |\n|  &&
+             `        };` && |\n|  &&
+             `        reader.onerror = () =>` && |\n|  &&
+             `          _logError("FileUploader: FileReader failed", reader.error);` && |\n|  &&
+             `        reader.readAsDataURL(file);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      exit() {` && |\n|  &&
+             `        if (this._oHBox) this._oHBox.destroy();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      renderer: {` && |\n|  &&
+             `        apiVersion: 2,` && |\n|  &&
+             `        render(oRm, oControl) {` && |\n|  &&
+             `          const directUpload = oControl.getProperty("checkDirectUpload");` && |\n|  &&
+             `          const path = oControl.getProperty("path");` && |\n|  &&
+             `` && |\n|  &&
+             `          // Clean up controls from a previous render pass.` && |\n|  &&
+             `          if (oControl._oHBox) oControl._oHBox.destroy();` && |\n|  &&
+             `          oControl._oHBox = null;` && |\n|  &&
+             `          oControl.oUploadButton = null;` && |\n|  &&
+             `          oControl.oFileUploader = null;` && |\n|  &&
+             `` && |\n|  &&
+             `          // Helper: read the first file from a FileUploader instance.` && |\n|  &&
+             `          const getFirstFile = (uploader) => {` && |\n|  &&
+             `            const fileUpload = uploader && uploader.oFileUpload;` && |\n|  &&
+             `            const files = fileUpload && fileUpload.files;` && |\n|  &&
+             `            return files && files[0];` && |\n|  &&
+             `          };` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!directUpload) {` && |\n|  &&
+             `            oControl.oUploadButton = new Button({` && |\n|  &&
+             `              text: oControl.getProperty("uploadButtonText"),` && |\n|  &&
+             `              enabled: path !== "",` && |\n|  &&
+             `              press: () => {` && |\n|  &&
+             `                oControl.setProperty(` && |\n|  &&
+             `                  "path",` && |\n|  &&
+             `                  oControl.oFileUploader.getProperty("value"),` && |\n|  &&
+             `                );` && |\n|  &&
+             `                const file = getFirstFile(oControl.oFileUploader);` && |\n|  &&
+             `                if (file) oControl._readFile(file);` && |\n|  &&
+             `              },` && |\n|  &&
+             `            });` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          oControl.oFileUploader = new FileUploader({` && |\n|  &&
+             `            icon: oControl.getProperty("icon"),` && |\n|  &&
+             `            iconOnly: oControl.getProperty("iconOnly"),` && |\n|  &&
+             `            buttonOnly: oControl.getProperty("buttonOnly"),` && |\n|  &&
+             `            buttonText: oControl.getProperty("buttonText"),` && |\n|  &&
+             `            style: oControl.getProperty("style"),` && |\n|  &&
+             `            fileType: oControl.getProperty("fileType"),` && |\n|  &&
+             `            visible: oControl.getProperty("visible"),` && |\n|  &&
+             `            uploadOnChange: directUpload,` && |\n|  &&
+             `            multiple: oControl.getProperty("multiple"),` && |\n|  &&
+             `            enabled: oControl.getProperty("enabled"),` && |\n|  &&
+             `            value: path,` && |\n|  &&
+             `            placeholder: oControl.getProperty("placeholder"),` && |\n|  &&
+             `            change: (oEvent) => {` && |\n|  &&
+             `              if (directUpload) return;` && |\n|  &&
+             `              const value = oEvent.getSource().getProperty("value");` && |\n|  &&
+             `              oControl.setProperty("path", value);` && |\n|  &&
+             `              if (oControl.oUploadButton) {` && |\n|  &&
+             `                oControl.oUploadButton.setEnabled(!!value);` && |\n|  &&
+             `                oControl.oUploadButton.invalidate();` && |\n|  &&
+             `              }` && |\n|  &&
+             `            },` && |\n|  &&
+             `            uploadComplete: (oEvent) => {` && |\n|  &&
+             `              if (!directUpload) return;` && |\n|  &&
+             `              const source = oEvent.getSource();` && |\n|  &&
+             `              oControl.setProperty("path", source.getProperty("value"));` && |\n|  &&
+             `              const file = getFirstFile(source);` && |\n|  &&
+             `              if (file) oControl._readFile(file);` && |\n|  &&
+             `            },` && |\n|  &&
+             `          });` && |\n|  &&
+             `` && |\n|  &&
+             `          oControl._oHBox = new HBox().addItem(oControl.oFileUploader);` && |\n|  &&
+             `          if (oControl.oUploadButton) {` && |\n|  &&
+             `            oControl._oHBox.addItem(oControl.oUploadButton);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          oRm.renderControl(oControl._oHBox);` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/MultiInputExt",` && |\n|  &&
+             `  ["sap/ui/core/Control", "sap/m/Token"],` && |\n|  &&
+             `  (Control, Token) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    return Control.extend("z2ui5.MultiInputExt", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        properties: {` && |\n|  &&
+             `          MultiInputId: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          MultiInputName: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          addedTokens: {` && |\n|  &&
+             `            type: "object",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          checkInit: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          removedTokens: {` && |\n|  &&
+             `            type: "object",` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `        events: {` && |\n|  &&
+             `          change: {` && |\n|  &&
+             `            allowPreventDefault: true,` && |\n|  &&
+             `            parameters: {},` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      init() {` && |\n|  &&
+             `        this._setControlBound = this.setControl.bind(this);` && |\n|  &&
+             `        _registerCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `      },` && |\n|  &&
+             `      exit() {` && |\n|  &&
+             `        _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onTokenUpdate(oEvent) {` && |\n|  &&
+             `        const mParameters = oEvent.mParameters;` && |\n|  &&
+             `        const isRemoved = mParameters.type === "removed";` && |\n|  &&
+             `        const rawList =` && |\n|  &&
+             `          mParameters[isRemoved ? "removedTokens" : "addedTokens"] || [];` && |\n|  &&
+             `        const tokens = rawList.map((item) => ({` && |\n|  &&
+             `          KEY: item.getKey(),` && |\n|  &&
+             `          TEXT: item.getText(),` && |\n|  &&
+             `        }));` && |\n|  &&
+             `        this.setProperty("addedTokens", isRemoved ? [] : tokens);` && |\n|  &&
+             `        this.setProperty("removedTokens", isRemoved ? tokens : []);` && |\n|  &&
+             `        this.fireChange();` && |\n|  &&
+             `      },` && |\n|  &&
+             `      renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `      setControl() {` && |\n|  &&
+             `        const table =` && |\n|  &&
+             `          z2ui5.oView && z2ui5.oView.byId(this.getProperty("MultiInputId"));` && |\n|  &&
+             `        if (!table || this.getProperty("checkInit")) return;` && |\n|  &&
+             `        this.setProperty("checkInit", true);` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          table.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n|  &&
+             `          // Custom validator: turn any free-text entry into a Token where` && |\n|  &&
+             `          // both key and visible text equal the input string.` && |\n|  &&
+             `          table.addValidator(({ text }) => new Token({ key: text, text }));` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("MultiInputExt.setControl: setup failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/UploadSetExt", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.UploadSetExt", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        uploadSetId: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        fileData: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        fileName: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        mediaType: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        fileSize: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        removedFileName: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `          defaultValue: "",` && |\n|  &&
+             `        },` && |\n|  &&
+             `        checkInit: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: false,` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `      events: {` && |\n|  &&
+             `        change: {` && |\n|  &&
+             `          allowPreventDefault: true,` && |\n|  &&
+             `          parameters: {},` && |\n|  &&
+             `        },` && |\n|  &&
+             `        remove: {` && |\n|  &&
+             `          allowPreventDefault: true,` && |\n|  &&
+             `          parameters: {},` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    init() {` && |\n|  &&
+             `      this._setControlBound = this.setControl.bind(this);` && |\n|  &&
+             `      _registerCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _readFile(file) {` && |\n|  &&
+             `      const reader = new FileReader();` && |\n|  &&
+             `      reader.onload = () => {` && |\n|  &&
+             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `        this.setProperty("fileData", reader.result);` && |\n|  &&
+             `        this.setProperty("fileName", file.name);` && |\n|  &&
+             `        this.setProperty("mediaType", file.type);` && |\n|  &&
+             `        this.setProperty("fileSize", String(file.size));` && |\n|  &&
+             `        this.fireChange();` && |\n|  &&
+             `      };` && |\n|  &&
+             `      reader.onerror = () =>` && |\n|  &&
+             `        _logError("UploadSetExt: FileReader failed", reader.error);` && |\n|  &&
+             `      reader.readAsDataURL(file);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    onItemAdded(oEvent) {` && |\n|  &&
+             `      const item = oEvent.getParameter("item");` && |\n|  &&
+             `      const file = item && item.getFileObject ? item.getFileObject() : null;` && |\n|  &&
+             `      if (file) this._readFile(file);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    onItemRemoved(oEvent) {` && |\n|  &&
+             `      const item = oEvent.getParameter("item");` && |\n|  &&
+             `      const name = item && item.getFileName ? item.getFileName() : "";` && |\n|  &&
+             `      this.setProperty("removedFileName", name);` && |\n|  &&
+             `      this.fireRemove();` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `    setControl() {` && |\n|  &&
+             `      const uploadSet =` && |\n|  &&
+             `        z2ui5.oView && z2ui5.oView.byId(this.getProperty("uploadSetId"));` && |\n|  &&
+             `      if (!uploadSet || this.getProperty("checkInit")) return;` && |\n|  &&
+             `      this.setProperty("checkInit", true);` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));` && |\n|  &&
+             `        uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("UploadSetExt.setControl: setup failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/SmartMultiInputExt",` && |\n|  &&
+             `  ["sap/ui/core/Control"],` && |\n|  &&
+             `  (Control) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    return Control.extend("z2ui5.SmartMultiInputExt", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        properties: {` && |\n|  &&
+             `          multiInputId: {` && |\n|  &&
+             `            type: "string",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          addedTokens: {` && |\n|  &&
+             `            type: "object",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          removedTokens: {` && |\n|  &&
+             `            type: "object",` && |\n|  &&
+             `          },` && |\n|  &&
+             `          rangeData: {` && |\n|  &&
+             `            type: "object",` && |\n|  &&
+             `            defaultValue: [],` && |\n|  &&
+             `          },` && |\n|  &&
+             `          checkInit: {` && |\n|  &&
+             `            type: "boolean",` && |\n|  &&
+             `            defaultValue: false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `        events: {` && |\n|  &&
+             `          change: {` && |\n|  &&
+             `            allowPreventDefault: true,` && |\n|  &&
+             `            parameters: {},` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      init() {` && |\n|  &&
+             `        this._setControlBound = this.setControl.bind(this);` && |\n|  &&
+             `        this._oInput = null;` && |\n|  &&
+             `        this._oPendingInnerControlsCreated = null;` && |\n|  &&
+             `        this._bInnerControlsCreated = false;` && |\n|  &&
+             `        _registerCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `      },` && |\n|  &&
+             `      exit() {` && |\n|  &&
+             `        _unregisterCallback("onAfterRendering", this._setControlBound);` && |\n|  &&
+             `        // Resolve any still-pending promise so awaiters don't hang.` && |\n|  &&
+             `        if (this._oPendingInnerControlsCreated) {` && |\n|  &&
+             `          this._oPendingInnerControlsCreated(null);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        this._oPendingInnerControlsCreated = null;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onTokenUpdate(oEvent) {` && |\n|  &&
+             `        const mParameters = oEvent.mParameters;` && |\n|  &&
+             `        const isRemoved = mParameters.type === "removed";` && |\n|  &&
+             `        const rawList =` && |\n|  &&
+             `          mParameters[isRemoved ? "removedTokens" : "addedTokens"] || [];` && |\n|  &&
+             `        const mappedTokens = rawList.map((item) => ({` && |\n|  &&
+             `          KEY: item.getKey(),` && |\n|  &&
+             `          TEXT: item.getText(),` && |\n|  &&
+             `        }));` && |\n|  &&
+             `        this.setProperty("addedTokens", isRemoved ? [] : mappedTokens);` && |\n|  &&
+             `        this.setProperty("removedTokens", isRemoved ? mappedTokens : []);` && |\n|  &&
+             `` && |\n|  &&
+             `        // Mirror each range entry with the visible token text + long key` && |\n|  &&
+             `        // so the backend has enough info to re-render the input later.` && |\n|  &&
+             `        const source = oEvent.getSource();` && |\n|  &&
+             `        const tokens = source.getTokens();` && |\n|  &&
+             `        const rangeData = source.getRangeData() || [];` && |\n|  &&
+             `        const enrichedRanges = rangeData.map((oRangeData, index) => {` && |\n|  &&
+             `          const token = tokens[index];` && |\n|  &&
+             `          oRangeData.tokenText = token ? token.getText() : "";` && |\n|  &&
+             `          oRangeData.tokenLongKey = token ? token.data("longKey") : undefined;` && |\n|  &&
+             `          return oRangeData;` && |\n|  &&
+             `        });` && |\n|  &&
+             `        this.setProperty("rangeData", enrichedRanges);` && |\n|  &&
+             `        this.fireChange();` && |\n|  &&
+             `      },` && |\n|  &&
+             `      async setRangeData(aRangeData) {` && |\n|  &&
+             `        this.setProperty("rangeData", aRangeData);` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const input = await this.inputInitialized();` && |\n|  &&
+             `          if ((this.isDestroyed && this.isDestroyed()) || !input) return;` && |\n|  &&
+             `` && |\n|  &&
+             `          // Convert the ABAP-style uppercase keys to the camelCase property` && |\n|  &&
+             `          // names the smart multi input expects. "keyField" needs its capital` && |\n|  &&
+             `          // F preserved.` && |\n|  &&
+             `          const normalizedRangeData = aRangeData.map((oRangeData) => {` && |\n|  &&
+             `            const out = {};` && |\n|  &&
+             `            for (const [key, value] of Object.entries(oRangeData)) {` && |\n|  &&
+             `              const lower = key.toLowerCase();` && |\n|  &&
+             `              const finalKey = lower === "keyfield" ? "keyField" : lower;` && |\n|  &&
              |\n|.
     result = result &&
-             `              out[finalKey] = value;` && |\n| &&
-             `            }` && |\n| &&
-             `            return out;` && |\n| &&
-             `          });` && |\n| &&
-             `          input.setRangeData(normalizedRangeData);` && |\n| &&
-             `` && |\n| &&
-             `          // We need to set token text explicitly, as setRangeData does no` && |\n| &&
-             `          // recalculation.` && |\n| &&
-             `          const inputTokens = input.getTokens() || [];` && |\n| &&
-             `          for (const [index, token] of inputTokens.entries()) {` && |\n| &&
-             `            const rangeItem = aRangeData[index];` && |\n| &&
-             `            if (!rangeItem) continue;` && |\n| &&
-             `            const { TOKENLONGKEY, TOKENTEXT } = rangeItem;` && |\n| &&
-             `            token.data("longKey", TOKENLONGKEY);` && |\n| &&
-             `            token.data("range", null);` && |\n| &&
-             `            if (TOKENTEXT) token.setText(TOKENTEXT);` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("SmartMultiInputExt.setRangeData failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `      renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `      setControl() {` && |\n| &&
-             `        const input =` && |\n| &&
-             `          z2ui5.oView && z2ui5.oView.byId(this.getProperty("multiInputId"));` && |\n| &&
-             `        if (!input || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
-             `        try {` && |\n| &&
-             `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
-             `          input.attachInnerControlsCreated(` && |\n| &&
-             `            this.onInnerControlsCreated.bind(this),` && |\n| &&
-             `          );` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("SmartMultiInputExt.setControl: setup failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `      // Returns a Promise that resolves once the smart multi input's inner` && |\n| &&
-             `      // controls exist - they are created lazily on first interaction.` && |\n| &&
-             `      inputInitialized() {` && |\n| &&
-             `        return new Promise((resolve) => {` && |\n| &&
-             `          if (this._bInnerControlsCreated) {` && |\n| &&
-             `            resolve(this._oInput);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            this._oPendingInnerControlsCreated = resolve;` && |\n| &&
-             `          }` && |\n| &&
-             `        });` && |\n| &&
-             `      },` && |\n| &&
-             `      onInnerControlsCreated(oEvent) {` && |\n| &&
-             `        this._oInput = oEvent.getSource();` && |\n| &&
-             `        if (this._oPendingInnerControlsCreated) {` && |\n| &&
-             `          this._oPendingInnerControlsCreated(this._oInput);` && |\n| &&
-             `        }` && |\n| &&
-             `        this._oPendingInnerControlsCreated = null;` && |\n| &&
-             `        this._bInnerControlsCreated = true;` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/CameraPicture",` && |\n| &&
-             `  ["sap/ui/core/Control", "sap/m/Dialog", "sap/m/Button", "sap/ui/core/HTML"],` && |\n| &&
-             `  (Control, Dialog, Button, HTML) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `    const _CTX_2D_OPTS = { willReadFrequently: true };` && |\n| &&
-             `    const _THUMB_W = 300;` && |\n| &&
-             `    return Control.extend("z2ui5.CameraPicture", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        properties: {` && |\n| &&
-             `          id: { type: "string" },` && |\n| &&
-             `          value: { type: "string" },` && |\n| &&
-             `          thumbnail: { type: "string" },` && |\n| &&
-             `          press: { type: "string" },` && |\n| &&
-             `          width: { type: "string", defaultValue: "200" },` && |\n| &&
-             `          height: { type: "string", defaultValue: "200" },` && |\n| &&
-             `          autoplay: { type: "boolean", defaultValue: true },` && |\n| &&
-             `          facingMode: { type: "string" },` && |\n| &&
-             `          deviceId: { type: "string" },` && |\n| &&
-             `        },` && |\n| &&
-             `        events: {` && |\n| &&
-             `          OnPhoto: {` && |\n| &&
-             `            allowPreventDefault: true,` && |\n| &&
-             `            parameters: {` && |\n| &&
-             `              photo: {` && |\n| &&
-             `                type: "string",` && |\n| &&
-             `              },` && |\n| &&
-             `            },` && |\n| &&
-             `          },` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      capture() {` && |\n| &&
-             `        const video = document.getElementById(``${this.getId()}-video``);` && |\n| &&
-             `        const canvas = document.getElementById(``${this.getId()}-canvas``);` && |\n| &&
-             `        if (!video || !canvas) return;` && |\n| &&
-             `` && |\n| &&
-             `        const videoWidth = video.videoWidth;` && |\n| &&
-             `        const videoHeight = video.videoHeight;` && |\n| &&
-             `        canvas.width = videoWidth;` && |\n| &&
-             `        canvas.height = videoHeight;` && |\n| &&
-             `` && |\n| &&
-             `        const ctx = canvas.getContext("2d", _CTX_2D_OPTS);` && |\n| &&
-             `        if (!ctx) return;` && |\n| &&
-             `        ctx.drawImage(video, 0, 0, videoWidth, videoHeight);` && |\n| &&
-             `` && |\n| &&
-             `        // Full-resolution JPEG (quality 0.85) for the value, plus a small` && |\n| &&
-             `        // thumbnail (max width _THUMB_W) at lower quality for previews.` && |\n| &&
-             `        let resultb64;` && |\n| &&
-             `        try {` && |\n| &&
-             `          resultb64 = canvas.toDataURL("image/jpeg", 0.85);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("CameraPicture: canvas toDataURL failed", e);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        const thumbH = videoWidth` && |\n| &&
-             `          ? Math.round((videoHeight * _THUMB_W) / videoWidth)` && |\n| &&
-             `          : _THUMB_W;` && |\n| &&
-             `        const thumbCanvas = document.createElement("canvas");` && |\n| &&
-             `        thumbCanvas.width = _THUMB_W;` && |\n| &&
-             `        thumbCanvas.height = thumbH;` && |\n| &&
-             `        const thumbCtx = thumbCanvas.getContext("2d", _CTX_2D_OPTS);` && |\n| &&
-             `        if (thumbCtx) thumbCtx.drawImage(canvas, 0, 0, _THUMB_W, thumbH);` && |\n| &&
-             `` && |\n| &&
-             `        let thumbB64 = "";` && |\n| &&
-             `        try {` && |\n| &&
-             `          thumbB64 = thumbCanvas.toDataURL("image/jpeg", 0.7);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          _logError("CameraPicture: thumb toDataURL failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `        this.setProperty("value", resultb64);` && |\n| &&
-             `        this.setProperty("thumbnail", thumbB64);` && |\n| &&
-             `        this.fireOnPhoto({ photo: resultb64 });` && |\n| &&
-             `        this._stopCamera();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _stopCamera() {` && |\n| &&
-             `        // Stop every track of the active stream so the OS frees the camera.` && |\n| &&
-             `        if (this._stream) {` && |\n| &&
-             `          for (const track of this._stream.getTracks()) track.stop();` && |\n| &&
-             `        }` && |\n| &&
-             `        this._stream = null;` && |\n| &&
-             `        const video = document.getElementById(``${this.getId()}-video``);` && |\n| &&
-             `        if (video) video.srcObject = null;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onPicture() {` && |\n| &&
-             `        if (this._oScanDialog && this._oScanDialog.isOpen()) return;` && |\n| &&
-             `        if (!this._oScanDialog) {` && |\n| &&
-             `          this._oScanDialog = new Dialog({` && |\n| &&
-             `            title: "Device Photo Function",` && |\n| &&
-             `            contentWidth: "640px",` && |\n| &&
-             `            contentHeight: "480px",` && |\n| &&
-             `            horizontalScrolling: false,` && |\n| &&
-             `            verticalScrolling: false,` && |\n| &&
-             `            stretch: true,` && |\n| &&
-             `            afterClose: () => this._stopCamera(),` && |\n| &&
-             `            content: [` && |\n| &&
-             `              new HTML({` && |\n| &&
-             `                id: ``${this.getId()}PictureContainer``,` && |\n| &&
-             `                content: ``<video style="width:100%;height:100%;object-fit:contain;" autoplay="true" id="${this.getId()}-video">``,` && |\n| &&
-             `              }),` && |\n| &&
-             `              new Button({` && |\n| &&
-             `                text: "Capture",` && |\n| &&
-             `                press: () => {` && |\n| &&
-             `                  this.capture();` && |\n| &&
-             `                  this._oScanDialog.close();` && |\n| &&
-             `                },` && |\n| &&
-             `              }),` && |\n| &&
-             `              new HTML({` && |\n| &&
-             `                content: ``<canvas hidden id="${this.getId()}-canvas" style="overflow:auto"></canvas>``,` && |\n| &&
-             `              }),` && |\n| &&
-             `            ],` && |\n| &&
-             `            endButton: new Button({` && |\n| &&
-             `              text: "Cancel",` && |\n| &&
-             `              press: () => {` && |\n| &&
-             `                this._stopCamera();` && |\n| &&
-             `                this._oScanDialog.close();` && |\n| &&
-             `              },` && |\n| &&
-             `            }),` && |\n| &&
-             `          });` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        this._oScanDialog.attachEventOnce("afterOpen", async () => {` && |\n| &&
-             `          if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `          const video = document.getElementById(``${this.getId()}-video``);` && |\n| &&
-             `          if (!video) {` && |\n| &&
-             `            _logError(` && |\n| &&
-             `              "CameraPicture: video element not found after dialog open",` && |\n| &&
-             `            );` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          const facingMode = this.getProperty("facingMode");` && |\n| &&
-             `          const deviceId = this.getProperty("deviceId");` && |\n| &&
-             `          const options = {` && |\n| &&
-             `            video: { width: { ideal: 1920 }, height: { ideal: 1080 } },` && |\n| &&
-             `          };` && |\n| &&
-             `          if (deviceId) options.video.deviceId = deviceId;` && |\n| &&
-             `          if (facingMode) options.video.facingMode = { exact: facingMode };` && |\n| &&
-             `` && |\n| &&
-             `          try {` && |\n| &&
-             `            const md = navigator.mediaDevices;` && |\n| &&
-             `            if (!md || !md.getUserMedia) return;` && |\n| &&
-             `            const stream = await md.getUserMedia(options);` && |\n| &&
-             `            if (!stream) return;` && |\n| &&
-             `            // Guard: the control could have been destroyed during the` && |\n| &&
-             `            // getUserMedia await. Release the camera if so.` && |\n| &&
-             `            if (this.isDestroyed && this.isDestroyed()) {` && |\n| &&
-             `              for (const t of stream.getTracks()) t.stop();` && |\n| &&
-             `              return;` && |\n| &&
-             `            }` && |\n| &&
-             `            this._stream = stream;` && |\n| &&
-             `            video.srcObject = stream;` && |\n| &&
-             `          } catch (error) {` && |\n| &&
-             `            _logError("CameraPicture: getUserMedia failed", error);` && |\n| &&
-             `          }` && |\n| &&
-             `        });` && |\n| &&
-             `        this._oScanDialog.open();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      exit() {` && |\n| &&
-             `        this._stopCamera();` && |\n| &&
-             `        if (this._oButton) this._oButton.destroy();` && |\n| &&
-             `        if (this._oScanDialog) this._oScanDialog.destroy();` && |\n| &&
-             `      },` && |\n| &&
-             `      renderer: {` && |\n| &&
-             `        apiVersion: 2,` && |\n| &&
-             `        render(oRm, oControl) {` && |\n| &&
-             `          if (!oControl._oButton) {` && |\n| &&
-             `            oControl._oButton = new Button({` && |\n| &&
-             `              icon: "sap-icon://camera",` && |\n| &&
-             `              text: "Camera",` && |\n| &&
-             `              press: oControl.onPicture.bind(oControl),` && |\n| &&
-             `            });` && |\n| &&
-             `          }` && |\n| &&
-             `          oRm.renderControl(oControl._oButton);` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define(` && |\n| &&
-             `  "z2ui5/CameraSelector",` && |\n| &&
-             `  ["sap/m/ComboBox", "sap/ui/core/Item", "sap/m/ComboBoxRenderer"],` && |\n| &&
-             `  (ComboBox, Item, ComboBoxRenderer) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `    return ComboBox.extend("z2ui5.CameraSelector", {` && |\n| &&
-             `      async init() {` && |\n| &&
-             `        ComboBox.prototype.init.call(this);` && |\n| &&
-             `        try {` && |\n| &&
-             `          const md = navigator.mediaDevices;` && |\n| &&
-             `          if (!md || !md.enumerateDevices) return;` && |\n| &&
-             `          const devices = await md.enumerateDevices();` && |\n| &&
-             `          if (!devices) return;` && |\n| &&
-             `          for (const device of devices) {` && |\n| &&
-             `            // Only video inputs are relevant; also stop adding items when the` && |\n| &&
-             `            // ComboBox has been destroyed during the await.` && |\n| &&
-             `            if (device.kind !== "videoinput") continue;` && |\n| &&
-             `            if (this.isDestroyed && this.isDestroyed()) return;` && |\n| &&
-             `            this.addItem(` && |\n| &&
-             `              new Item({ key: device.deviceId, text: device.label }),` && |\n| &&
-             `            );` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (err) {` && |\n| &&
-             `          _logError("CameraDeviceList: enumerateDevices failed", err);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      renderer: ComboBoxRenderer,` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/UITableExt", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  const opSymbols = { EQ: "", NE: "!", LT: "<", LE: "<=", GT: ">", GE: ">=" };` && |\n| &&
-             `  const filterDisplayFns = {` && |\n| &&
-             `    Contains: (v) => ``*${v ?? ""}*``,` && |\n| &&
-             `    StartsWith: (v) => ``^${v ?? ""}``,` && |\n| &&
-             `    EndsWith: (v) => ``${v ?? ""}$``,` && |\n| &&
-             `  };` && |\n| &&
-             `` && |\n| &&
-             `  return Control.extend("z2ui5.UITableExt", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        tableId: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    init() {` && |\n| &&
-             `      this._beforeBound = () => {` && |\n| &&
-             `        this.readFilter();` && |\n| &&
-             `        this.readSort();` && |\n| &&
-             `      };` && |\n| &&
-             `      this._afterBound = () => {` && |\n| &&
-             `        this.setFilter();` && |\n| &&
-             `        this.setSort();` && |\n| &&
-             `      };` && |\n| &&
-             `      _registerCallback("onBeforeRoundtrip", this._beforeBound);` && |\n| &&
-             `      _registerCallback("onAfterRoundtrip", this._afterBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      _unregisterCallback("onBeforeRoundtrip", this._beforeBound);` && |\n| &&
-             `      _unregisterCallback("onAfterRoundtrip", this._afterBound);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _getTable() {` && |\n| &&
-             `      if (!z2ui5.oView) return undefined;` && |\n| &&
-             `      return z2ui5.oView.byId(this.getProperty("tableId"));` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    readFilter() {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const table = this._getTable();` && |\n| &&
-             `        const binding = table && table.getBinding();` && |\n| &&
-             `        this.aFilters = binding ? binding.aFilters : undefined;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("UITableExt.readFilter failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _applyWhenRendered(oTable, fn) {` && |\n| &&
-             `      if (oTable.getDomRef()) {` && |\n| &&
-             `        fn();` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
-             `      // Not rendered yet -> run ``fn`` once the next render completes.` && |\n| &&
-             `      const delegate = {` && |\n| &&
-             `        onAfterRendering: () => {` && |\n| &&
-             `          oTable.removeEventDelegate(delegate);` && |\n| &&
-             `          if (!(this.isDestroyed && this.isDestroyed())) fn();` && |\n| &&
-             `        },` && |\n| &&
-             `      };` && |\n| &&
-             `      oTable.addEventDelegate(delegate);` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _applyFilters(oTable, aFilters) {` && |\n| &&
-             `      if (!aFilters) return;` && |\n| &&
-             `      const binding = oTable.getBinding();` && |\n| &&
-             `      if (!binding) return;` && |\n| &&
-             `      binding.filter(aFilters);` && |\n| &&
-             `      const columns = oTable.getColumns();` && |\n| &&
-             `` && |\n| &&
-             `      for (const oFilter of aFilters) {` && |\n| &&
-             `        // Multi-filter? Pick the inner filter for the column lookup.` && |\n| &&
-             `        let sProperty = oFilter.sPath;` && |\n| &&
-             `        if (!sProperty && oFilter.aFilters && oFilter.aFilters[0]) {` && |\n| &&
-             `          sProperty = oFilter.aFilters[0].sPath;` && |\n| &&
-             `        }` && |\n| &&
-             `        if (!sProperty) continue;` && |\n| &&
-             `` && |\n| &&
-             `        const operator = oFilter.sOperator;` && |\n| &&
-             `        // Pick the most meaningful value to display in the column header.` && |\n| &&
-             `        let vValue = oFilter.oValue1;` && |\n| &&
-             `        if (vValue === undefined) vValue = oFilter.oValue2;` && |\n| &&
-             `        if (vValue === undefined && oFilter.aFilters && oFilter.aFilters[0]) {` && |\n| &&
-             `          vValue = oFilter.aFilters[0].oValue1;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        // Choose how to format the column header label for this operator.` && |\n| &&
-             `        let displayFn;` && |\n| &&
-             `        if (operator === "BT") {` && |\n| &&
-             `          // "between" displays "from...to".` && |\n| &&
-             `          displayFn = (v) => {` && |\n| &&
-             `            const from = v == null ? "" : v;` && |\n| &&
-             `            const to = oFilter.oValue2 == null ? "" : oFilter.oValue2;` && |\n| &&
-             `            return ``${from}...${to}``;` && |\n| &&
-             `          };` && |\n| &&
-             `        } else if (filterDisplayFns[operator]) {` && |\n| &&
-             `          displayFn = filterDisplayFns[operator];` && |\n| &&
-             `        } else {` && |\n| &&
-             `          // Fallback: optional operator prefix (e.g. "!" for NE) + value.` && |\n| &&
-             `          const prefix = opSymbols[operator] || "";` && |\n| &&
-             `          displayFn = (v) => ``${prefix}${v == null ? "" : v}``;` && |\n| &&
-             `        }` && |\n| &&
-             `        const display = displayFn(vValue);` && |\n| &&
-             `` && |\n| &&
-             `        for (const oCol of columns) {` && |\n| &&
-             `          if (` && |\n| &&
-             `            oCol.getFilterProperty &&` && |\n| &&
-             `            oCol.getFilterProperty() === sProperty` && |\n| &&
-             `          ) {` && |\n| &&
-             `            oCol.setFilterValue(display);` && |\n| &&
-             `            oCol.setFiltered(!!display);` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _applyToTable(applyFn, errorMsg) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const oTable = this._getTable();` && |\n| &&
-             `        if (!oTable) return;` && |\n| &&
+             `              out[finalKey] = value;` && |\n|  &&
+             `            }` && |\n|  &&
+             `            return out;` && |\n|  &&
+             `          });` && |\n|  &&
+             `          input.setRangeData(normalizedRangeData);` && |\n|  &&
+             `` && |\n|  &&
+             `          // We need to set token text explicitly, as setRangeData does no` && |\n|  &&
+             `          // recalculation.` && |\n|  &&
+             `          const inputTokens = input.getTokens() || [];` && |\n|  &&
+             `          for (const [index, token] of inputTokens.entries()) {` && |\n|  &&
+             `            const rangeItem = aRangeData[index];` && |\n|  &&
+             `            if (!rangeItem) continue;` && |\n|  &&
+             `            const { TOKENLONGKEY, TOKENTEXT } = rangeItem;` && |\n|  &&
+             `            token.data("longKey", TOKENLONGKEY);` && |\n|  &&
+             `            token.data("range", null);` && |\n|  &&
+             `            if (TOKENTEXT) token.setText(TOKENTEXT);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("SmartMultiInputExt.setRangeData failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `      renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `      setControl() {` && |\n|  &&
+             `        const input =` && |\n|  &&
+             `          z2ui5.oView && z2ui5.oView.byId(this.getProperty("multiInputId"));` && |\n|  &&
+             `        if (!input || this.getProperty("checkInit")) return;` && |\n|  &&
+             `        this.setProperty("checkInit", true);` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n|  &&
+             `          input.attachInnerControlsCreated(` && |\n|  &&
+             `            this.onInnerControlsCreated.bind(this),` && |\n|  &&
+             `          );` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("SmartMultiInputExt.setControl: setup failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `      // Returns a Promise that resolves once the smart multi input's inner` && |\n|  &&
+             `      // controls exist - they are created lazily on first interaction.` && |\n|  &&
+             `      inputInitialized() {` && |\n|  &&
+             `        return new Promise((resolve) => {` && |\n|  &&
+             `          if (this._bInnerControlsCreated) {` && |\n|  &&
+             `            resolve(this._oInput);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            this._oPendingInnerControlsCreated = resolve;` && |\n|  &&
+             `          }` && |\n|  &&
+             `        });` && |\n|  &&
+             `      },` && |\n|  &&
+             `      onInnerControlsCreated(oEvent) {` && |\n|  &&
+             `        this._oInput = oEvent.getSource();` && |\n|  &&
+             `        if (this._oPendingInnerControlsCreated) {` && |\n|  &&
+             `          this._oPendingInnerControlsCreated(this._oInput);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        this._oPendingInnerControlsCreated = null;` && |\n|  &&
+             `        this._bInnerControlsCreated = true;` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/CameraPicture",` && |\n|  &&
+             `  ["sap/ui/core/Control", "sap/m/Dialog", "sap/m/Button", "sap/ui/core/HTML"],` && |\n|  &&
+             `  (Control, Dialog, Button, HTML) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `    const _CTX_2D_OPTS = { willReadFrequently: true };` && |\n|  &&
+             `    const _THUMB_W = 300;` && |\n|  &&
+             `    return Control.extend("z2ui5.CameraPicture", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        properties: {` && |\n|  &&
+             `          id: { type: "string" },` && |\n|  &&
+             `          value: { type: "string" },` && |\n|  &&
+             `          thumbnail: { type: "string" },` && |\n|  &&
+             `          press: { type: "string" },` && |\n|  &&
+             `          width: { type: "string", defaultValue: "200" },` && |\n|  &&
+             `          height: { type: "string", defaultValue: "200" },` && |\n|  &&
+             `          autoplay: { type: "boolean", defaultValue: true },` && |\n|  &&
+             `          facingMode: { type: "string" },` && |\n|  &&
+             `          deviceId: { type: "string" },` && |\n|  &&
+             `        },` && |\n|  &&
+             `        events: {` && |\n|  &&
+             `          OnPhoto: {` && |\n|  &&
+             `            allowPreventDefault: true,` && |\n|  &&
+             `            parameters: {` && |\n|  &&
+             `              photo: {` && |\n|  &&
+             `                type: "string",` && |\n|  &&
+             `              },` && |\n|  &&
+             `            },` && |\n|  &&
+             `          },` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      capture() {` && |\n|  &&
+             `        const video = document.getElementById(``${this.getId()}-video``);` && |\n|  &&
+             `        const canvas = document.getElementById(``${this.getId()}-canvas``);` && |\n|  &&
+             `        if (!video || !canvas) return;` && |\n|  &&
+             `` && |\n|  &&
+             `        const videoWidth = video.videoWidth;` && |\n|  &&
+             `        const videoHeight = video.videoHeight;` && |\n|  &&
+             `        canvas.width = videoWidth;` && |\n|  &&
+             `        canvas.height = videoHeight;` && |\n|  &&
+             `` && |\n|  &&
+             `        const ctx = canvas.getContext("2d", _CTX_2D_OPTS);` && |\n|  &&
+             `        if (!ctx) return;` && |\n|  &&
+             `        ctx.drawImage(video, 0, 0, videoWidth, videoHeight);` && |\n|  &&
+             `` && |\n|  &&
+             `        // Full-resolution JPEG (quality 0.85) for the value, plus a small` && |\n|  &&
+             `        // thumbnail (max width _THUMB_W) at lower quality for previews.` && |\n|  &&
+             `        let resultb64;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          resultb64 = canvas.toDataURL("image/jpeg", 0.85);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("CameraPicture: canvas toDataURL failed", e);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        const thumbH = videoWidth` && |\n|  &&
+             `          ? Math.round((videoHeight * _THUMB_W) / videoWidth)` && |\n|  &&
+             `          : _THUMB_W;` && |\n|  &&
+             `        const thumbCanvas = document.createElement("canvas");` && |\n|  &&
+             `        thumbCanvas.width = _THUMB_W;` && |\n|  &&
+             `        thumbCanvas.height = thumbH;` && |\n|  &&
+             `        const thumbCtx = thumbCanvas.getContext("2d", _CTX_2D_OPTS);` && |\n|  &&
+             `        if (thumbCtx) thumbCtx.drawImage(canvas, 0, 0, _THUMB_W, thumbH);` && |\n|  &&
+             `` && |\n|  &&
+             `        let thumbB64 = "";` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          thumbB64 = thumbCanvas.toDataURL("image/jpeg", 0.7);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          _logError("CameraPicture: thumb toDataURL failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `        this.setProperty("value", resultb64);` && |\n|  &&
+             `        this.setProperty("thumbnail", thumbB64);` && |\n|  &&
+             `        this.fireOnPhoto({ photo: resultb64 });` && |\n|  &&
+             `        this._stopCamera();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _stopCamera() {` && |\n|  &&
+             `        // Stop every track of the active stream so the OS frees the camera.` && |\n|  &&
+             `        if (this._stream) {` && |\n|  &&
+             `          for (const track of this._stream.getTracks()) track.stop();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        this._stream = null;` && |\n|  &&
+             `        const video = document.getElementById(``${this.getId()}-video``);` && |\n|  &&
+             `        if (video) video.srcObject = null;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onPicture() {` && |\n|  &&
+             `        if (this._oScanDialog && this._oScanDialog.isOpen()) return;` && |\n|  &&
+             `        if (!this._oScanDialog) {` && |\n|  &&
+             `          this._oScanDialog = new Dialog({` && |\n|  &&
+             `            title: "Device Photo Function",` && |\n|  &&
+             `            contentWidth: "640px",` && |\n|  &&
+             `            contentHeight: "480px",` && |\n|  &&
+             `            horizontalScrolling: false,` && |\n|  &&
+             `            verticalScrolling: false,` && |\n|  &&
+             `            stretch: true,` && |\n|  &&
+             `            afterClose: () => this._stopCamera(),` && |\n|  &&
+             `            content: [` && |\n|  &&
+             `              new HTML({` && |\n|  &&
+             `                id: ``${this.getId()}PictureContainer``,` && |\n|  &&
+             `                content: ``<video style="width:100%;height:100%;object-fit:contain;" autoplay="true" id="${this.getId()}-video">``,` && |\n|  &&
+             `              }),` && |\n|  &&
+             `              new Button({` && |\n|  &&
+             `                text: "Capture",` && |\n|  &&
+             `                press: () => {` && |\n|  &&
+             `                  this.capture();` && |\n|  &&
+             `                  this._oScanDialog.close();` && |\n|  &&
+             `                },` && |\n|  &&
+             `              }),` && |\n|  &&
+             `              new HTML({` && |\n|  &&
+             `                content: ``<canvas hidden id="${this.getId()}-canvas" style="overflow:auto"></canvas>``,` && |\n|  &&
+             `              }),` && |\n|  &&
+             `            ],` && |\n|  &&
+             `            endButton: new Button({` && |\n|  &&
+             `              text: "Cancel",` && |\n|  &&
+             `              press: () => {` && |\n|  &&
+             `                this._stopCamera();` && |\n|  &&
+             `                this._oScanDialog.close();` && |\n|  &&
+             `              },` && |\n|  &&
+             `            }),` && |\n|  &&
+             `          });` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        this._oScanDialog.attachEventOnce("afterOpen", async () => {` && |\n|  &&
+             `          if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `          const video = document.getElementById(``${this.getId()}-video``);` && |\n|  &&
+             `          if (!video) {` && |\n|  &&
+             `            _logError(` && |\n|  &&
+             `              "CameraPicture: video element not found after dialog open",` && |\n|  &&
+             `            );` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          const facingMode = this.getProperty("facingMode");` && |\n|  &&
+             `          const deviceId = this.getProperty("deviceId");` && |\n|  &&
+             `          const options = {` && |\n|  &&
+             `            video: { width: { ideal: 1920 }, height: { ideal: 1080 } },` && |\n|  &&
+             `          };` && |\n|  &&
+             `          if (deviceId) options.video.deviceId = deviceId;` && |\n|  &&
+             `          if (facingMode) options.video.facingMode = { exact: facingMode };` && |\n|  &&
+             `` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const md = navigator.mediaDevices;` && |\n|  &&
+             `            if (!md || !md.getUserMedia) return;` && |\n|  &&
+             `            const stream = await md.getUserMedia(options);` && |\n|  &&
+             `            if (!stream) return;` && |\n|  &&
+             `            // Guard: the control could have been destroyed during the` && |\n|  &&
+             `            // getUserMedia await. Release the camera if so.` && |\n|  &&
+             `            if (this.isDestroyed && this.isDestroyed()) {` && |\n|  &&
+             `              for (const t of stream.getTracks()) t.stop();` && |\n|  &&
+             `              return;` && |\n|  &&
+             `            }` && |\n|  &&
+             `            this._stream = stream;` && |\n|  &&
+             `            video.srcObject = stream;` && |\n|  &&
+             `          } catch (error) {` && |\n|  &&
+             `            _logError("CameraPicture: getUserMedia failed", error);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        });` && |\n|  &&
+             `        this._oScanDialog.open();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      exit() {` && |\n|  &&
+             `        this._stopCamera();` && |\n|  &&
+             `        if (this._oButton) this._oButton.destroy();` && |\n|  &&
+             `        if (this._oScanDialog) this._oScanDialog.destroy();` && |\n|  &&
+             `      },` && |\n|  &&
+             `      renderer: {` && |\n|  &&
+             `        apiVersion: 2,` && |\n|  &&
+             `        render(oRm, oControl) {` && |\n|  &&
+             `          if (!oControl._oButton) {` && |\n|  &&
+             `            oControl._oButton = new Button({` && |\n|  &&
+             `              icon: "sap-icon://camera",` && |\n|  &&
+             `              text: "Camera",` && |\n|  &&
+             `              press: oControl.onPicture.bind(oControl),` && |\n|  &&
+             `            });` && |\n|  &&
+             `          }` && |\n|  &&
+             `          oRm.renderControl(oControl._oButton);` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define(` && |\n|  &&
+             `  "z2ui5/CameraSelector",` && |\n|  &&
+             `  ["sap/m/ComboBox", "sap/ui/core/Item", "sap/m/ComboBoxRenderer"],` && |\n|  &&
+             `  (ComboBox, Item, ComboBoxRenderer) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `    return ComboBox.extend("z2ui5.CameraSelector", {` && |\n|  &&
+             `      async init() {` && |\n|  &&
+             `        ComboBox.prototype.init.call(this);` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const md = navigator.mediaDevices;` && |\n|  &&
+             `          if (!md || !md.enumerateDevices) return;` && |\n|  &&
+             `          const devices = await md.enumerateDevices();` && |\n|  &&
+             `          if (!devices) return;` && |\n|  &&
+             `          for (const device of devices) {` && |\n|  &&
+             `            // Only video inputs are relevant; also stop adding items when the` && |\n|  &&
+             `            // ComboBox has been destroyed during the await.` && |\n|  &&
+             `            if (device.kind !== "videoinput") continue;` && |\n|  &&
+             `            if (this.isDestroyed && this.isDestroyed()) return;` && |\n|  &&
+             `            this.addItem(` && |\n|  &&
+             `              new Item({ key: device.deviceId, text: device.label }),` && |\n|  &&
+             `            );` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (err) {` && |\n|  &&
+             `          _logError("CameraDeviceList: enumerateDevices failed", err);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      renderer: ComboBoxRenderer,` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/UITableExt", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  const opSymbols = { EQ: "", NE: "!", LT: "<", LE: "<=", GT: ">", GE: ">=" };` && |\n|  &&
+             `  const filterDisplayFns = {` && |\n|  &&
+             `    Contains: (v) => ``*${v ?? ""}*``,` && |\n|  &&
+             `    StartsWith: (v) => ``^${v ?? ""}``,` && |\n|  &&
+             `    EndsWith: (v) => ``${v ?? ""}$``,` && |\n|  &&
+             `  };` && |\n|  &&
+             `` && |\n|  &&
+             `  return Control.extend("z2ui5.UITableExt", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        tableId: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    init() {` && |\n|  &&
+             `      this._beforeBound = () => {` && |\n|  &&
+             `        this.readFilter();` && |\n|  &&
+             `        this.readSort();` && |\n|  &&
+             `      };` && |\n|  &&
+             `      this._afterBound = () => {` && |\n|  &&
+             `        this.setFilter();` && |\n|  &&
+             `        this.setSort();` && |\n|  &&
+             `      };` && |\n|  &&
+             `      _registerCallback("onBeforeRoundtrip", this._beforeBound);` && |\n|  &&
+             `      _registerCallback("onAfterRoundtrip", this._afterBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      _unregisterCallback("onBeforeRoundtrip", this._beforeBound);` && |\n|  &&
+             `      _unregisterCallback("onAfterRoundtrip", this._afterBound);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _getTable() {` && |\n|  &&
+             `      if (!z2ui5.oView) return undefined;` && |\n|  &&
+             `      return z2ui5.oView.byId(this.getProperty("tableId"));` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    readFilter() {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const table = this._getTable();` && |\n|  &&
+             `        const binding = table && table.getBinding();` && |\n|  &&
+             `        this.aFilters = binding ? binding.aFilters : undefined;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("UITableExt.readFilter failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _applyWhenRendered(oTable, fn) {` && |\n|  &&
+             `      if (oTable.getDomRef()) {` && |\n|  &&
+             `        fn();` && |\n|  &&
+             `        return;` && |\n|  &&
+             `      }` && |\n|  &&
+             `      // Not rendered yet -> run ``fn`` once the next render completes.` && |\n|  &&
+             `      const delegate = {` && |\n|  &&
+             `        onAfterRendering: () => {` && |\n|  &&
+             `          oTable.removeEventDelegate(delegate);` && |\n|  &&
+             `          if (!(this.isDestroyed && this.isDestroyed())) fn();` && |\n|  &&
+             `        },` && |\n|  &&
+             `      };` && |\n|  &&
+             `      oTable.addEventDelegate(delegate);` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _applyFilters(oTable, aFilters) {` && |\n|  &&
+             `      if (!aFilters) return;` && |\n|  &&
+             `      const binding = oTable.getBinding();` && |\n|  &&
+             `      if (!binding) return;` && |\n|  &&
+             `      binding.filter(aFilters);` && |\n|  &&
+             `      const columns = oTable.getColumns();` && |\n|  &&
+             `` && |\n|  &&
+             `      for (const oFilter of aFilters) {` && |\n|  &&
+             `        // Multi-filter? Pick the inner filter for the column lookup.` && |\n|  &&
+             `        let sProperty = oFilter.sPath;` && |\n|  &&
+             `        if (!sProperty && oFilter.aFilters && oFilter.aFilters[0]) {` && |\n|  &&
+             `          sProperty = oFilter.aFilters[0].sPath;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (!sProperty) continue;` && |\n|  &&
+             `` && |\n|  &&
+             `        const operator = oFilter.sOperator;` && |\n|  &&
+             `        // Pick the most meaningful value to display in the column header.` && |\n|  &&
+             `        let vValue = oFilter.oValue1;` && |\n|  &&
+             `        if (vValue === undefined) vValue = oFilter.oValue2;` && |\n|  &&
+             `        if (vValue === undefined && oFilter.aFilters && oFilter.aFilters[0]) {` && |\n|  &&
+             `          vValue = oFilter.aFilters[0].oValue1;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        // Choose how to format the column header label for this operator.` && |\n|  &&
+             `        let displayFn;` && |\n|  &&
+             `        if (operator === "BT") {` && |\n|  &&
+             `          // "between" displays "from...to".` && |\n|  &&
+             `          displayFn = (v) => {` && |\n|  &&
+             `            const from = v == null ? "" : v;` && |\n|  &&
+             `            const to = oFilter.oValue2 == null ? "" : oFilter.oValue2;` && |\n|  &&
+             `            return ``${from}...${to}``;` && |\n|  &&
+             `          };` && |\n|  &&
+             `        } else if (filterDisplayFns[operator]) {` && |\n|  &&
+             `          displayFn = filterDisplayFns[operator];` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          // Fallback: optional operator prefix (e.g. "!" for NE) + value.` && |\n|  &&
+             `          const prefix = opSymbols[operator] || "";` && |\n|  &&
+             `          displayFn = (v) => ``${prefix}${v == null ? "" : v}``;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const display = displayFn(vValue);` && |\n|  &&
+             `` && |\n|  &&
+             `        for (const oCol of columns) {` && |\n|  &&
+             `          if (` && |\n|  &&
+             `            oCol.getFilterProperty &&` && |\n|  &&
+             `            oCol.getFilterProperty() === sProperty` && |\n|  &&
+             `          ) {` && |\n|  &&
+             `            oCol.setFilterValue(display);` && |\n|  &&
+             `            oCol.setFiltered(!!display);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _applyToTable(applyFn, errorMsg) {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const oTable = this._getTable();` && |\n|  &&
+             `        if (!oTable) return;` && |\n|  &&
              |\n|.
     result = result &&
-             `        this._applyWhenRendered(oTable, () => applyFn(oTable));` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError(errorMsg, e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    setFilter() {` && |\n| &&
-             `      this._applyToTable(` && |\n| &&
-             `        (oTable) => this._applyFilters(oTable, this.aFilters),` && |\n| &&
-             `        "UITableExt.setFilter failed",` && |\n| &&
-             `      );` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    readSort() {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const table = this._getTable();` && |\n| &&
-             `        const binding = table && table.getBinding();` && |\n| &&
-             `        this.aSorters = binding ? binding.aSorters : undefined;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("UITableExt.readSort failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    _applySorters(oTable, aSorters) {` && |\n| &&
-             `      if (!aSorters) return;` && |\n| &&
-             `      const binding = oTable.getBinding();` && |\n| &&
-             `      if (!binding) return;` && |\n| &&
-             `      binding.sort(aSorters);` && |\n| &&
-             `` && |\n| &&
-             `      const columns = oTable.getColumns();` && |\n| &&
-             `      for (const [idx, srt] of aSorters.entries()) {` && |\n| &&
-             `        for (const oCol of columns) {` && |\n| &&
-             `          if (oCol.getSortProperty && oCol.getSortProperty() === srt.sPath) {` && |\n| &&
-             `            oCol.setSorted(true);` && |\n| &&
-             `            oCol.setSortOrder(srt.bDescending ? "Descending" : "Ascending");` && |\n| &&
-             `            // setSortIndex is only available on some column variants.` && |\n| &&
-             `            if (oCol.setSortIndex) oCol.setSortIndex(idx);` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    setSort() {` && |\n| &&
-             `      this._applyToTable(` && |\n| &&
-             `        (oTable) => this._applySorters(oTable, this.aSorters),` && |\n| &&
-             `        "UITableExt.setSort failed",` && |\n| &&
-             `      );` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Util", [], () => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `` && |\n| &&
-             `  // Splits an 8-character ABAP date string "YYYYMMDD" into the [year, month,` && |\n| &&
-             `  // day] tuple JavaScript's Date constructor expects. Note: Date months are` && |\n| &&
-             `  // 0-based, so we subtract 1 from the month component.` && |\n| &&
-             `  function parseDmy(d) {` && |\n| &&
-             `    return [+d.slice(0, 4), +d.slice(4, 6) - 1, +d.slice(6, 8)];` && |\n| &&
-             `  }` && |\n| &&
-             `` && |\n| &&
-             `  return {` && |\n| &&
-             `    DateCreateObject(s) {` && |\n| &&
-             `      return new Date(s);` && |\n| &&
-             `    },` && |\n| &&
-             `    DateAbapDateToDateObject(d) {` && |\n| &&
-             `      return new Date(...parseDmy(d));` && |\n| &&
-             `    },` && |\n| &&
-             `    // t is an ABAP time string "HHMMSS"; if omitted we default to midnight.` && |\n| &&
-             `    DateAbapDateTimeToDateObject(d, t = "000000") {` && |\n| &&
-             `      return new Date(` && |\n| &&
-             `        ...parseDmy(d),` && |\n| &&
-             `        +t.slice(0, 2),` && |\n| &&
-             `        +t.slice(2, 4),` && |\n| &&
-             `        +t.slice(4, 6),` && |\n| &&
-             `      );` && |\n| &&
-             `    },` && |\n| &&
-             `  };` && |\n| &&
-             `});` && |\n| &&
-             `sap.ui.require(["z2ui5/Util"], (Util) => (z2ui5.Util = Util));` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Favicon", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.Favicon", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        favicon: {` && |\n| &&
-             `          type: "string",` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setFavicon(val) {` && |\n| &&
-             `      this.setProperty("favicon", val);` && |\n| &&
-             `      const existing = document.head.querySelector('link[rel="shortcut icon"]');` && |\n| &&
-             `      if (existing) {` && |\n| &&
-             `        existing.href = val;` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
-             `      const link = document.createElement("link");` && |\n| &&
-             `      link.rel = "shortcut icon";` && |\n| &&
-             `      link.href = val;` && |\n| &&
-             `      document.head.appendChild(link);` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
-             `sap.ui.define("z2ui5/Dirty", ["sap/ui/core/Control"], (Control) => {` && |\n| &&
-             `  "use strict";` && |\n| &&
-             `  return Control.extend("z2ui5.Dirty", {` && |\n| &&
-             `    metadata: {` && |\n| &&
-             `      properties: {` && |\n| &&
-             `        isDirty: {` && |\n| &&
-             `          type: "boolean",` && |\n| &&
-             `          defaultValue: false,` && |\n| &&
-             `        },` && |\n| &&
-             `      },` && |\n| &&
-             `    },` && |\n| &&
-             `    setIsDirty(val) {` && |\n| &&
-             `      this.setProperty("isDirty", val);` && |\n| &&
-             `` && |\n| &&
-             `      // Fallback for non-launchpad scenarios: ask the browser to confirm` && |\n| &&
-             `      // before leaving the page when something is unsaved.` && |\n| &&
-             `      const fallback = () => {` && |\n| &&
-             `        if (val) {` && |\n| &&
-             `          window.onbeforeunload = (e) => {` && |\n| &&
-             `            e.preventDefault();` && |\n| &&
-             `            e.returnValue = "";` && |\n| &&
-             `          };` && |\n| &&
-             `        } else {` && |\n| &&
-             `          window.onbeforeunload = null;` && |\n| &&
-             `        }` && |\n| &&
-             `      };` && |\n| &&
-             `` && |\n| &&
-             `      // Use the FLP dirty flag when running inside the Launchpad (SAPUI5` && |\n| &&
-             `      // only); otherwise fall back to the browser unload prompt.` && |\n| &&
-             `      try {` && |\n| &&
-             `        const launchpad = z2ui5.oLaunchpad;` && |\n| &&
-             `        const hasFlpDirtyFlag =` && |\n| &&
-             `          launchpad &&` && |\n| &&
-             `          launchpad.Container &&` && |\n| &&
-             `          launchpad.Container.setDirtyFlag &&` && |\n| &&
-             `          launchpad.ShellUIService;` && |\n| &&
-             `        if (hasFlpDirtyFlag) {` && |\n| &&
-             `          launchpad.Container.setDirtyFlag(val);` && |\n| &&
-             `        } else {` && |\n| &&
-             `          fallback();` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        _logError("Dirty.setIsDirty: setDirtyFlag failed", e);` && |\n| &&
-             `        fallback();` && |\n| &&
-             `      }` && |\n| &&
-             `    },` && |\n| &&
-             `    exit() {` && |\n| &&
-             `      window.onbeforeunload = null;` && |\n| &&
-             `    },` && |\n| &&
-             `    renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `  });` && |\n| &&
-             `});` && |\n| &&
-             `` && |\n| &&
+             `        this._applyWhenRendered(oTable, () => applyFn(oTable));` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError(errorMsg, e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    setFilter() {` && |\n|  &&
+             `      this._applyToTable(` && |\n|  &&
+             `        (oTable) => this._applyFilters(oTable, this.aFilters),` && |\n|  &&
+             `        "UITableExt.setFilter failed",` && |\n|  &&
+             `      );` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    readSort() {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const table = this._getTable();` && |\n|  &&
+             `        const binding = table && table.getBinding();` && |\n|  &&
+             `        this.aSorters = binding ? binding.aSorters : undefined;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("UITableExt.readSort failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    _applySorters(oTable, aSorters) {` && |\n|  &&
+             `      if (!aSorters) return;` && |\n|  &&
+             `      const binding = oTable.getBinding();` && |\n|  &&
+             `      if (!binding) return;` && |\n|  &&
+             `      binding.sort(aSorters);` && |\n|  &&
+             `` && |\n|  &&
+             `      const columns = oTable.getColumns();` && |\n|  &&
+             `      for (const [idx, srt] of aSorters.entries()) {` && |\n|  &&
+             `        for (const oCol of columns) {` && |\n|  &&
+             `          if (oCol.getSortProperty && oCol.getSortProperty() === srt.sPath) {` && |\n|  &&
+             `            oCol.setSorted(true);` && |\n|  &&
+             `            oCol.setSortOrder(srt.bDescending ? "Descending" : "Ascending");` && |\n|  &&
+             `            // setSortIndex is only available on some column variants.` && |\n|  &&
+             `            if (oCol.setSortIndex) oCol.setSortIndex(idx);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `` && |\n|  &&
+             `    setSort() {` && |\n|  &&
+             `      this._applyToTable(` && |\n|  &&
+             `        (oTable) => this._applySorters(oTable, this.aSorters),` && |\n|  &&
+             `        "UITableExt.setSort failed",` && |\n|  &&
+             `      );` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Util", [], () => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `  // Splits an 8-character ABAP date string "YYYYMMDD" into the [year, month,` && |\n|  &&
+             `  // day] tuple JavaScript's Date constructor expects. Note: Date months are` && |\n|  &&
+             `  // 0-based, so we subtract 1 from the month component.` && |\n|  &&
+             `  function parseDmy(d) {` && |\n|  &&
+             `    return [+d.slice(0, 4), +d.slice(4, 6) - 1, +d.slice(6, 8)];` && |\n|  &&
+             `  }` && |\n|  &&
+             `` && |\n|  &&
+             `  return {` && |\n|  &&
+             `    DateCreateObject(s) {` && |\n|  &&
+             `      return new Date(s);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    DateAbapDateToDateObject(d) {` && |\n|  &&
+             `      return new Date(...parseDmy(d));` && |\n|  &&
+             `    },` && |\n|  &&
+             `    // t is an ABAP time string "HHMMSS"; if omitted we default to midnight.` && |\n|  &&
+             `    DateAbapDateTimeToDateObject(d, t = "000000") {` && |\n|  &&
+             `      return new Date(` && |\n|  &&
+             `        ...parseDmy(d),` && |\n|  &&
+             `        +t.slice(0, 2),` && |\n|  &&
+             `        +t.slice(2, 4),` && |\n|  &&
+             `        +t.slice(4, 6),` && |\n|  &&
+             `      );` && |\n|  &&
+             `    },` && |\n|  &&
+             `  };` && |\n|  &&
+             `});` && |\n|  &&
+             `sap.ui.require(["z2ui5/Util"], (Util) => (z2ui5.Util = Util));` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Favicon", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.Favicon", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        favicon: {` && |\n|  &&
+             `          type: "string",` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setFavicon(val) {` && |\n|  &&
+             `      this.setProperty("favicon", val);` && |\n|  &&
+             `      const existing = document.head.querySelector('link[rel="shortcut icon"]');` && |\n|  &&
+             `      if (existing) {` && |\n|  &&
+             `        existing.href = val;` && |\n|  &&
+             `        return;` && |\n|  &&
+             `      }` && |\n|  &&
+             `      const link = document.createElement("link");` && |\n|  &&
+             `      link.rel = "shortcut icon";` && |\n|  &&
+             `      link.href = val;` && |\n|  &&
+             `      document.head.appendChild(link);` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
+             `sap.ui.define("z2ui5/Dirty", ["sap/ui/core/Control"], (Control) => {` && |\n|  &&
+             `  "use strict";` && |\n|  &&
+             `  return Control.extend("z2ui5.Dirty", {` && |\n|  &&
+             `    metadata: {` && |\n|  &&
+             `      properties: {` && |\n|  &&
+             `        isDirty: {` && |\n|  &&
+             `          type: "boolean",` && |\n|  &&
+             `          defaultValue: false,` && |\n|  &&
+             `        },` && |\n|  &&
+             `      },` && |\n|  &&
+             `    },` && |\n|  &&
+             `    setIsDirty(val) {` && |\n|  &&
+             `      this.setProperty("isDirty", val);` && |\n|  &&
+             `` && |\n|  &&
+             `      // Fallback for non-launchpad scenarios: ask the browser to confirm` && |\n|  &&
+             `      // before leaving the page when something is unsaved.` && |\n|  &&
+             `      const fallback = () => {` && |\n|  &&
+             `        if (val) {` && |\n|  &&
+             `          window.onbeforeunload = (e) => {` && |\n|  &&
+             `            e.preventDefault();` && |\n|  &&
+             `            e.returnValue = "";` && |\n|  &&
+             `          };` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          window.onbeforeunload = null;` && |\n|  &&
+             `        }` && |\n|  &&
+             `      };` && |\n|  &&
+             `` && |\n|  &&
+             `      // Use the FLP dirty flag when running inside the Launchpad (SAPUI5` && |\n|  &&
+             `      // only); otherwise fall back to the browser unload prompt.` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const launchpad = z2ui5.oLaunchpad;` && |\n|  &&
+             `        const hasFlpDirtyFlag =` && |\n|  &&
+             `          launchpad &&` && |\n|  &&
+             `          launchpad.Container &&` && |\n|  &&
+             `          launchpad.Container.setDirtyFlag &&` && |\n|  &&
+             `          launchpad.ShellUIService;` && |\n|  &&
+             `        if (hasFlpDirtyFlag) {` && |\n|  &&
+             `          launchpad.Container.setDirtyFlag(val);` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          fallback();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        _logError("Dirty.setIsDirty: setDirtyFlag failed", e);` && |\n|  &&
+             `        fallback();` && |\n|  &&
+             `      }` && |\n|  &&
+             `    },` && |\n|  &&
+             `    exit() {` && |\n|  &&
+             `      window.onbeforeunload = null;` && |\n|  &&
+             `    },` && |\n|  &&
+             `    renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `  });` && |\n|  &&
+             `});` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_app_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_xml.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_app_xml IMPLEMENTATION.
 
   METHOD get.
 
-    result = `<mvc:View controllerName="z2ui5.controller.App"` &&
+    result =              `<mvc:View controllerName="z2ui5.controller.App"` &&
              `    xmlns:html="http://www.w3.org/1999/xhtml"` &&
              `    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"` &&
              `    xmlns="sap.m">` &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -18,216 +18,216 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/UIComponent",` && |\n| &&
-             `    "z2ui5/model/models",` && |\n| &&
-             `    "z2ui5/cc/Server",` && |\n| &&
-             `    "sap/ui/VersionInfo",` && |\n| &&
-             `    "z2ui5/cc/DebugTool",` && |\n| &&
-             `    "sap/ui/core/Theming",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    return UIComponent.extend("z2ui5.Component", {` && |\n| &&
-             `      metadata: {` && |\n| &&
-             `        manifest: "json",` && |\n| &&
-             `        interfaces: ["sap.ui.core.IAsyncContentCreation"],` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      init() {` && |\n| &&
-             `        // The global "z2ui5" object holds shared state for the whole app. When` && |\n| &&
-             `        // the component is (re-)initialized we make sure oConfig exists so the` && |\n| &&
-             `        // base init() and our helpers can rely on it.` && |\n| &&
-             `        if (typeof z2ui5 !== "undefined") z2ui5.oConfig = {};` && |\n| &&
-             `` && |\n| &&
-             `        UIComponent.prototype.init.call(this);` && |\n| &&
-             `` && |\n| &&
-             `        // After the base init, ensure z2ui5 / z2ui5.oConfig still exist. When` && |\n| &&
-             `        // running locally without the SAP launchpad the global is re-created.` && |\n| &&
-             `        if (typeof z2ui5 === "undefined") z2ui5 = {};` && |\n| &&
-             `        if (z2ui5.checkLocal === false) z2ui5 = {};` && |\n| &&
-             `        if (typeof z2ui5.oConfig === "undefined") z2ui5.oConfig = {};` && |\n| &&
-             `        z2ui5.oConfig.ComponentData = this.getComponentData();` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oDeviceModel = Models.createDeviceModel();` && |\n| &&
-             `        this.setModel(z2ui5.oDeviceModel, "device");` && |\n| &&
-             `` && |\n| &&
-             `        this._initLaunchpad();` && |\n| &&
-             `        this._initVersionInfo();` && |\n| &&
-             `` && |\n| &&
-             `        this._installUnloadListener();` && |\n| &&
-             `        this._installDebugToolShortcut();` && |\n| &&
-             `        this._installPopstateListener();` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oRouter = this.getRouter();` && |\n| &&
-             `        z2ui5.oRouter.initialize();` && |\n| &&
-             `        z2ui5.oRouter.stop();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Event listeners installed in init() and removed in exit()` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `      _installUnloadListener() {` && |\n| &&
-             `        this._boundUnload = this._onUnload.bind(this);` && |\n| &&
-             `        // Safari on iOS does not fire "beforeunload" reliably, so we use` && |\n| &&
-             `        // "pagehide" there.` && |\n| &&
-             `        const isIos = /iPad|iPhone/.test(navigator.userAgent);` && |\n| &&
-             `        this._unloadEvent = isIos ? "pagehide" : "beforeunload";` && |\n| &&
-             `        window.addEventListener(this._unloadEvent, this._boundUnload);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _installDebugToolShortcut() {` && |\n| &&
-             `        // Ctrl + F12 opens / closes the in-app debug tool.` && |\n| &&
-             `        this._boundKeydown = (zEvent) => {` && |\n| &&
-             `          if (zEvent.ctrlKey && zEvent.key === "F12") {` && |\n| &&
-             `            if (!z2ui5.debugTool) z2ui5.debugTool = new DebugTool();` && |\n| &&
-             `            z2ui5.debugTool.toggle();` && |\n| &&
-             `          }` && |\n| &&
-             `        };` && |\n| &&
-             `        document.addEventListener("keydown", this._boundKeydown);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _installPopstateListener() {` && |\n| &&
-             `        // The browser's back/forward buttons restore a previously displayed` && |\n| &&
-             `        // view from history.state without doing a backend roundtrip.` && |\n| &&
-             `        this._boundPopstate = (event) => {` && |\n| &&
-             `          const state = event && event.state;` && |\n| &&
-             `          if (!state) return;` && |\n| &&
-             `` && |\n| &&
-             `          // These flags only apply once when the state was first pushed; on` && |\n| &&
-             `          // restore we strip them so they don't trigger again.` && |\n| &&
-             `          if (state.response && state.response.PARAMS) {` && |\n| &&
-             `            delete state.response.PARAMS.SET_PUSH_STATE;` && |\n| &&
-             `            delete state.response.PARAMS.SET_APP_STATE_ACTIVE;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (!state.view) return;` && |\n| &&
-             `` && |\n| &&
-             `          if (z2ui5.oController) z2ui5.oController.ViewDestroy();` && |\n| &&
-             `          z2ui5.oResponse = state.response;` && |\n| &&
-             `` && |\n| &&
-             `          const displayPromise =` && |\n| &&
-             `            z2ui5.oController &&` && |\n| &&
-             `            z2ui5.oController.displayView(state.view, state.model);` && |\n| &&
-             `          if (displayPromise && displayPromise.catch) {` && |\n| &&
-             `            displayPromise.catch((e) =>` && |\n| &&
-             `              logError("popstate: displayView failed", e),` && |\n| &&
-             `            );` && |\n| &&
-             `          }` && |\n| &&
-             `        };` && |\n| &&
-             `        window.addEventListener("popstate", this._boundPopstate);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // SAP Fiori Launchpad integration (only when running inside FLP)` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `      _initLaunchpad() {` && |\n| &&
-             `        const Container = sap.ui.require("sap/ushell/Container");` && |\n| &&
-             `        if (!Container) return; // not running inside the launchpad -> nothing to do` && |\n| &&
-             `` && |\n| &&
-             `        const launchpad = { Container };` && |\n| &&
-             `        this._launchpad = launchpad;` && |\n| &&
-             `        z2ui5.oLaunchpad = launchpad;` && |\n| &&
-             `` && |\n| &&
-             `        // The FLP services load asynchronously. By the time they resolve, the` && |\n| &&
-             `        // component may already have been destroyed (e.g. user navigated away` && |\n| &&
-             `        // before the services were ready). setIfAlive guards against writing` && |\n| &&
-             `        // to a stale launchpad object in that case.` && |\n| &&
-             `        const setIfAlive = (key, value) => {` && |\n| &&
-             `          const stillAlive = !this.isDestroyed || !this.isDestroyed();` && |\n| &&
-             `          if (stillAlive && this._launchpad === launchpad) {` && |\n| &&
-             `            launchpad[key] = value;` && |\n| &&
-             `          }` && |\n| &&
-             `        };` && |\n| &&
-             `` && |\n| &&
-             `        Container.getServiceAsync("ShellUIService")` && |\n| &&
-             `          .then((s) => setIfAlive("ShellUIService", s))` && |\n| &&
-             `          .catch((e) => logError("Component: ShellUIService init failed", e));` && |\n| &&
-             `` && |\n| &&
-             `        Container.getServiceAsync("CrossApplicationNavigation")` && |\n| &&
-             `          .then((s) => setIfAlive("CrossAppNavigator", s))` && |\n| &&
-             `          .catch((e) =>` && |\n| &&
-             `            logError("Component: CrossApplicationNavigation init failed", e),` && |\n| &&
-             `          );` && |\n| &&
-             `` && |\n| &&
-             `        sap.ui.require(` && |\n| &&
-             `          ["sap/ushell/services/AppConfiguration"],` && |\n| &&
-             `          (ac) => setIfAlive("AppConfiguration", ac),` && |\n| &&
-             `          (e) => logError("Component: AppConfiguration init failed", e),` && |\n| &&
-             `        );` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async _initVersionInfo() {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const info = await VersionInfo.load();` && |\n| &&
-             `          const stillAlive = !this.isDestroyed || !this.isDestroyed();` && |\n| &&
-             `          if (stillAlive) {` && |\n| &&
-             `            z2ui5.oConfig.S_UI5 = {` && |\n| &&
-             `              VERSION: info.version,` && |\n| &&
-             `              BUILDTIMESTAMP: info.buildTimestamp,` && |\n| &&
-             `              GAV: info.gav,` && |\n| &&
-             `              THEME: Theming ? Theming.getTheme() : "",` && |\n| &&
-             `            };` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("Component: VersionInfo load failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _onUnload() {` && |\n| &&
-             `        window.removeEventListener(this._unloadEvent, this._boundUnload);` && |\n| &&
-             `        this.destroy();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Component teardown` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `      exit() {` && |\n| &&
-             `        window.removeEventListener(this._unloadEvent, this._boundUnload);` && |\n| &&
-             `        document.removeEventListener("keydown", this._boundKeydown);` && |\n| &&
-             `        window.removeEventListener("popstate", this._boundPopstate);` && |\n| &&
-             `` && |\n| &&
-             `        Server.endSession();` && |\n| &&
-             `` && |\n| &&
-             `        // Robust launchpad teardown:` && |\n| &&
-             `        //  1. Clear the FLP dirty flag so it does not carry over into the` && |\n| &&
-             `        //     next app the user opens.` && |\n| &&
-             `        //  2. Detach the shared launchpad object so a subsequent re-launch` && |\n| &&
-             `        //     starts from a clean state and any still-pending init Promises` && |\n| &&
-             `        //     become no-ops via setIfAlive().` && |\n| &&
-             `        try {` && |\n| &&
-             `          const setDirtyFlag =` && |\n| &&
-             `            this._launchpad &&` && |\n| &&
-             `            this._launchpad.Container &&` && |\n| &&
-             `            this._launchpad.Container.setDirtyFlag;` && |\n| &&
-             `          if (setDirtyFlag) setDirtyFlag.call(this._launchpad.Container, false);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("Component: clearing FLP dirty flag failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `        if (z2ui5.oLaunchpad === this._launchpad) z2ui5.oLaunchpad = null;` && |\n| &&
-             `        this._launchpad = null;` && |\n| &&
-             `` && |\n| &&
-             `        if (UIComponent.prototype.exit) UIComponent.prototype.exit.call(this);` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
+    result =              `sap.ui.define(` && |\n|  &&
+             `  [` && |\n|  &&
+             `    "sap/ui/core/UIComponent",` && |\n|  &&
+             `    "z2ui5/model/models",` && |\n|  &&
+             `    "z2ui5/cc/Server",` && |\n|  &&
+             `    "sap/ui/VersionInfo",` && |\n|  &&
+             `    "z2ui5/cc/DebugTool",` && |\n|  &&
+             `    "sap/ui/core/Theming",` && |\n|  &&
+             `  ],` && |\n|  &&
+             `  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    // Append an entry to the global error log. We create the array on first use.` && |\n|  &&
+             `    function logError(message, error) {` && |\n|  &&
+             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n|  &&
+             `      z2ui5.errors.push({` && |\n|  &&
+             `        message: message,` && |\n|  &&
+             `        error: error,` && |\n|  &&
+             `        ts: new Date().toISOString(),` && |\n|  &&
+             `      });` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    return UIComponent.extend("z2ui5.Component", {` && |\n|  &&
+             `      metadata: {` && |\n|  &&
+             `        manifest: "json",` && |\n|  &&
+             `        interfaces: ["sap.ui.core.IAsyncContentCreation"],` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      init() {` && |\n|  &&
+             `        // The global "z2ui5" object holds shared state for the whole app. When` && |\n|  &&
+             `        // the component is (re-)initialized we make sure oConfig exists so the` && |\n|  &&
+             `        // base init() and our helpers can rely on it.` && |\n|  &&
+             `        if (typeof z2ui5 !== "undefined") z2ui5.oConfig = {};` && |\n|  &&
+             `` && |\n|  &&
+             `        UIComponent.prototype.init.call(this);` && |\n|  &&
+             `` && |\n|  &&
+             `        // After the base init, ensure z2ui5 / z2ui5.oConfig still exist. When` && |\n|  &&
+             `        // running locally without the SAP launchpad the global is re-created.` && |\n|  &&
+             `        if (typeof z2ui5 === "undefined") z2ui5 = {};` && |\n|  &&
+             `        if (z2ui5.checkLocal === false) z2ui5 = {};` && |\n|  &&
+             `        if (typeof z2ui5.oConfig === "undefined") z2ui5.oConfig = {};` && |\n|  &&
+             `        z2ui5.oConfig.ComponentData = this.getComponentData();` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oDeviceModel = Models.createDeviceModel();` && |\n|  &&
+             `        this.setModel(z2ui5.oDeviceModel, "device");` && |\n|  &&
+             `` && |\n|  &&
+             `        this._initLaunchpad();` && |\n|  &&
+             `        this._initVersionInfo();` && |\n|  &&
+             `` && |\n|  &&
+             `        this._installUnloadListener();` && |\n|  &&
+             `        this._installDebugToolShortcut();` && |\n|  &&
+             `        this._installPopstateListener();` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oRouter = this.getRouter();` && |\n|  &&
+             `        z2ui5.oRouter.initialize();` && |\n|  &&
+             `        z2ui5.oRouter.stop();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // Event listeners installed in init() and removed in exit()` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `      _installUnloadListener() {` && |\n|  &&
+             `        this._boundUnload = this._onUnload.bind(this);` && |\n|  &&
+             `        // Safari on iOS does not fire "beforeunload" reliably, so we use` && |\n|  &&
+             `        // "pagehide" there.` && |\n|  &&
+             `        const isIos = /iPad|iPhone/.test(navigator.userAgent);` && |\n|  &&
+             `        this._unloadEvent = isIos ? "pagehide" : "beforeunload";` && |\n|  &&
+             `        window.addEventListener(this._unloadEvent, this._boundUnload);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _installDebugToolShortcut() {` && |\n|  &&
+             `        // Ctrl + F12 opens / closes the in-app debug tool.` && |\n|  &&
+             `        this._boundKeydown = (zEvent) => {` && |\n|  &&
+             `          if (zEvent.ctrlKey && zEvent.key === "F12") {` && |\n|  &&
+             `            if (!z2ui5.debugTool) z2ui5.debugTool = new DebugTool();` && |\n|  &&
+             `            z2ui5.debugTool.toggle();` && |\n|  &&
+             `          }` && |\n|  &&
+             `        };` && |\n|  &&
+             `        document.addEventListener("keydown", this._boundKeydown);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _installPopstateListener() {` && |\n|  &&
+             `        // The browser's back/forward buttons restore a previously displayed` && |\n|  &&
+             `        // view from history.state without doing a backend roundtrip.` && |\n|  &&
+             `        this._boundPopstate = (event) => {` && |\n|  &&
+             `          const state = event && event.state;` && |\n|  &&
+             `          if (!state) return;` && |\n|  &&
+             `` && |\n|  &&
+             `          // These flags only apply once when the state was first pushed; on` && |\n|  &&
+             `          // restore we strip them so they don't trigger again.` && |\n|  &&
+             `          if (state.response && state.response.PARAMS) {` && |\n|  &&
+             `            delete state.response.PARAMS.SET_PUSH_STATE;` && |\n|  &&
+             `            delete state.response.PARAMS.SET_APP_STATE_ACTIVE;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!state.view) return;` && |\n|  &&
+             `` && |\n|  &&
+             `          if (z2ui5.oController) z2ui5.oController.ViewDestroy();` && |\n|  &&
+             `          z2ui5.oResponse = state.response;` && |\n|  &&
+             `` && |\n|  &&
+             `          const displayPromise =` && |\n|  &&
+             `            z2ui5.oController &&` && |\n|  &&
+             `            z2ui5.oController.displayView(state.view, state.model);` && |\n|  &&
+             `          if (displayPromise && displayPromise.catch) {` && |\n|  &&
+             `            displayPromise.catch((e) =>` && |\n|  &&
+             `              logError("popstate: displayView failed", e),` && |\n|  &&
+             `            );` && |\n|  &&
+             `          }` && |\n|  &&
+             `        };` && |\n|  &&
+             `        window.addEventListener("popstate", this._boundPopstate);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // SAP Fiori Launchpad integration (only when running inside FLP)` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `      _initLaunchpad() {` && |\n|  &&
+             `        const Container = sap.ui.require("sap/ushell/Container");` && |\n|  &&
+             `        if (!Container) return; // not running inside the launchpad -> nothing to do` && |\n|  &&
+             `` && |\n|  &&
+             `        const launchpad = { Container };` && |\n|  &&
+             `        this._launchpad = launchpad;` && |\n|  &&
+             `        z2ui5.oLaunchpad = launchpad;` && |\n|  &&
+             `` && |\n|  &&
+             `        // The FLP services load asynchronously. By the time they resolve, the` && |\n|  &&
+             `        // component may already have been destroyed (e.g. user navigated away` && |\n|  &&
+             `        // before the services were ready). setIfAlive guards against writing` && |\n|  &&
+             `        // to a stale launchpad object in that case.` && |\n|  &&
+             `        const setIfAlive = (key, value) => {` && |\n|  &&
+             `          const stillAlive = !this.isDestroyed || !this.isDestroyed();` && |\n|  &&
+             `          if (stillAlive && this._launchpad === launchpad) {` && |\n|  &&
+             `            launchpad[key] = value;` && |\n|  &&
+             `          }` && |\n|  &&
+             `        };` && |\n|  &&
+             `` && |\n|  &&
+             `        Container.getServiceAsync("ShellUIService")` && |\n|  &&
+             `          .then((s) => setIfAlive("ShellUIService", s))` && |\n|  &&
+             `          .catch((e) => logError("Component: ShellUIService init failed", e));` && |\n|  &&
+             `` && |\n|  &&
+             `        Container.getServiceAsync("CrossApplicationNavigation")` && |\n|  &&
+             `          .then((s) => setIfAlive("CrossAppNavigator", s))` && |\n|  &&
+             `          .catch((e) =>` && |\n|  &&
+             `            logError("Component: CrossApplicationNavigation init failed", e),` && |\n|  &&
+             `          );` && |\n|  &&
+             `` && |\n|  &&
+             `        sap.ui.require(` && |\n|  &&
+             `          ["sap/ushell/services/AppConfiguration"],` && |\n|  &&
+             `          (ac) => setIfAlive("AppConfiguration", ac),` && |\n|  &&
+             `          (e) => logError("Component: AppConfiguration init failed", e),` && |\n|  &&
+             `        );` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async _initVersionInfo() {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const info = await VersionInfo.load();` && |\n|  &&
+             `          const stillAlive = !this.isDestroyed || !this.isDestroyed();` && |\n|  &&
+             `          if (stillAlive) {` && |\n|  &&
+             `            z2ui5.oConfig.S_UI5 = {` && |\n|  &&
+             `              VERSION: info.version,` && |\n|  &&
+             `              BUILDTIMESTAMP: info.buildTimestamp,` && |\n|  &&
+             `              GAV: info.gav,` && |\n|  &&
+             `              THEME: Theming ? Theming.getTheme() : "",` && |\n|  &&
+             `            };` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("Component: VersionInfo load failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _onUnload() {` && |\n|  &&
+             `        window.removeEventListener(this._unloadEvent, this._boundUnload);` && |\n|  &&
+             `        this.destroy();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // Component teardown` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `      exit() {` && |\n|  &&
+             `        window.removeEventListener(this._unloadEvent, this._boundUnload);` && |\n|  &&
+             `        document.removeEventListener("keydown", this._boundKeydown);` && |\n|  &&
+             `        window.removeEventListener("popstate", this._boundPopstate);` && |\n|  &&
+             `` && |\n|  &&
+             `        Server.endSession();` && |\n|  &&
+             `` && |\n|  &&
+             `        // Robust launchpad teardown:` && |\n|  &&
+             `        //  1. Clear the FLP dirty flag so it does not carry over into the` && |\n|  &&
+             `        //     next app the user opens.` && |\n|  &&
+             `        //  2. Detach the shared launchpad object so a subsequent re-launch` && |\n|  &&
+             `        //     starts from a clean state and any still-pending init Promises` && |\n|  &&
+             `        //     become no-ops via setIfAlive().` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const setDirtyFlag =` && |\n|  &&
+             `            this._launchpad &&` && |\n|  &&
+             `            this._launchpad.Container &&` && |\n|  &&
+             `            this._launchpad.Container.setDirtyFlag;` && |\n|  &&
+             `          if (setDirtyFlag) setDirtyFlag.call(this._launchpad.Container, false);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("Component: clearing FLP dirty flag failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (z2ui5.oLaunchpad === this._launchpad) z2ui5.oLaunchpad = null;` && |\n|  &&
+             `        this._launchpad = null;` && |\n|  &&
+             `` && |\n|  &&
+             `        if (UIComponent.prototype.exit) UIComponent.prototype.exit.call(this);` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
@@ -18,385 +18,385 @@ CLASS z2ui5_cl_app_debugtool_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/Control",` && |\n| &&
-             `    "sap/ui/core/Fragment",` && |\n| &&
-             `    "sap/ui/model/json/JSONModel",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (Control, Fragment, JSONModel) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Pretty-print any value (object, array, primitive) as indented JSON.` && |\n| &&
-             `    // ``null`` is used as a fallback so undefined values still produce output.` && |\n| &&
-             `    function toJson(val) {` && |\n| &&
-             `      const safe = val === undefined ? null : val;` && |\n| &&
-             `      return JSON.stringify(safe, null, 3);` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // XSL stylesheet used by prettifyXml to reindent any XML string.` && |\n| &&
-             `    const PRETTIFY_XSL = ``<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">` && |\n| &&
-             `        <xsl:strip-space elements="*" />` && |\n| &&
-             `        <xsl:template match="para[content-style][not(text())]">` && |\n| &&
-             `          <xsl:value-of select="normalize-space(.)" />` && |\n| &&
-             `        </xsl:template>` && |\n| &&
-             `        <xsl:template match="node()|@*">` && |\n| &&
-             `          <xsl:copy>` && |\n| &&
-             `            <xsl:apply-templates select="node()|@*" />` && |\n| &&
-             `          </xsl:copy>` && |\n| &&
-             `        </xsl:template>` && |\n| &&
-             `        <xsl:output indent="yes" />` && |\n| &&
-             `      </xsl:stylesheet>``;` && |\n| &&
-             `` && |\n| &&
-             `    // The XSLT processor and (de)serializers are expensive to construct, so` && |\n| &&
-             `    // we keep them as module-level singletons.` && |\n| &&
-             `    const _xmlSerializer = new XMLSerializer();` && |\n| &&
-             `    const _domParser = new DOMParser();` && |\n| &&
-             `    let _xsltProcessor = null;` && |\n| &&
-             `` && |\n| &&
-             `    function getXsltProcessor() {` && |\n| &&
-             `      if (_xsltProcessor) return _xsltProcessor;` && |\n| &&
-             `      const xsltDoc = _domParser.parseFromString(` && |\n| &&
-             `        PRETTIFY_XSL,` && |\n| &&
-             `        "application/xml",` && |\n| &&
-             `      );` && |\n| &&
-             `      _xsltProcessor = new XSLTProcessor();` && |\n| &&
-             `      _xsltProcessor.importStylesheet(xsltDoc);` && |\n| &&
-             `      return _xsltProcessor;` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    return Control.extend("z2ui5.cc.DebugTool", {` && |\n| &&
-             `      // Reformat an XML string with indentation. If anything goes wrong the` && |\n| &&
-             `      // original input is returned unchanged - the debug tool must never` && |\n| &&
-             `      // crash the host app.` && |\n| &&
-             `      prettifyXml(sourceXml) {` && |\n| &&
-             `        if (!sourceXml) return "";` && |\n| &&
-             `        try {` && |\n| &&
-             `          const xmlDoc = _domParser.parseFromString(` && |\n| &&
-             `            sourceXml,` && |\n| &&
-             `            "application/xml",` && |\n| &&
-             `          );` && |\n| &&
-             `          const resultDoc = getXsltProcessor().transformToDocument(xmlDoc);` && |\n| &&
-             `          if (!resultDoc) return sourceXml;` && |\n| &&
-             `          const resultXml = _xmlSerializer.serializeToString(resultDoc);` && |\n| &&
-             `          // The serializer escapes < and > inside text nodes; undo this so` && |\n| &&
-             `          // the output is browseable XML again.` && |\n| &&
-             `          return resultXml.replace(/&gt;|&lt;/g, (m) =>` && |\n| &&
-             `            m === "&gt;" ? ">" : "<",` && |\n| &&
-             `          );` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          return sourceXml;` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Called when the user picks an entry in the dropdown of the debug` && |\n| &&
-             `      // dialog. Each case shows a different piece of internal state.` && |\n| &&
-             `      onItemSelect(oEvent) {` && |\n| &&
-             `        const oSource = oEvent.getSource();` && |\n| &&
-             `        const selItem = oSource.getSelectedKey();` && |\n| &&
-             `        const oView = z2ui5.oView;` && |\n| &&
-             `        const oResponse = z2ui5.oResponse;` && |\n| &&
-             `` && |\n| &&
-             `        // Cache a bound version of displayEditor so we don't recreate the` && |\n| &&
-             `        // bound function on every call.` && |\n| &&
-             `        if (!this._displayEditorBound) {` && |\n| &&
-             `          this._displayEditorBound = this.displayEditor.bind(this);` && |\n| &&
-             `        }` && |\n| &&
-             `        const displayEditor = this._displayEditorBound;` && |\n| &&
-             `        const prettifyXml = this.prettifyXml;` && |\n| &&
-             `` && |\n| &&
-             `        switch (selItem) {` && |\n| &&
-             `          case "CONFIG":` && |\n| &&
-             `            displayEditor(oEvent, toJson(z2ui5.oConfig), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `` && |\n| &&
-             `          case "MODEL": {` && |\n| &&
-             `            const data =` && |\n| &&
-             `              oView && oView.getModel() && oView.getModel().getData();` && |\n| &&
-             `            displayEditor(oEvent, toJson(data), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "VIEW": {` && |\n| &&
-             `            // Prefer the actual viewContent string; fall back to the XML` && |\n| &&
-             `            // that arrived in the last server response.` && |\n| &&
-             `            const viewContent =` && |\n| &&
-             `              (oView && oView.mProperties && oView.mProperties.viewContent) ||` && |\n| &&
-             `              (z2ui5.responseData &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT.PARAMS &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT.PARAMS.S_VIEW &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT.PARAMS.S_VIEW.XML);` && |\n| &&
-             `            const rendered =` && |\n| &&
-             `              oView && oView._xContent && oView._xContent.outerHTML;` && |\n| &&
-             `            displayEditor(` && |\n| &&
-             `              oEvent,` && |\n| &&
-             `              prettifyXml(viewContent),` && |\n| &&
-             `              "xml",` && |\n| &&
-             `              prettifyXml(rendered),` && |\n| &&
-             `            );` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "PLAIN":` && |\n| &&
-             `            displayEditor(oEvent, toJson(z2ui5.responseData), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `` && |\n| &&
-             `          case "REQUEST":` && |\n| &&
-             `            displayEditor(oEvent, toJson(z2ui5.oBody), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `` && |\n| &&
-             `          case "POPUP": {` && |\n| &&
-             `            const xml =` && |\n| &&
-             `              oResponse &&` && |\n| &&
-             `              oResponse.PARAMS &&` && |\n| &&
-             `              oResponse.PARAMS.S_POPUP &&` && |\n| &&
-             `              oResponse.PARAMS.S_POPUP.XML;` && |\n| &&
-             `            displayEditor(oEvent, prettifyXml(xml), "xml");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "POPUP_MODEL": {` && |\n| &&
-             `            const data =` && |\n| &&
-             `              z2ui5.oViewPopup &&` && |\n| &&
-             `              z2ui5.oViewPopup.getModel() &&` && |\n| &&
-             `              z2ui5.oViewPopup.getModel().getData();` && |\n| &&
-             `            displayEditor(oEvent, toJson(data), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "POPOVER": {` && |\n| &&
-             `            const xml =` && |\n| &&
-             `              oResponse &&` && |\n| &&
-             `              oResponse.PARAMS &&` && |\n| &&
-             `              oResponse.PARAMS.S_POPOVER &&` && |\n| &&
-             `              oResponse.PARAMS.S_POPOVER.XML;` && |\n| &&
-             `            displayEditor(oEvent, prettifyXml(xml), "xml");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "POPOVER_MODEL": {` && |\n| &&
-             `            const data =` && |\n| &&
-             `              z2ui5.oViewPopover &&` && |\n| &&
-             `              z2ui5.oViewPopover.getModel() &&` && |\n| &&
-             `              z2ui5.oViewPopover.getModel().getData();` && |\n| &&
-             `            displayEditor(oEvent, toJson(data), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "NEST1": {` && |\n| &&
-             `            const nest = z2ui5.oViewNest;` && |\n| &&
-             `            const xml =` && |\n| &&
-             `              nest && nest.mProperties && nest.mProperties.viewContent;` && |\n| &&
-             `            const rendered = nest && nest._xContent && nest._xContent.outerHTML;` && |\n| &&
-             `            displayEditor(` && |\n| &&
-             `              oEvent,` && |\n| &&
-             `              prettifyXml(xml),` && |\n| &&
-             `              "xml",` && |\n| &&
-             `              prettifyXml(rendered),` && |\n| &&
-             `            );` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "NEST1_MODEL": {` && |\n| &&
-             `            const data =` && |\n| &&
-             `              z2ui5.oViewNest &&` && |\n| &&
-             `              z2ui5.oViewNest.getModel() &&` && |\n| &&
-             `              z2ui5.oViewNest.getModel().getData();` && |\n| &&
-             `            displayEditor(oEvent, toJson(data), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "NEST2": {` && |\n| &&
-             `            const nest = z2ui5.oViewNest2;` && |\n| &&
-             `            const xml =` && |\n| &&
-             `              nest && nest.mProperties && nest.mProperties.viewContent;` && |\n| &&
-             `            const rendered = nest && nest._xContent && nest._xContent.outerHTML;` && |\n| &&
-             `            displayEditor(` && |\n| &&
-             `              oEvent,` && |\n| &&
-             `              prettifyXml(xml),` && |\n| &&
-             `              "xml",` && |\n| &&
-             `              prettifyXml(rendered),` && |\n| &&
-             `            );` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "NEST2_MODEL": {` && |\n| &&
-             `            const data =` && |\n| &&
-             `              z2ui5.oViewNest2 &&` && |\n| &&
-             `              z2ui5.oViewNest2.getModel() &&` && |\n| &&
-             `              z2ui5.oViewNest2.getModel().getData();` && |\n| &&
-             `            displayEditor(oEvent, toJson(data), "json");` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          case "SOURCE": {` && |\n| &&
-             `            // Show the ABAP source of the running app inside an iframe.` && |\n| &&
-             `            const parent = oSource.getParent();` && |\n| &&
-             `            const content = parent && parent.getContent && parent.getContent();` && |\n| &&
-             `            const contentControl =` && |\n| &&
-             `              content &&` && |\n| &&
-             `              content[2] &&` && |\n| &&
-             `              content[2].getItems &&` && |\n| &&
-             `              content[2].getItems()[0];` && |\n| &&
-             `            if (!contentControl) break;` && |\n| &&
-             `` && |\n| &&
-             `            const appName =` && |\n| &&
-             `              (z2ui5.responseData &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT &&` && |\n| &&
-             `                z2ui5.responseData.S_FRONT.APP) ||` && |\n| &&
-             `              "";` && |\n| &&
-             `            const appId = encodeURIComponent(appName);` && |\n| &&
-             `            const url = ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n| &&
-             `            contentControl.setProperty(` && |\n| &&
-             `              "content",` && |\n| &&
-             `              ``<iframe id="test" src="${url}" height="800px" width="1200px" />``,` && |\n| &&
-             `            );` && |\n| &&
-             `` && |\n| &&
-             `            const oModel = oSource.getModel();` && |\n| &&
-             `            if (!oModel) break;` && |\n| &&
-             `            const modelData = oModel.getData();` && |\n| &&
-             `            modelData.editor_visible = false;` && |\n| &&
-             `            modelData.source_visible = true;` && |\n| &&
-             `            oModel.refresh();` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Populates the dialog model so the right editor / source area is shown` && |\n| &&
-             `      // with the given content. ``xcontent`` is the rendered DOM variant that` && |\n| &&
-             `      // can be toggled in via the "Templating" button.` && |\n| &&
-             `      displayEditor(oEvent, content, type, xcontent = "") {` && |\n| &&
-             `        const oModel = oEvent.getSource().getModel();` && |\n| &&
-             `        const modelData = oModel.getData();` && |\n| &&
-             `        modelData.editor_visible = true;` && |\n| &&
-             `        modelData.source_visible = false;` && |\n| &&
-             `        modelData.isTemplating = !!(` && |\n| &&
-             `          content && content.includes("xmlns:template")` && |\n| &&
-             `        );` && |\n| &&
-             `        modelData.value = content;` && |\n| &&
-             `        modelData.previousValue = content;` && |\n| &&
-             `        modelData.xContent = xcontent;` && |\n| &&
-             `        modelData.type = type;` && |\n| &&
-             `        oModel.refresh();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onTemplatingPress(oEvent) {` && |\n| &&
-             `        const oSource = oEvent.getSource();` && |\n| &&
-             `        const oModel = oSource.getModel();` && |\n| &&
-             `        const modelData = oModel.getData();` && |\n| &&
-             `        // Toggle between the original (previousValue) and the rendered DOM` && |\n| &&
-             `        // (xContent) representation.` && |\n| &&
-             `        if (oSource.getPressed()) {` && |\n| &&
-             `          modelData.value = modelData.xContent;` && |\n| &&
-             `        } else {` && |\n| &&
-             `          modelData.value = modelData.previousValue;` && |\n| &&
-             `        }` && |\n| &&
-             `        oModel.refresh();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onClose() {` && |\n| &&
-             `        this.close();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async show() {` && |\n| &&
-             `        // Guard against double-clicks while the fragment is still loading.` && |\n| &&
-             `        if (this._showPending) return;` && |\n| &&
-             `        this._showPending = true;` && |\n| &&
-             `        try {` && |\n| &&
-             `          if (!this.oDialog) {` && |\n| &&
-             `            this.oDialog = await Fragment.load({` && |\n| &&
-             `              name: "z2ui5.cc.DebugTool",` && |\n| &&
-             `              controller: this,` && |\n| &&
-             `            });` && |\n| &&
-             `          }` && |\n| &&
-             `          // If the user closed the app while the fragment was loading we` && |\n| &&
-             `          // must throw the freshly created dialog away.` && |\n| &&
-             `          if (this.isDestroyed && this.isDestroyed()) {` && |\n| &&
-             `            if (this.oDialog) this.oDialog.destroy();` && |\n| &&
-             `            this.oDialog = null;` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          const value = toJson(z2ui5.responseData);` && |\n| &&
-             `          const oData = {` && |\n| &&
-             `            type: "json",` && |\n| &&
-             `            source_visible: false,` && |\n| &&
-             `            editor_visible: true,` && |\n| &&
-             `            value: value,` && |\n| &&
-             `            xContent: "",` && |\n| &&
-             `            previousValue: value,` && |\n| &&
-             `            isTemplating: false,` && |\n| &&
-             `            templatingSource: false,` && |\n| &&
-             `            activeNest1: !!(` && |\n| &&
-             `              z2ui5.oViewNest &&` && |\n| &&
-             `              z2ui5.oViewNest.mProperties &&` && |\n| &&
-             `              z2ui5.oViewNest.mProperties.viewContent` && |\n| &&
-             `            ),` && |\n| &&
-             `            activeNest2: !!(` && |\n| &&
-             `              z2ui5.oViewNest2 &&` && |\n| &&
-             `              z2ui5.oViewNest2.mProperties &&` && |\n| &&
-             `              z2ui5.oViewNest2.mProperties.viewContent` && |\n| &&
-             `            ),` && |\n| &&
-             `            activePopup: !!(` && |\n| &&
-             `              z2ui5.oResponse &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS.S_POPUP &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS.S_POPUP.XML` && |\n| &&
-             `            ),` && |\n| &&
-             `            activePopover: !!(` && |\n| &&
-             `              z2ui5.oResponse &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS.S_POPOVER &&` && |\n| &&
-             `              z2ui5.oResponse.PARAMS.S_POPOVER.XML` && |\n| &&
-             `            ),` && |\n| &&
-             `          };` && |\n| &&
-             `` && |\n| &&
-             `          const oModel = new JSONModel(oData);` && |\n| &&
-             `          const oDialog = this.oDialog;` && |\n| &&
-             `          oDialog.addStyleClass("dbg-ltr");` && |\n| &&
-             `          oDialog.setModel(oModel);` && |\n| &&
-             `          oDialog.open();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("DebugTool.show failed", e);` && |\n| &&
-             `        } finally {` && |\n| &&
-             `          this._showPending = false;` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      close() {` && |\n| &&
-             `        if (!this.oDialog) return;` && |\n| &&
-             `        const oDialog = this.oDialog;` && |\n| &&
-             `        this.oDialog = null;` && |\n| &&
-             `        oDialog.close();` && |\n| &&
-             `        oDialog.destroy();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      toggle() {` && |\n| &&
-             `        if (this.oDialog) {` && |\n| &&
-             `          this.close();` && |\n| &&
-             `        } else {` && |\n| &&
-             `          this.show();` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // The control itself renders nothing - it just provides the dialog API.` && |\n| &&
-             `      renderer: { apiVersion: 2, render() {} },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
+    result =              `sap.ui.define(` && |\n|  &&
+             `  [` && |\n|  &&
+             `    "sap/ui/core/Control",` && |\n|  &&
+             `    "sap/ui/core/Fragment",` && |\n|  &&
+             `    "sap/ui/model/json/JSONModel",` && |\n|  &&
+             `  ],` && |\n|  &&
+             `  (Control, Fragment, JSONModel) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    // Append an entry to the global error log. We create the array on first use.` && |\n|  &&
+             `    function logError(message, error) {` && |\n|  &&
+             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n|  &&
+             `      z2ui5.errors.push({` && |\n|  &&
+             `        message: message,` && |\n|  &&
+             `        error: error,` && |\n|  &&
+             `        ts: new Date().toISOString(),` && |\n|  &&
+             `      });` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // Pretty-print any value (object, array, primitive) as indented JSON.` && |\n|  &&
+             `    // ``null`` is used as a fallback so undefined values still produce output.` && |\n|  &&
+             `    function toJson(val) {` && |\n|  &&
+             `      const safe = val === undefined ? null : val;` && |\n|  &&
+             `      return JSON.stringify(safe, null, 3);` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // XSL stylesheet used by prettifyXml to reindent any XML string.` && |\n|  &&
+             `    const PRETTIFY_XSL = ``<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">` && |\n|  &&
+             `        <xsl:strip-space elements="*" />` && |\n|  &&
+             `        <xsl:template match="para[content-style][not(text())]">` && |\n|  &&
+             `          <xsl:value-of select="normalize-space(.)" />` && |\n|  &&
+             `        </xsl:template>` && |\n|  &&
+             `        <xsl:template match="node()|@*">` && |\n|  &&
+             `          <xsl:copy>` && |\n|  &&
+             `            <xsl:apply-templates select="node()|@*" />` && |\n|  &&
+             `          </xsl:copy>` && |\n|  &&
+             `        </xsl:template>` && |\n|  &&
+             `        <xsl:output indent="yes" />` && |\n|  &&
+             `      </xsl:stylesheet>``;` && |\n|  &&
+             `` && |\n|  &&
+             `    // The XSLT processor and (de)serializers are expensive to construct, so` && |\n|  &&
+             `    // we keep them as module-level singletons.` && |\n|  &&
+             `    const _xmlSerializer = new XMLSerializer();` && |\n|  &&
+             `    const _domParser = new DOMParser();` && |\n|  &&
+             `    let _xsltProcessor = null;` && |\n|  &&
+             `` && |\n|  &&
+             `    function getXsltProcessor() {` && |\n|  &&
+             `      if (_xsltProcessor) return _xsltProcessor;` && |\n|  &&
+             `      const xsltDoc = _domParser.parseFromString(` && |\n|  &&
+             `        PRETTIFY_XSL,` && |\n|  &&
+             `        "application/xml",` && |\n|  &&
+             `      );` && |\n|  &&
+             `      _xsltProcessor = new XSLTProcessor();` && |\n|  &&
+             `      _xsltProcessor.importStylesheet(xsltDoc);` && |\n|  &&
+             `      return _xsltProcessor;` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    return Control.extend("z2ui5.cc.DebugTool", {` && |\n|  &&
+             `      // Reformat an XML string with indentation. If anything goes wrong the` && |\n|  &&
+             `      // original input is returned unchanged - the debug tool must never` && |\n|  &&
+             `      // crash the host app.` && |\n|  &&
+             `      prettifyXml(sourceXml) {` && |\n|  &&
+             `        if (!sourceXml) return "";` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const xmlDoc = _domParser.parseFromString(` && |\n|  &&
+             `            sourceXml,` && |\n|  &&
+             `            "application/xml",` && |\n|  &&
+             `          );` && |\n|  &&
+             `          const resultDoc = getXsltProcessor().transformToDocument(xmlDoc);` && |\n|  &&
+             `          if (!resultDoc) return sourceXml;` && |\n|  &&
+             `          const resultXml = _xmlSerializer.serializeToString(resultDoc);` && |\n|  &&
+             `          // The serializer escapes < and > inside text nodes; undo this so` && |\n|  &&
+             `          // the output is browseable XML again.` && |\n|  &&
+             `          return resultXml.replace(/&gt;|&lt;/g, (m) =>` && |\n|  &&
+             `            m === "&gt;" ? ">" : "<",` && |\n|  &&
+             `          );` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          return sourceXml;` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Called when the user picks an entry in the dropdown of the debug` && |\n|  &&
+             `      // dialog. Each case shows a different piece of internal state.` && |\n|  &&
+             `      onItemSelect(oEvent) {` && |\n|  &&
+             `        const oSource = oEvent.getSource();` && |\n|  &&
+             `        const selItem = oSource.getSelectedKey();` && |\n|  &&
+             `        const oView = z2ui5.oView;` && |\n|  &&
+             `        const oResponse = z2ui5.oResponse;` && |\n|  &&
+             `` && |\n|  &&
+             `        // Cache a bound version of displayEditor so we don't recreate the` && |\n|  &&
+             `        // bound function on every call.` && |\n|  &&
+             `        if (!this._displayEditorBound) {` && |\n|  &&
+             `          this._displayEditorBound = this.displayEditor.bind(this);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const displayEditor = this._displayEditorBound;` && |\n|  &&
+             `        const prettifyXml = this.prettifyXml;` && |\n|  &&
+             `` && |\n|  &&
+             `        switch (selItem) {` && |\n|  &&
+             `          case "CONFIG":` && |\n|  &&
+             `            displayEditor(oEvent, toJson(z2ui5.oConfig), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `` && |\n|  &&
+             `          case "MODEL": {` && |\n|  &&
+             `            const data =` && |\n|  &&
+             `              oView && oView.getModel() && oView.getModel().getData();` && |\n|  &&
+             `            displayEditor(oEvent, toJson(data), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "VIEW": {` && |\n|  &&
+             `            // Prefer the actual viewContent string; fall back to the XML` && |\n|  &&
+             `            // that arrived in the last server response.` && |\n|  &&
+             `            const viewContent =` && |\n|  &&
+             `              (oView && oView.mProperties && oView.mProperties.viewContent) ||` && |\n|  &&
+             `              (z2ui5.responseData &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT.PARAMS &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT.PARAMS.S_VIEW &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT.PARAMS.S_VIEW.XML);` && |\n|  &&
+             `            const rendered =` && |\n|  &&
+             `              oView && oView._xContent && oView._xContent.outerHTML;` && |\n|  &&
+             `            displayEditor(` && |\n|  &&
+             `              oEvent,` && |\n|  &&
+             `              prettifyXml(viewContent),` && |\n|  &&
+             `              "xml",` && |\n|  &&
+             `              prettifyXml(rendered),` && |\n|  &&
+             `            );` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "PLAIN":` && |\n|  &&
+             `            displayEditor(oEvent, toJson(z2ui5.responseData), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `` && |\n|  &&
+             `          case "REQUEST":` && |\n|  &&
+             `            displayEditor(oEvent, toJson(z2ui5.oBody), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `` && |\n|  &&
+             `          case "POPUP": {` && |\n|  &&
+             `            const xml =` && |\n|  &&
+             `              oResponse &&` && |\n|  &&
+             `              oResponse.PARAMS &&` && |\n|  &&
+             `              oResponse.PARAMS.S_POPUP &&` && |\n|  &&
+             `              oResponse.PARAMS.S_POPUP.XML;` && |\n|  &&
+             `            displayEditor(oEvent, prettifyXml(xml), "xml");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "POPUP_MODEL": {` && |\n|  &&
+             `            const data =` && |\n|  &&
+             `              z2ui5.oViewPopup &&` && |\n|  &&
+             `              z2ui5.oViewPopup.getModel() &&` && |\n|  &&
+             `              z2ui5.oViewPopup.getModel().getData();` && |\n|  &&
+             `            displayEditor(oEvent, toJson(data), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "POPOVER": {` && |\n|  &&
+             `            const xml =` && |\n|  &&
+             `              oResponse &&` && |\n|  &&
+             `              oResponse.PARAMS &&` && |\n|  &&
+             `              oResponse.PARAMS.S_POPOVER &&` && |\n|  &&
+             `              oResponse.PARAMS.S_POPOVER.XML;` && |\n|  &&
+             `            displayEditor(oEvent, prettifyXml(xml), "xml");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "POPOVER_MODEL": {` && |\n|  &&
+             `            const data =` && |\n|  &&
+             `              z2ui5.oViewPopover &&` && |\n|  &&
+             `              z2ui5.oViewPopover.getModel() &&` && |\n|  &&
+             `              z2ui5.oViewPopover.getModel().getData();` && |\n|  &&
+             `            displayEditor(oEvent, toJson(data), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "NEST1": {` && |\n|  &&
+             `            const nest = z2ui5.oViewNest;` && |\n|  &&
+             `            const xml =` && |\n|  &&
+             `              nest && nest.mProperties && nest.mProperties.viewContent;` && |\n|  &&
+             `            const rendered = nest && nest._xContent && nest._xContent.outerHTML;` && |\n|  &&
+             `            displayEditor(` && |\n|  &&
+             `              oEvent,` && |\n|  &&
+             `              prettifyXml(xml),` && |\n|  &&
+             `              "xml",` && |\n|  &&
+             `              prettifyXml(rendered),` && |\n|  &&
+             `            );` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "NEST1_MODEL": {` && |\n|  &&
+             `            const data =` && |\n|  &&
+             `              z2ui5.oViewNest &&` && |\n|  &&
+             `              z2ui5.oViewNest.getModel() &&` && |\n|  &&
+             `              z2ui5.oViewNest.getModel().getData();` && |\n|  &&
+             `            displayEditor(oEvent, toJson(data), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "NEST2": {` && |\n|  &&
+             `            const nest = z2ui5.oViewNest2;` && |\n|  &&
+             `            const xml =` && |\n|  &&
+             `              nest && nest.mProperties && nest.mProperties.viewContent;` && |\n|  &&
+             `            const rendered = nest && nest._xContent && nest._xContent.outerHTML;` && |\n|  &&
+             `            displayEditor(` && |\n|  &&
+             `              oEvent,` && |\n|  &&
+             `              prettifyXml(xml),` && |\n|  &&
+             `              "xml",` && |\n|  &&
+             `              prettifyXml(rendered),` && |\n|  &&
+             `            );` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "NEST2_MODEL": {` && |\n|  &&
+             `            const data =` && |\n|  &&
+             `              z2ui5.oViewNest2 &&` && |\n|  &&
+             `              z2ui5.oViewNest2.getModel() &&` && |\n|  &&
+             `              z2ui5.oViewNest2.getModel().getData();` && |\n|  &&
+             `            displayEditor(oEvent, toJson(data), "json");` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          case "SOURCE": {` && |\n|  &&
+             `            // Show the ABAP source of the running app inside an iframe.` && |\n|  &&
+             `            const parent = oSource.getParent();` && |\n|  &&
+             `            const content = parent && parent.getContent && parent.getContent();` && |\n|  &&
+             `            const contentControl =` && |\n|  &&
+             `              content &&` && |\n|  &&
+             `              content[2] &&` && |\n|  &&
+             `              content[2].getItems &&` && |\n|  &&
+             `              content[2].getItems()[0];` && |\n|  &&
+             `            if (!contentControl) break;` && |\n|  &&
+             `` && |\n|  &&
+             `            const appName =` && |\n|  &&
+             `              (z2ui5.responseData &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT &&` && |\n|  &&
+             `                z2ui5.responseData.S_FRONT.APP) ||` && |\n|  &&
+             `              "";` && |\n|  &&
+             `            const appId = encodeURIComponent(appName);` && |\n|  &&
+             `            const url = ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n|  &&
+             `            contentControl.setProperty(` && |\n|  &&
+             `              "content",` && |\n|  &&
+             `              ``<iframe id="test" src="${url}" height="800px" width="1200px" />``,` && |\n|  &&
+             `            );` && |\n|  &&
+             `` && |\n|  &&
+             `            const oModel = oSource.getModel();` && |\n|  &&
+             `            if (!oModel) break;` && |\n|  &&
+             `            const modelData = oModel.getData();` && |\n|  &&
+             `            modelData.editor_visible = false;` && |\n|  &&
+             `            modelData.source_visible = true;` && |\n|  &&
+             `            oModel.refresh();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Populates the dialog model so the right editor / source area is shown` && |\n|  &&
+             `      // with the given content. ``xcontent`` is the rendered DOM variant that` && |\n|  &&
+             `      // can be toggled in via the "Templating" button.` && |\n|  &&
+             `      displayEditor(oEvent, content, type, xcontent = "") {` && |\n|  &&
+             `        const oModel = oEvent.getSource().getModel();` && |\n|  &&
+             `        const modelData = oModel.getData();` && |\n|  &&
+             `        modelData.editor_visible = true;` && |\n|  &&
+             `        modelData.source_visible = false;` && |\n|  &&
+             `        modelData.isTemplating = !!(` && |\n|  &&
+             `          content && content.includes("xmlns:template")` && |\n|  &&
+             `        );` && |\n|  &&
+             `        modelData.value = content;` && |\n|  &&
+             `        modelData.previousValue = content;` && |\n|  &&
+             `        modelData.xContent = xcontent;` && |\n|  &&
+             `        modelData.type = type;` && |\n|  &&
+             `        oModel.refresh();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onTemplatingPress(oEvent) {` && |\n|  &&
+             `        const oSource = oEvent.getSource();` && |\n|  &&
+             `        const oModel = oSource.getModel();` && |\n|  &&
+             `        const modelData = oModel.getData();` && |\n|  &&
+             `        // Toggle between the original (previousValue) and the rendered DOM` && |\n|  &&
+             `        // (xContent) representation.` && |\n|  &&
+             `        if (oSource.getPressed()) {` && |\n|  &&
+             `          modelData.value = modelData.xContent;` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          modelData.value = modelData.previousValue;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        oModel.refresh();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onClose() {` && |\n|  &&
+             `        this.close();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async show() {` && |\n|  &&
+             `        // Guard against double-clicks while the fragment is still loading.` && |\n|  &&
+             `        if (this._showPending) return;` && |\n|  &&
+             `        this._showPending = true;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          if (!this.oDialog) {` && |\n|  &&
+             `            this.oDialog = await Fragment.load({` && |\n|  &&
+             `              name: "z2ui5.cc.DebugTool",` && |\n|  &&
+             `              controller: this,` && |\n|  &&
+             `            });` && |\n|  &&
+             `          }` && |\n|  &&
+             `          // If the user closed the app while the fragment was loading we` && |\n|  &&
+             `          // must throw the freshly created dialog away.` && |\n|  &&
+             `          if (this.isDestroyed && this.isDestroyed()) {` && |\n|  &&
+             `            if (this.oDialog) this.oDialog.destroy();` && |\n|  &&
+             `            this.oDialog = null;` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          const value = toJson(z2ui5.responseData);` && |\n|  &&
+             `          const oData = {` && |\n|  &&
+             `            type: "json",` && |\n|  &&
+             `            source_visible: false,` && |\n|  &&
+             `            editor_visible: true,` && |\n|  &&
+             `            value: value,` && |\n|  &&
+             `            xContent: "",` && |\n|  &&
+             `            previousValue: value,` && |\n|  &&
+             `            isTemplating: false,` && |\n|  &&
+             `            templatingSource: false,` && |\n|  &&
+             `            activeNest1: !!(` && |\n|  &&
+             `              z2ui5.oViewNest &&` && |\n|  &&
+             `              z2ui5.oViewNest.mProperties &&` && |\n|  &&
+             `              z2ui5.oViewNest.mProperties.viewContent` && |\n|  &&
+             `            ),` && |\n|  &&
+             `            activeNest2: !!(` && |\n|  &&
+             `              z2ui5.oViewNest2 &&` && |\n|  &&
+             `              z2ui5.oViewNest2.mProperties &&` && |\n|  &&
+             `              z2ui5.oViewNest2.mProperties.viewContent` && |\n|  &&
+             `            ),` && |\n|  &&
+             `            activePopup: !!(` && |\n|  &&
+             `              z2ui5.oResponse &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS.S_POPUP &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS.S_POPUP.XML` && |\n|  &&
+             `            ),` && |\n|  &&
+             `            activePopover: !!(` && |\n|  &&
+             `              z2ui5.oResponse &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS.S_POPOVER &&` && |\n|  &&
+             `              z2ui5.oResponse.PARAMS.S_POPOVER.XML` && |\n|  &&
+             `            ),` && |\n|  &&
+             `          };` && |\n|  &&
+             `` && |\n|  &&
+             `          const oModel = new JSONModel(oData);` && |\n|  &&
+             `          const oDialog = this.oDialog;` && |\n|  &&
+             `          oDialog.addStyleClass("dbg-ltr");` && |\n|  &&
+             `          oDialog.setModel(oModel);` && |\n|  &&
+             `          oDialog.open();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("DebugTool.show failed", e);` && |\n|  &&
+             `        } finally {` && |\n|  &&
+             `          this._showPending = false;` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      close() {` && |\n|  &&
+             `        if (!this.oDialog) return;` && |\n|  &&
+             `        const oDialog = this.oDialog;` && |\n|  &&
+             `        this.oDialog = null;` && |\n|  &&
+             `        oDialog.close();` && |\n|  &&
+             `        oDialog.destroy();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      toggle() {` && |\n|  &&
+             `        if (this.oDialog) {` && |\n|  &&
+             `          this.close();` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          this.show();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // The control itself renders nothing - it just provides the dialog API.` && |\n|  &&
+             `      renderer: { apiVersion: 2, render() {} },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_debugtool_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_debugtool_xml.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_debugtool_xml IMPLEMENTATION.
 
   METHOD get.
 
-    result = `<core:FragmentDefinition` &&
+    result =              `<core:FragmentDefinition` &&
              `    xmlns="sap.m"` &&
              `    xmlns:mvc="sap.ui.core.mvc"` &&
              `    xmlns:core="sap.ui.core"` &&

--- a/src/01/03/z2ui5_cl_app_index_html.clas.abap
+++ b/src/01/03/z2ui5_cl_app_index_html.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_index_html IMPLEMENTATION.
 
   METHOD get.
 
-    result = `<!DOCTYPE html>` &&
+    result =              `<!DOCTYPE html>` &&
              `<html lang="en">` &&
              `<head>` &&
              `    <meta charset="UTF-8">` &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
 
   METHOD get.
 
-    result = `{` &&
+    result =              `{` &&
              `  "_version": "1.65.0",` &&
              `  "sap.app": {` &&
              `    "id": "z2ui5",` &&

--- a/src/01/03/z2ui5_cl_app_models_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_models_js.clas.abap
@@ -18,23 +18,23 @@ CLASS z2ui5_cl_app_models_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  ["sap/ui/model/json/JSONModel", "sap/ui/Device"],` && |\n| &&
-             `  (JSONModel, Device) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    return {` && |\n| &&
-             `      // Creates a read-only JSON model that exposes the current device info` && |\n| &&
-             `      // (phone / tablet / desktop, orientation, ...) to the views.` && |\n| &&
-             `      createDeviceModel() {` && |\n| &&
-             `        const oModel = new JSONModel(Device);` && |\n| &&
-             `        oModel.setDefaultBindingMode("OneWay");` && |\n| &&
-             `        return oModel;` && |\n| &&
-             `      },` && |\n| &&
-             `    };` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
+    result =              `sap.ui.define(` && |\n|  &&
+             `  ["sap/ui/model/json/JSONModel", "sap/ui/Device"],` && |\n|  &&
+             `  (JSONModel, Device) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    return {` && |\n|  &&
+             `      // Creates a read-only JSON model that exposes the current device info` && |\n|  &&
+             `      // (phone / tablet / desktop, orientation, ...) to the views.` && |\n|  &&
+             `      createDeviceModel() {` && |\n|  &&
+             `        const oModel = new JSONModel(Device);` && |\n|  &&
+             `        oModel.setDefaultBindingMode("OneWay");` && |\n|  &&
+             `        return oModel;` && |\n|  &&
+             `      },` && |\n|  &&
+             `    };` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -18,477 +18,477 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  ["sap/ui/core/BusyIndicator", "sap/m/MessageBox"],` && |\n| &&
-             `  (BusyIndicator, MessageBox) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    // Errors longer than this are truncated before being shown to the user,` && |\n| &&
-             `    // so a stack trace from the backend cannot blow up the error overlay.` && |\n| &&
-             `    const ERROR_MAX_LENGTH = 50000;` && |\n| &&
-             `    const _MSG_TYPES = Object.freeze(["S_MSG_TOAST", "S_MSG_BOX"]);` && |\n| &&
-             `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    return {` && |\n| &&
-             `      endSession() {` && |\n| &&
-             `        if (!z2ui5.contextId) return;` && |\n| &&
-             `        // Best-effort notify the backend that the session ends. Errors are` && |\n| &&
-             `        // intentionally swallowed: the browser tab is closing anyway.` && |\n| &&
-             `        fetch(z2ui5.url, {` && |\n| &&
-             `          method: "HEAD",` && |\n| &&
-             `          keepalive: true,` && |\n| &&
-             `          headers: {` && |\n| &&
-             `            "sap-terminate": "session",` && |\n| &&
-             `            "sap-contextid": z2ui5.contextId,` && |\n| &&
-             `            "sap-contextid-accept": "header",` && |\n| &&
-             `          },` && |\n| &&
-             `        }).catch(() => {});` && |\n| &&
-             `        delete z2ui5.contextId;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _getDeviceInfo() {` && |\n| &&
-             `        const d = sap.ui.Device;` && |\n| &&
-             `        const sys = d.system;` && |\n| &&
-             `        const system = sys.phone` && |\n| &&
-             `          ? "phone"` && |\n| &&
-             `          : sys.tablet` && |\n| &&
-             `            ? "tablet"` && |\n| &&
-             `            : sys.combi` && |\n| &&
-             `              ? "combi"` && |\n| &&
-             `              : "desktop";` && |\n| &&
-             `        return {` && |\n| &&
-             `          SYSTEM: system,` && |\n| &&
-             `          ORIENTATION: d.orientation.portrait ? "portrait" : "landscape",` && |\n| &&
-             `          BROWSER: {` && |\n| &&
-             `            NAME: d.browser.name || "",` && |\n| &&
-             `            VERSION: String(d.browser.version || ""),` && |\n| &&
-             `          },` && |\n| &&
-             `          OS: {` && |\n| &&
-             `            NAME: d.os.name || "",` && |\n| &&
-             `            VERSION: String(d.os.version || ""),` && |\n| &&
-             `          },` && |\n| &&
-             `          RESIZE: {` && |\n| &&
-             `            WIDTH: d.resize.width || window.innerWidth,` && |\n| &&
-             `            HEIGHT: d.resize.height || window.innerHeight,` && |\n| &&
-             `          },` && |\n| &&
-             `          SUPPORT: {` && |\n| &&
-             `            TOUCH: d.support.touch || false,` && |\n| &&
-             `            POINTER: d.support.pointer || false,` && |\n| &&
-             `            RETINA: d.support.retina || false,` && |\n| &&
-             `          },` && |\n| &&
-             `        };` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _getFocusInfo() {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const active = document.activeElement;` && |\n| &&
-             `          if (!active) return {};` && |\n| &&
-             `          const ui5El =` && |\n| &&
-             `            sap.ui.core.Element && sap.ui.core.Element.closestTo` && |\n| &&
-             `              ? sap.ui.core.Element.closestTo(active)` && |\n| &&
-             `              : null;` && |\n| &&
-             `          if (!ui5El) return {};` && |\n| &&
-             `          const fullId = ui5El.getId();` && |\n| &&
-             `          const views = [` && |\n| &&
-             `            z2ui5.oView,` && |\n| &&
-             `            z2ui5.oViewNest,` && |\n| &&
-             `            z2ui5.oViewNest2,` && |\n| &&
-             `            z2ui5.oViewPopup,` && |\n| &&
-             `            z2ui5.oViewPopover,` && |\n| &&
-             `          ];` && |\n| &&
-             `          let id = fullId;` && |\n| &&
-             `          for (const v of views) {` && |\n| &&
-             `            if (!v) continue;` && |\n| &&
-             `            const prefix = v.getId() + "--";` && |\n| &&
-             `            if (fullId.startsWith(prefix)) {` && |\n| &&
-             `              id = fullId.slice(prefix.length);` && |\n| &&
-             `              break;` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `          return {` && |\n| &&
-             `            ID: id,` && |\n| &&
-             `            SELECTION_START: active.selectionStart || 0,` && |\n| &&
-             `            SELECTION_END: active.selectionEnd || 0,` && |\n| &&
-             `          };` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          return {};` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _getScrollInfo() {` && |\n| &&
-             `        // For each visible view, find the first scrollable descendant` && |\n| &&
-             `        // (typically a sap.m.Page) and return its current scroll offsets.` && |\n| &&
-             `        // X = scrollLeft (horizontal), Y = scrollTop (vertical).` && |\n| &&
-             `        // Only views that exist and have a scrollable target are included;` && |\n| &&
-             `        // empty slots are omitted to keep the request payload small.` && |\n| &&
-             `        const getOne = (view) => {` && |\n| &&
-             `          if (!view || !view.findAggregatedObjects) return null;` && |\n| &&
-             `          let target = null;` && |\n| &&
-             `          try {` && |\n| &&
-             `            const candidates = view.findAggregatedObjects(true, (c) => {` && |\n| &&
-             `              try {` && |\n| &&
-             `                return c.getScrollDelegate && c.getScrollDelegate();` && |\n| &&
-             `              } catch (e) {` && |\n| &&
-             `                return false;` && |\n| &&
-             `              }` && |\n| &&
-             `            });` && |\n| &&
-             `            target = candidates && candidates[0];` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            return null;` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!target) return null;` && |\n| &&
-             `          let x = 0;` && |\n| &&
-             `          let y = 0;` && |\n| &&
-             `          try {` && |\n| &&
-             `            const d = target.getScrollDelegate();` && |\n| &&
-             `            if (d) {` && |\n| &&
-             `              if (d.getScrollTop) y = d.getScrollTop() || 0;` && |\n| &&
-             `              if (d.getScrollLeft) x = d.getScrollLeft() || 0;` && |\n| &&
-             `            }` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            // ignored - fall through to DOM lookup` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!x || !y) {` && |\n| &&
-             `            const el = document.getElementById(``${target.getId()}-inner``);` && |\n| &&
-             `            if (el) {` && |\n| &&
-             `              if (!y) y = el.scrollTop || 0;` && |\n| &&
-             `              if (!x) x = el.scrollLeft || 0;` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `          let id = target.getId();` && |\n| &&
-             `          const prefix = view.getId() + "--";` && |\n| &&
-             `          if (id.startsWith(prefix)) id = id.slice(prefix.length);` && |\n| &&
-             `          return { ID: id, X: x, Y: y };` && |\n| &&
-             `        };` && |\n| &&
-             `        const out = {};` && |\n| &&
-             `        const slots = [` && |\n| &&
-             `          ["MAIN", z2ui5.oView],` && |\n| &&
-             `          ["NEST", z2ui5.oViewNest],` && |\n| &&
-             `          ["NEST2", z2ui5.oViewNest2],` && |\n| &&
-             `          ["POPUP", z2ui5.oViewPopup],` && |\n| &&
-             `          ["POPOVER", z2ui5.oViewPopover],` && |\n| &&
-             `        ];` && |\n| &&
-             `        for (const [key, view] of slots) {` && |\n| &&
-             `          const v = getOne(view);` && |\n| &&
-             `          if (v) out[key] = v;` && |\n| &&
-             `        }` && |\n| &&
-             `        // Returning undefined lets JSON.stringify omit S_SCROLL entirely.` && |\n| &&
-             `        return Object.keys(out).length ? out : undefined;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      Roundtrip() {` && |\n| &&
-             `        z2ui5.checkTimerActive = false;` && |\n| &&
-             `        z2ui5.checkNestAfter = false;` && |\n| &&
-             `        z2ui5.checkNestAfter2 = false;` && |\n| &&
-             `` && |\n| &&
-             `        if (!z2ui5.oBody) z2ui5.oBody = {};` && |\n| &&
-             `        const oBody = z2ui5.oBody;` && |\n| &&
-             `` && |\n| &&
-             `        // Pick the first event argument (event name) safely.` && |\n| &&
-             `        let eventName;` && |\n| &&
-             `        if (oBody.ARGUMENTS && oBody.ARGUMENTS[0]) {` && |\n| &&
-             `          eventName = oBody.ARGUMENTS[0][0];` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        oBody.S_FRONT = {` && |\n| &&
-             `          CONFIG: {` && |\n| &&
-             `            S_UI5: z2ui5.oConfig && z2ui5.oConfig.S_UI5,` && |\n| &&
-             `            S_DEVICE: this._getDeviceInfo(),` && |\n| &&
-             `            S_FOCUS: this._getFocusInfo(),` && |\n| &&
-             `            S_SCROLL: this._getScrollInfo(),` && |\n| &&
-             `            ComponentData: z2ui5.oConfig && z2ui5.oConfig.ComponentData,` && |\n| &&
-             `          },` && |\n| &&
-             `          ID: oBody.ID,` && |\n| &&
-             `          ORIGIN: window.location.origin,` && |\n| &&
-             `          PATHNAME: window.location.pathname,` && |\n| &&
-             `          SEARCH: z2ui5.search || window.location.search,` && |\n| &&
-             `          VIEW: oBody.VIEWNAME,` && |\n| &&
-             `          EVENT: eventName,` && |\n| &&
-             `          HASH: window.location.hash,` && |\n| &&
-             `        };` && |\n| &&
-             `        const sFront = oBody.S_FRONT;` && |\n| &&
-             `` && |\n| &&
-             `        // The first argument was the event name (already stored as EVENT),` && |\n| &&
-             `        // the remaining entries are the actual event arguments.` && |\n| &&
-             `        if (oBody.ARGUMENTS) oBody.ARGUMENTS.shift();` && |\n| &&
-             `        sFront.T_EVENT_ARG = oBody.ARGUMENTS;` && |\n| &&
-             `` && |\n| &&
-             `        delete oBody.ID;` && |\n| &&
-             `        delete oBody.VIEWNAME;` && |\n| &&
-             `        delete oBody.ARGUMENTS;` && |\n| &&
-             `` && |\n| &&
-             `        // Remove empty / undefined fields so the backend request stays small` && |\n| &&
-             `        // and these keys are not present in the JSON sent over the wire.` && |\n| &&
-             `        if (!sFront.T_EVENT_ARG || sFront.T_EVENT_ARG.length === 0) {` && |\n| &&
-             `          delete sFront.T_EVENT_ARG;` && |\n| &&
-             `        }` && |\n| &&
-             `        if (sFront.SEARCH === "") delete sFront.SEARCH;` && |\n| &&
-             `        if (!oBody.XX) delete oBody.XX;` && |\n| &&
-             `` && |\n| &&
-             `        this.readHttp();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async readHttp() {` && |\n| &&
-             `        // Step 1: send the request.` && |\n| &&
-             `        let response;` && |\n| &&
-             `        try {` && |\n| &&
-             `          response = await fetch(z2ui5.url, {` && |\n| &&
-             `            method: "POST",` && |\n| &&
-             `            headers: {` && |\n| &&
-             `              "Content-Type": "application/json",` && |\n| &&
-             `              "sap-contextid-accept": "header",` && |\n| &&
-             `              "sap-contextid": z2ui5.contextId || "",` && |\n| &&
-             `            },` && |\n| &&
-             `            body: JSON.stringify({ value: z2ui5.oBody }),` && |\n| &&
-             `          });` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          this.responseError(``Network error: ${e.message}``);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        z2ui5.contextId = response.headers.get("sap-contextid");` && |\n| &&
-             `` && |\n| &&
-             `        // Step 2: if the HTTP status is not 2xx, treat the body as error text.` && |\n| &&
-             `        if (!response.ok) {` && |\n| &&
-             `          let text;` && |\n| &&
-             `          try {` && |\n| &&
-             `            text = await response.text();` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            text = ``HTTP ${response.status}: could not read error body``;` && |\n| &&
-             `          }` && |\n| &&
-             `          this.responseError(text);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        // Step 3: parse the JSON body.` && |\n| &&
-             `        let responseData;` && |\n| &&
-             `        try {` && |\n| &&
-             `          responseData = await response.json();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          this.responseError(``Invalid JSON response: ${e.message}``);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        if (!responseData || !responseData.S_FRONT) {` && |\n| &&
-             `          this.responseError("Invalid response: missing S_FRONT");` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        // Step 4: hand the parsed response to the success handler.` && |\n| &&
-             `        z2ui5.responseData = responseData;` && |\n| &&
-             `        z2ui5.xxChangedPaths = new Set();` && |\n| &&
-             `        this.responseSuccess({` && |\n| &&
-             `          ID: responseData.S_FRONT.ID,` && |\n| &&
-             `          PARAMS: responseData.S_FRONT.PARAMS,` && |\n| &&
-             `          OVIEWMODEL: responseData.MODEL,` && |\n| &&
-             `        });` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async responseSuccess(response) {` && |\n| &&
-             `        const oController = z2ui5.oController;` && |\n| &&
-             `        try {` && |\n| &&
-             `          z2ui5.oResponse = response;` && |\n| &&
-             `          const params = response.PARAMS;` && |\n| &&
-             `          const sView = params && params.S_VIEW;` && |\n| &&
-             `` && |\n| &&
-             `          if (sView && sView.CHECK_DESTROY) oController.ViewDestroy();` && |\n| &&
-             `` && |\n| &&
-             `          // The backend can send small JS snippets to run after the response.` && |\n| &&
-             `          // Each snippet is either a literal expression or an "eF(...)" call` && |\n| &&
-             `          // whose arguments are wrapped in single quotes.` && |\n| &&
-             `          const followUp = params && params.S_FOLLOW_UP_ACTION;` && |\n| &&
-             `          const customJs = followUp && followUp.CUSTOM_JS;` && |\n| &&
-             `          if (customJs) {` && |\n| &&
-             `            queueMicrotask(() => {` && |\n| &&
-             `              if (oController.isDestroyed && oController.isDestroyed()) return;` && |\n| &&
-             `              for (const item of customJs) {` && |\n| &&
-             `                this._runCustomJs(item, oController);` && |\n| &&
-             `              }` && |\n| &&
-             `            });` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          for (const t of _MSG_TYPES) oController.showMessage(t, params);` && |\n| &&
-             `` && |\n| &&
-             `          // Full view replacement -> destroy & rebuild, nothing more to do.` && |\n| &&
-             `          if (sView && sView.XML) {` && |\n| &&
-             `            oController.ViewDestroy();` && |\n| &&
-             `            await oController.displayView(sView.XML, response.OVIEWMODEL);` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          // Partial response: refresh whichever existing views the backend` && |\n| &&
-             `          // sent updates for.` && |\n| &&
-             `          const updateTargets = [` && |\n| &&
-             `            ["S_VIEW", z2ui5.oView],` && |\n| &&
-             `            ["S_VIEW_NEST", z2ui5.oViewNest],` && |\n| &&
-             `            ["S_VIEW_NEST2", z2ui5.oViewNest2],` && |\n| &&
-             `            ["S_POPUP", z2ui5.oViewPopup],` && |\n| &&
-             `            ["S_POPOVER", z2ui5.oViewPopover],` && |\n| &&
-             `          ];` && |\n| &&
-             `          for (const [key, view] of updateTargets) {` && |\n| &&
-             `            oController.updateModelIfRequired(key, view);` && |\n| &&
-             `          }` && |\n| &&
-             `          oController._processAfterRendering();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          BusyIndicator.hide();` && |\n| &&
-             `          z2ui5.isBusy = false;` && |\n| &&
-             `          logError("responseSuccess: unexpected error", e);` && |\n| &&
-             `          const msg = e.message || "";` && |\n| &&
-             `          if (msg.includes("openui5") && msg.includes("script load error")) {` && |\n| &&
-             `            oController.checkSDKcompatibility(e);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            MessageBox.error(e.toLocaleString());` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Executes a single custom-JS snippet from the backend.` && |\n| &&
-             `      // Format A:  "alert(123)"           -> runs the expression` && |\n| &&
-             `      // Format B:  "eF('A','B','C')"      -> calls oController.eF('A','B','C')` && |\n| &&
-             `      _runCustomJs(item, oController) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const parts = item.split("'");` && |\n| &&
-             `          // Arguments live at the odd indices between single quotes.` && |\n| &&
-             `          const args = parts.filter((_, index) => index % 2 === 1);` && |\n| &&
-             `          if (args.length > 0) {` && |\n| &&
-             `            oController.eF(...args);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            // eslint-disable-next-line no-new-func` && |\n| &&
-             `            Function("return " + parts[0])();` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("customJs: execution failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _getOrCreateErrorContainer() {` && |\n| &&
-             `        const existing = document.getElementById("serverErrorContainer");` && |\n| &&
-             `        if (existing) return existing;` && |\n| &&
-             `` && |\n| &&
-             `        const container = document.createElement("div");` && |\n| &&
-             `        container.id = "serverErrorContainer";` && |\n| &&
-             `        container.style.cssText = ``` && |\n| &&
-             `          position: fixed;` && |\n| &&
-             `          top: 50%;` && |\n| &&
-             `          left: 50%;` && |\n| &&
-             `          transform: translate(-50%, -50%);` && |\n| &&
-             `          width: 90%;` && |\n| &&
-             `          height: 90%;` && |\n| &&
-             `          background: white;` && |\n| &&
-             `          border: 2px solid #d32f2f;` && |\n| &&
-             `          border-radius: 4px;` && |\n| &&
-             `          box-shadow: 0 4px 6px rgba(0,0,0,0.3);` && |\n| &&
-             `          z-index: 9999;` && |\n| &&
-             `          display: flex;` && |\n| &&
-             `          flex-direction: column;` && |\n| &&
-             `        ``;` && |\n| &&
-             `        document.body.appendChild(container);` && |\n| &&
-             `        return container;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      responseError(response) {` && |\n| &&
-             `        BusyIndicator.hide();` && |\n| &&
-             `        z2ui5.isBusy = false;` && |\n| &&
-             `` && |\n| &&
-             `        const full = String(response);` && |\n| &&
-             `        let errorMessage;` && |\n| &&
-             `        if (full.length > ERROR_MAX_LENGTH) {` && |\n| &&
-             `          errorMessage =` && |\n| &&
-             `            full.slice(0, ERROR_MAX_LENGTH) +` && |\n| &&
-             `            "\n\n<!-- Content truncated - too long -->";` && |\n| &&
-             `        } else {` && |\n| &&
-             `          errorMessage = full;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        const errorContainer = this._getOrCreateErrorContainer();` && |\n| &&
-             `        errorContainer.textContent = "";` && |\n| &&
-             `` && |\n| &&
-             `        // Header bar with title and action buttons.` && |\n| &&
-             `        const headerDiv = document.createElement("div");` && |\n| &&
-             `        headerDiv.style.cssText =` && |\n| &&
-             `          "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";` && |\n| &&
-             `` && |\n| &&
-             `        const h3 = document.createElement("h3");` && |\n| &&
-             `        h3.textContent = "Server Error - Please Restart The App";` && |\n| &&
-             `        h3.style.cssText = "margin: 0";` && |\n| &&
-             `        headerDiv.appendChild(h3);` && |\n| &&
-             `` && |\n| &&
-             `        const btnStyle =` && |\n| &&
-             `          "padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;";` && |\n| &&
-             `` && |\n| &&
-             `        const actionsDiv = document.createElement("div");` && |\n| &&
-             `        actionsDiv.style.cssText = "display: flex; gap: 8px;";` && |\n| &&
-             `` && |\n| &&
+    result =              `sap.ui.define(` && |\n|  &&
+             `  ["sap/ui/core/BusyIndicator", "sap/m/MessageBox"],` && |\n|  &&
+             `  (BusyIndicator, MessageBox) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    // Errors longer than this are truncated before being shown to the user,` && |\n|  &&
+             `    // so a stack trace from the backend cannot blow up the error overlay.` && |\n|  &&
+             `    const ERROR_MAX_LENGTH = 50000;` && |\n|  &&
+             `    const _MSG_TYPES = Object.freeze(["S_MSG_TOAST", "S_MSG_BOX"]);` && |\n|  &&
+             `` && |\n|  &&
+             `    // Append an entry to the global error log. We create the array on first use.` && |\n|  &&
+             `    function logError(message, error) {` && |\n|  &&
+             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n|  &&
+             `      z2ui5.errors.push({` && |\n|  &&
+             `        message: message,` && |\n|  &&
+             `        error: error,` && |\n|  &&
+             `        ts: new Date().toISOString(),` && |\n|  &&
+             `      });` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    return {` && |\n|  &&
+             `      endSession() {` && |\n|  &&
+             `        if (!z2ui5.contextId) return;` && |\n|  &&
+             `        // Best-effort notify the backend that the session ends. Errors are` && |\n|  &&
+             `        // intentionally swallowed: the browser tab is closing anyway.` && |\n|  &&
+             `        fetch(z2ui5.url, {` && |\n|  &&
+             `          method: "HEAD",` && |\n|  &&
+             `          keepalive: true,` && |\n|  &&
+             `          headers: {` && |\n|  &&
+             `            "sap-terminate": "session",` && |\n|  &&
+             `            "sap-contextid": z2ui5.contextId,` && |\n|  &&
+             `            "sap-contextid-accept": "header",` && |\n|  &&
+             `          },` && |\n|  &&
+             `        }).catch(() => {});` && |\n|  &&
+             `        delete z2ui5.contextId;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _getDeviceInfo() {` && |\n|  &&
+             `        const d = sap.ui.Device;` && |\n|  &&
+             `        const sys = d.system;` && |\n|  &&
+             `        const system = sys.phone` && |\n|  &&
+             `          ? "phone"` && |\n|  &&
+             `          : sys.tablet` && |\n|  &&
+             `            ? "tablet"` && |\n|  &&
+             `            : sys.combi` && |\n|  &&
+             `              ? "combi"` && |\n|  &&
+             `              : "desktop";` && |\n|  &&
+             `        return {` && |\n|  &&
+             `          SYSTEM: system,` && |\n|  &&
+             `          ORIENTATION: d.orientation.portrait ? "portrait" : "landscape",` && |\n|  &&
+             `          BROWSER: {` && |\n|  &&
+             `            NAME: d.browser.name || "",` && |\n|  &&
+             `            VERSION: String(d.browser.version || ""),` && |\n|  &&
+             `          },` && |\n|  &&
+             `          OS: {` && |\n|  &&
+             `            NAME: d.os.name || "",` && |\n|  &&
+             `            VERSION: String(d.os.version || ""),` && |\n|  &&
+             `          },` && |\n|  &&
+             `          RESIZE: {` && |\n|  &&
+             `            WIDTH: d.resize.width || window.innerWidth,` && |\n|  &&
+             `            HEIGHT: d.resize.height || window.innerHeight,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          SUPPORT: {` && |\n|  &&
+             `            TOUCH: d.support.touch || false,` && |\n|  &&
+             `            POINTER: d.support.pointer || false,` && |\n|  &&
+             `            RETINA: d.support.retina || false,` && |\n|  &&
+             `          },` && |\n|  &&
+             `        };` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _getFocusInfo() {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const active = document.activeElement;` && |\n|  &&
+             `          if (!active) return {};` && |\n|  &&
+             `          const ui5El =` && |\n|  &&
+             `            sap.ui.core.Element && sap.ui.core.Element.closestTo` && |\n|  &&
+             `              ? sap.ui.core.Element.closestTo(active)` && |\n|  &&
+             `              : null;` && |\n|  &&
+             `          if (!ui5El) return {};` && |\n|  &&
+             `          const fullId = ui5El.getId();` && |\n|  &&
+             `          const views = [` && |\n|  &&
+             `            z2ui5.oView,` && |\n|  &&
+             `            z2ui5.oViewNest,` && |\n|  &&
+             `            z2ui5.oViewNest2,` && |\n|  &&
+             `            z2ui5.oViewPopup,` && |\n|  &&
+             `            z2ui5.oViewPopover,` && |\n|  &&
+             `          ];` && |\n|  &&
+             `          let id = fullId;` && |\n|  &&
+             `          for (const v of views) {` && |\n|  &&
+             `            if (!v) continue;` && |\n|  &&
+             `            const prefix = v.getId() + "--";` && |\n|  &&
+             `            if (fullId.startsWith(prefix)) {` && |\n|  &&
+             `              id = fullId.slice(prefix.length);` && |\n|  &&
+             `              break;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `          return {` && |\n|  &&
+             `            ID: id,` && |\n|  &&
+             `            SELECTION_START: active.selectionStart || 0,` && |\n|  &&
+             `            SELECTION_END: active.selectionEnd || 0,` && |\n|  &&
+             `          };` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          return {};` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _getScrollInfo() {` && |\n|  &&
+             `        // For each visible view, find the first scrollable descendant` && |\n|  &&
+             `        // (typically a sap.m.Page) and return its current scroll offsets.` && |\n|  &&
+             `        // X = scrollLeft (horizontal), Y = scrollTop (vertical).` && |\n|  &&
+             `        // Only views that exist and have a scrollable target are included;` && |\n|  &&
+             `        // empty slots are omitted to keep the request payload small.` && |\n|  &&
+             `        const getOne = (view) => {` && |\n|  &&
+             `          if (!view || !view.findAggregatedObjects) return null;` && |\n|  &&
+             `          let target = null;` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const candidates = view.findAggregatedObjects(true, (c) => {` && |\n|  &&
+             `              try {` && |\n|  &&
+             `                return c.getScrollDelegate && c.getScrollDelegate();` && |\n|  &&
+             `              } catch (e) {` && |\n|  &&
+             `                return false;` && |\n|  &&
+             `              }` && |\n|  &&
+             `            });` && |\n|  &&
+             `            target = candidates && candidates[0];` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            return null;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (!target) return null;` && |\n|  &&
+             `          let x = 0;` && |\n|  &&
+             `          let y = 0;` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const d = target.getScrollDelegate();` && |\n|  &&
+             `            if (d) {` && |\n|  &&
+             `              if (d.getScrollTop) y = d.getScrollTop() || 0;` && |\n|  &&
+             `              if (d.getScrollLeft) x = d.getScrollLeft() || 0;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            // ignored - fall through to DOM lookup` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (!x || !y) {` && |\n|  &&
+             `            const el = document.getElementById(``${target.getId()}-inner``);` && |\n|  &&
+             `            if (el) {` && |\n|  &&
+             `              if (!y) y = el.scrollTop || 0;` && |\n|  &&
+             `              if (!x) x = el.scrollLeft || 0;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `          let id = target.getId();` && |\n|  &&
+             `          const prefix = view.getId() + "--";` && |\n|  &&
+             `          if (id.startsWith(prefix)) id = id.slice(prefix.length);` && |\n|  &&
+             `          return { ID: id, X: x, Y: y };` && |\n|  &&
+             `        };` && |\n|  &&
+             `        const out = {};` && |\n|  &&
+             `        const slots = [` && |\n|  &&
+             `          ["MAIN", z2ui5.oView],` && |\n|  &&
+             `          ["NEST", z2ui5.oViewNest],` && |\n|  &&
+             `          ["NEST2", z2ui5.oViewNest2],` && |\n|  &&
+             `          ["POPUP", z2ui5.oViewPopup],` && |\n|  &&
+             `          ["POPOVER", z2ui5.oViewPopover],` && |\n|  &&
+             `        ];` && |\n|  &&
+             `        for (const [key, view] of slots) {` && |\n|  &&
+             `          const v = getOne(view);` && |\n|  &&
+             `          if (v) out[key] = v;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        // Returning undefined lets JSON.stringify omit S_SCROLL entirely.` && |\n|  &&
+             `        return Object.keys(out).length ? out : undefined;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      Roundtrip() {` && |\n|  &&
+             `        z2ui5.checkTimerActive = false;` && |\n|  &&
+             `        z2ui5.checkNestAfter = false;` && |\n|  &&
+             `        z2ui5.checkNestAfter2 = false;` && |\n|  &&
+             `` && |\n|  &&
+             `        if (!z2ui5.oBody) z2ui5.oBody = {};` && |\n|  &&
+             `        const oBody = z2ui5.oBody;` && |\n|  &&
+             `` && |\n|  &&
+             `        // Pick the first event argument (event name) safely.` && |\n|  &&
+             `        let eventName;` && |\n|  &&
+             `        if (oBody.ARGUMENTS && oBody.ARGUMENTS[0]) {` && |\n|  &&
+             `          eventName = oBody.ARGUMENTS[0][0];` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        oBody.S_FRONT = {` && |\n|  &&
+             `          CONFIG: {` && |\n|  &&
+             `            S_UI5: z2ui5.oConfig && z2ui5.oConfig.S_UI5,` && |\n|  &&
+             `            S_DEVICE: this._getDeviceInfo(),` && |\n|  &&
+             `            S_FOCUS: this._getFocusInfo(),` && |\n|  &&
+             `            S_SCROLL: this._getScrollInfo(),` && |\n|  &&
+             `            ComponentData: z2ui5.oConfig && z2ui5.oConfig.ComponentData,` && |\n|  &&
+             `          },` && |\n|  &&
+             `          ID: oBody.ID,` && |\n|  &&
+             `          ORIGIN: window.location.origin,` && |\n|  &&
+             `          PATHNAME: window.location.pathname,` && |\n|  &&
+             `          SEARCH: z2ui5.search || window.location.search,` && |\n|  &&
+             `          VIEW: oBody.VIEWNAME,` && |\n|  &&
+             `          EVENT: eventName,` && |\n|  &&
+             `          HASH: window.location.hash,` && |\n|  &&
+             `        };` && |\n|  &&
+             `        const sFront = oBody.S_FRONT;` && |\n|  &&
+             `` && |\n|  &&
+             `        // The first argument was the event name (already stored as EVENT),` && |\n|  &&
+             `        // the remaining entries are the actual event arguments.` && |\n|  &&
+             `        if (oBody.ARGUMENTS) oBody.ARGUMENTS.shift();` && |\n|  &&
+             `        sFront.T_EVENT_ARG = oBody.ARGUMENTS;` && |\n|  &&
+             `` && |\n|  &&
+             `        delete oBody.ID;` && |\n|  &&
+             `        delete oBody.VIEWNAME;` && |\n|  &&
+             `        delete oBody.ARGUMENTS;` && |\n|  &&
+             `` && |\n|  &&
+             `        // Remove empty / undefined fields so the backend request stays small` && |\n|  &&
+             `        // and these keys are not present in the JSON sent over the wire.` && |\n|  &&
+             `        if (!sFront.T_EVENT_ARG || sFront.T_EVENT_ARG.length === 0) {` && |\n|  &&
+             `          delete sFront.T_EVENT_ARG;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (sFront.SEARCH === "") delete sFront.SEARCH;` && |\n|  &&
+             `        if (!oBody.XX) delete oBody.XX;` && |\n|  &&
+             `` && |\n|  &&
+             `        this.readHttp();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async readHttp() {` && |\n|  &&
+             `        // Step 1: send the request.` && |\n|  &&
+             `        let response;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          response = await fetch(z2ui5.url, {` && |\n|  &&
+             `            method: "POST",` && |\n|  &&
+             `            headers: {` && |\n|  &&
+             `              "Content-Type": "application/json",` && |\n|  &&
+             `              "sap-contextid-accept": "header",` && |\n|  &&
+             `              "sap-contextid": z2ui5.contextId || "",` && |\n|  &&
+             `            },` && |\n|  &&
+             `            body: JSON.stringify({ value: z2ui5.oBody }),` && |\n|  &&
+             `          });` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          this.responseError(``Network error: ${e.message}``);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        z2ui5.contextId = response.headers.get("sap-contextid");` && |\n|  &&
+             `` && |\n|  &&
+             `        // Step 2: if the HTTP status is not 2xx, treat the body as error text.` && |\n|  &&
+             `        if (!response.ok) {` && |\n|  &&
+             `          let text;` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            text = await response.text();` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            text = ``HTTP ${response.status}: could not read error body``;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          this.responseError(text);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        // Step 3: parse the JSON body.` && |\n|  &&
+             `        let responseData;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          responseData = await response.json();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          this.responseError(``Invalid JSON response: ${e.message}``);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (!responseData || !responseData.S_FRONT) {` && |\n|  &&
+             `          this.responseError("Invalid response: missing S_FRONT");` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        // Step 4: hand the parsed response to the success handler.` && |\n|  &&
+             `        z2ui5.responseData = responseData;` && |\n|  &&
+             `        z2ui5.xxChangedPaths = new Set();` && |\n|  &&
+             `        this.responseSuccess({` && |\n|  &&
+             `          ID: responseData.S_FRONT.ID,` && |\n|  &&
+             `          PARAMS: responseData.S_FRONT.PARAMS,` && |\n|  &&
+             `          OVIEWMODEL: responseData.MODEL,` && |\n|  &&
+             `        });` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async responseSuccess(response) {` && |\n|  &&
+             `        const oController = z2ui5.oController;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          z2ui5.oResponse = response;` && |\n|  &&
+             `          const params = response.PARAMS;` && |\n|  &&
+             `          const sView = params && params.S_VIEW;` && |\n|  &&
+             `` && |\n|  &&
+             `          if (sView && sView.CHECK_DESTROY) oController.ViewDestroy();` && |\n|  &&
+             `` && |\n|  &&
+             `          // The backend can send small JS snippets to run after the response.` && |\n|  &&
+             `          // Each snippet is either a literal expression or an "eF(...)" call` && |\n|  &&
+             `          // whose arguments are wrapped in single quotes.` && |\n|  &&
+             `          const followUp = params && params.S_FOLLOW_UP_ACTION;` && |\n|  &&
+             `          const customJs = followUp && followUp.CUSTOM_JS;` && |\n|  &&
+             `          if (customJs) {` && |\n|  &&
+             `            queueMicrotask(() => {` && |\n|  &&
+             `              if (oController.isDestroyed && oController.isDestroyed()) return;` && |\n|  &&
+             `              for (const item of customJs) {` && |\n|  &&
+             `                this._runCustomJs(item, oController);` && |\n|  &&
+             `              }` && |\n|  &&
+             `            });` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          for (const t of _MSG_TYPES) oController.showMessage(t, params);` && |\n|  &&
+             `` && |\n|  &&
+             `          // Full view replacement -> destroy & rebuild, nothing more to do.` && |\n|  &&
+             `          if (sView && sView.XML) {` && |\n|  &&
+             `            oController.ViewDestroy();` && |\n|  &&
+             `            await oController.displayView(sView.XML, response.OVIEWMODEL);` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          // Partial response: refresh whichever existing views the backend` && |\n|  &&
+             `          // sent updates for.` && |\n|  &&
+             `          const updateTargets = [` && |\n|  &&
+             `            ["S_VIEW", z2ui5.oView],` && |\n|  &&
+             `            ["S_VIEW_NEST", z2ui5.oViewNest],` && |\n|  &&
+             `            ["S_VIEW_NEST2", z2ui5.oViewNest2],` && |\n|  &&
+             `            ["S_POPUP", z2ui5.oViewPopup],` && |\n|  &&
+             `            ["S_POPOVER", z2ui5.oViewPopover],` && |\n|  &&
+             `          ];` && |\n|  &&
+             `          for (const [key, view] of updateTargets) {` && |\n|  &&
+             `            oController.updateModelIfRequired(key, view);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          oController._processAfterRendering();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          BusyIndicator.hide();` && |\n|  &&
+             `          z2ui5.isBusy = false;` && |\n|  &&
+             `          logError("responseSuccess: unexpected error", e);` && |\n|  &&
+             `          const msg = e.message || "";` && |\n|  &&
+             `          if (msg.includes("openui5") && msg.includes("script load error")) {` && |\n|  &&
+             `            oController.checkSDKcompatibility(e);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            MessageBox.error(e.toLocaleString());` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Executes a single custom-JS snippet from the backend.` && |\n|  &&
+             `      // Format A:  "alert(123)"           -> runs the expression` && |\n|  &&
+             `      // Format B:  "eF('A','B','C')"      -> calls oController.eF('A','B','C')` && |\n|  &&
+             `      _runCustomJs(item, oController) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const parts = item.split("'");` && |\n|  &&
+             `          // Arguments live at the odd indices between single quotes.` && |\n|  &&
+             `          const args = parts.filter((_, index) => index % 2 === 1);` && |\n|  &&
+             `          if (args.length > 0) {` && |\n|  &&
+             `            oController.eF(...args);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            // eslint-disable-next-line no-new-func` && |\n|  &&
+             `            Function("return " + parts[0])();` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("customJs: execution failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _getOrCreateErrorContainer() {` && |\n|  &&
+             `        const existing = document.getElementById("serverErrorContainer");` && |\n|  &&
+             `        if (existing) return existing;` && |\n|  &&
+             `` && |\n|  &&
+             `        const container = document.createElement("div");` && |\n|  &&
+             `        container.id = "serverErrorContainer";` && |\n|  &&
+             `        container.style.cssText = ``` && |\n|  &&
+             `          position: fixed;` && |\n|  &&
+             `          top: 50%;` && |\n|  &&
+             `          left: 50%;` && |\n|  &&
+             `          transform: translate(-50%, -50%);` && |\n|  &&
+             `          width: 90%;` && |\n|  &&
+             `          height: 90%;` && |\n|  &&
+             `          background: white;` && |\n|  &&
+             `          border: 2px solid #d32f2f;` && |\n|  &&
+             `          border-radius: 4px;` && |\n|  &&
+             `          box-shadow: 0 4px 6px rgba(0,0,0,0.3);` && |\n|  &&
+             `          z-index: 9999;` && |\n|  &&
+             `          display: flex;` && |\n|  &&
+             `          flex-direction: column;` && |\n|  &&
+             `        ``;` && |\n|  &&
+             `        document.body.appendChild(container);` && |\n|  &&
+             `        return container;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      responseError(response) {` && |\n|  &&
+             `        BusyIndicator.hide();` && |\n|  &&
+             `        z2ui5.isBusy = false;` && |\n|  &&
+             `` && |\n|  &&
+             `        const full = String(response);` && |\n|  &&
+             `        let errorMessage;` && |\n|  &&
+             `        if (full.length > ERROR_MAX_LENGTH) {` && |\n|  &&
+             `          errorMessage =` && |\n|  &&
+             `            full.slice(0, ERROR_MAX_LENGTH) +` && |\n|  &&
+             `            "\n\n<!-- Content truncated - too long -->";` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          errorMessage = full;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        const errorContainer = this._getOrCreateErrorContainer();` && |\n|  &&
+             `        errorContainer.textContent = "";` && |\n|  &&
+             `` && |\n|  &&
+             `        // Header bar with title and action buttons.` && |\n|  &&
+             `        const headerDiv = document.createElement("div");` && |\n|  &&
+             `        headerDiv.style.cssText =` && |\n|  &&
+             `          "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";` && |\n|  &&
+             `` && |\n|  &&
+             `        const h3 = document.createElement("h3");` && |\n|  &&
+             `        h3.textContent = "Server Error - Please Restart The App";` && |\n|  &&
+             `        h3.style.cssText = "margin: 0";` && |\n|  &&
              |\n|.
     result = result &&
-             `        const refreshBtn = document.createElement("button");` && |\n| &&
-             `        refreshBtn.type = "button";` && |\n| &&
-             `        refreshBtn.textContent = "Refresh";` && |\n| &&
-             `        refreshBtn.style.cssText = btnStyle;` && |\n| &&
-             `        refreshBtn.addEventListener("click", () => window.location.reload());` && |\n| &&
-             `        actionsDiv.appendChild(refreshBtn);` && |\n| &&
-             `` && |\n| &&
-             `        const logoutBtn = document.createElement("button");` && |\n| &&
-             `        logoutBtn.type = "button";` && |\n| &&
-             `        logoutBtn.textContent = "Logout";` && |\n| &&
-             `        logoutBtn.style.cssText = btnStyle;` && |\n| &&
-             `        logoutBtn.addEventListener("click", () => this._handleLogout());` && |\n| &&
-             `        actionsDiv.appendChild(logoutBtn);` && |\n| &&
-             `` && |\n| &&
-             `        headerDiv.appendChild(actionsDiv);` && |\n| &&
-             `        errorContainer.appendChild(headerDiv);` && |\n| &&
-             `` && |\n| &&
-             `        // The error text itself lives inside a sandboxed iframe so any HTML` && |\n| &&
-             `        // in the backend response cannot execute or affect the main page.` && |\n| &&
-             `        const iframe = document.createElement("iframe");` && |\n| &&
-             `        iframe.id = "errorIframe";` && |\n| &&
-             `        iframe.style.cssText =` && |\n| &&
-             `          "width: 100%; height: 100%; border: none; flex: 1;";` && |\n| &&
-             `        iframe.setAttribute("sandbox", "allow-same-origin");` && |\n| &&
-             `        errorContainer.appendChild(iframe);` && |\n| &&
-             `` && |\n| &&
-             `        const contentDocument = iframe.contentDocument;` && |\n| &&
-             `        if (contentDocument) {` && |\n| &&
-             `          const pre = contentDocument.createElement("pre");` && |\n| &&
-             `          pre.style.cssText =` && |\n| &&
-             `            "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";` && |\n| &&
-             `          pre.textContent = errorMessage;` && |\n| &&
-             `          const target =` && |\n| &&
-             `            contentDocument.body || contentDocument.documentElement;` && |\n| &&
-             `          target.appendChild(pre);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Logout via the launchpad if available; otherwise hit the SAP logoff URL.` && |\n| &&
-             `      _handleLogout() {` && |\n| &&
-             `        const fallback = () => {` && |\n| &&
-             `          window.location.href = "/sap/public/bc/icf/logoff";` && |\n| &&
-             `        };` && |\n| &&
-             `        try {` && |\n| &&
-             `          const launchpadLogout =` && |\n| &&
-             `            z2ui5.oLaunchpad &&` && |\n| &&
-             `            z2ui5.oLaunchpad.Container &&` && |\n| &&
-             `            z2ui5.oLaunchpad.Container.logout;` && |\n| &&
-             `          if (launchpadLogout) {` && |\n| &&
-             `            z2ui5.oLaunchpad.Container.logout();` && |\n| &&
-             `          } else {` && |\n| &&
-             `            fallback();` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          fallback();` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `    };` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
+             `        headerDiv.appendChild(h3);` && |\n|  &&
+             `` && |\n|  &&
+             `        const btnStyle =` && |\n|  &&
+             `          "padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;";` && |\n|  &&
+             `` && |\n|  &&
+             `        const actionsDiv = document.createElement("div");` && |\n|  &&
+             `        actionsDiv.style.cssText = "display: flex; gap: 8px;";` && |\n|  &&
+             `` && |\n|  &&
+             `        const refreshBtn = document.createElement("button");` && |\n|  &&
+             `        refreshBtn.type = "button";` && |\n|  &&
+             `        refreshBtn.textContent = "Refresh";` && |\n|  &&
+             `        refreshBtn.style.cssText = btnStyle;` && |\n|  &&
+             `        refreshBtn.addEventListener("click", () => window.location.reload());` && |\n|  &&
+             `        actionsDiv.appendChild(refreshBtn);` && |\n|  &&
+             `` && |\n|  &&
+             `        const logoutBtn = document.createElement("button");` && |\n|  &&
+             `        logoutBtn.type = "button";` && |\n|  &&
+             `        logoutBtn.textContent = "Logout";` && |\n|  &&
+             `        logoutBtn.style.cssText = btnStyle;` && |\n|  &&
+             `        logoutBtn.addEventListener("click", () => this._handleLogout());` && |\n|  &&
+             `        actionsDiv.appendChild(logoutBtn);` && |\n|  &&
+             `` && |\n|  &&
+             `        headerDiv.appendChild(actionsDiv);` && |\n|  &&
+             `        errorContainer.appendChild(headerDiv);` && |\n|  &&
+             `` && |\n|  &&
+             `        // The error text itself lives inside a sandboxed iframe so any HTML` && |\n|  &&
+             `        // in the backend response cannot execute or affect the main page.` && |\n|  &&
+             `        const iframe = document.createElement("iframe");` && |\n|  &&
+             `        iframe.id = "errorIframe";` && |\n|  &&
+             `        iframe.style.cssText =` && |\n|  &&
+             `          "width: 100%; height: 100%; border: none; flex: 1;";` && |\n|  &&
+             `        iframe.setAttribute("sandbox", "allow-same-origin");` && |\n|  &&
+             `        errorContainer.appendChild(iframe);` && |\n|  &&
+             `` && |\n|  &&
+             `        const contentDocument = iframe.contentDocument;` && |\n|  &&
+             `        if (contentDocument) {` && |\n|  &&
+             `          const pre = contentDocument.createElement("pre");` && |\n|  &&
+             `          pre.style.cssText =` && |\n|  &&
+             `            "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";` && |\n|  &&
+             `          pre.textContent = errorMessage;` && |\n|  &&
+             `          const target =` && |\n|  &&
+             `            contentDocument.body || contentDocument.documentElement;` && |\n|  &&
+             `          target.appendChild(pre);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Logout via the launchpad if available; otherwise hit the SAP logoff URL.` && |\n|  &&
+             `      _handleLogout() {` && |\n|  &&
+             `        const fallback = () => {` && |\n|  &&
+             `          window.location.href = "/sap/public/bc/icf/logoff";` && |\n|  &&
+             `        };` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const launchpadLogout =` && |\n|  &&
+             `            z2ui5.oLaunchpad &&` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container &&` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container.logout;` && |\n|  &&
+             `          if (launchpadLogout) {` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container.logout();` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            fallback();` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          fallback();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `    };` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -125,49 +125,79 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `      },` && |\n|  &&
              `` && |\n|  &&
              `      _getScrollInfo() {` && |\n|  &&
-             `        // For each visible view, find the first scrollable descendant` && |\n|  &&
-             `        // (typically a sap.m.Page) and return its current scroll offsets.` && |\n|  &&
-             `        // X = scrollLeft (horizontal), Y = scrollTop (vertical).` && |\n|  &&
-             `        // Only views that exist and have a scrollable target are included;` && |\n|  &&
-             `        // empty slots are omitted to keep the request payload small.` && |\n|  &&
+             `        // For each visible view, find the scrollable descendant that is` && |\n|  &&
+             `        // actually scrolled (typically a sap.m.Page) and return its current` && |\n|  &&
+             `        // scroll offsets. X = scrollLeft, Y = scrollTop.` && |\n|  &&
+             `        //` && |\n|  &&
+             `        // Multiple controls in the tree expose getScrollDelegate (App,` && |\n|  &&
+             `        // NavContainer, Page, ScrollContainer, ...). findAggregatedObjects` && |\n|  &&
+             `        // returns them in pre-order, so the outer App/NavContainer comes` && |\n|  &&
+             `        // first - but its delegate never scrolls visible content. We pick` && |\n|  &&
+             `        // the first candidate whose container is actually scrolled, with` && |\n|  &&
+             `        // the deepest overflowing container as a fallback.` && |\n|  &&
+             `        //` && |\n|  &&
+             `        // Reading the position directly from the container's DOM avoids` && |\n|  &&
+             `        // relying on the delegate's cached _scrollY/_scrollX which can lag` && |\n|  &&
+             `        // until a scroll event fires.` && |\n|  &&
+             `        const containerOf = (control) => {` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const d = control.getScrollDelegate();` && |\n|  &&
+             `            if (d && d.getContainerDomRef) {` && |\n|  &&
+             `              const dom = d.getContainerDomRef();` && |\n|  &&
+             `              if (dom) return dom;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            // ignored` && |\n|  &&
+             `          }` && |\n|  &&
+             `          // Fallback to known ID suffixes for common controls.` && |\n|  &&
+             `          const id = control.getId();` && |\n|  &&
+             `          return (` && |\n|  &&
+             `            document.getElementById(``${id}-cont``) || // sap.m.Page` && |\n|  &&
+             `            document.getElementById(``${id}-scroll``) || // sap.m.ScrollContainer` && |\n|  &&
+             `            null` && |\n|  &&
+             `          );` && |\n|  &&
+             `        };` && |\n|  &&
              `        const getOne = (view) => {` && |\n|  &&
              `          if (!view || !view.findAggregatedObjects) return null;` && |\n|  &&
-             `          let target = null;` && |\n|  &&
+             `          let candidates;` && |\n|  &&
              `          try {` && |\n|  &&
-             `            const candidates = view.findAggregatedObjects(true, (c) => {` && |\n|  &&
+             `            candidates = view.findAggregatedObjects(true, (c) => {` && |\n|  &&
              `              try {` && |\n|  &&
              `                return c.getScrollDelegate && c.getScrollDelegate();` && |\n|  &&
              `              } catch (e) {` && |\n|  &&
              `                return false;` && |\n|  &&
              `              }` && |\n|  &&
              `            });` && |\n|  &&
-             `            target = candidates && candidates[0];` && |\n|  &&
              `          } catch (e) {` && |\n|  &&
              `            return null;` && |\n|  &&
              `          }` && |\n|  &&
-             `          if (!target) return null;` && |\n|  &&
-             `          let x = 0;` && |\n|  &&
-             `          let y = 0;` && |\n|  &&
-             `          try {` && |\n|  &&
-             `            const d = target.getScrollDelegate();` && |\n|  &&
-             `            if (d) {` && |\n|  &&
-             `              if (d.getScrollTop) y = d.getScrollTop() || 0;` && |\n|  &&
-             `              if (d.getScrollLeft) x = d.getScrollLeft() || 0;` && |\n|  &&
+             `          if (!candidates || !candidates.length) return null;` && |\n|  &&
+             `` && |\n|  &&
+             `          let chosen = null;` && |\n|  &&
+             `          let fallback = null;` && |\n|  &&
+             `          for (const c of candidates) {` && |\n|  &&
+             `            const dom = containerOf(c);` && |\n|  &&
+             `            if (!dom) continue;` && |\n|  &&
+             `            const x = dom.scrollLeft || 0;` && |\n|  &&
+             `            const y = dom.scrollTop || 0;` && |\n|  &&
+             `            if (x || y) {` && |\n|  &&
+             `              chosen = { control: c, x, y };` && |\n|  &&
+             `              break;` && |\n|  &&
              `            }` && |\n|  &&
-             `          } catch (e) {` && |\n|  &&
-             `            // ignored - fall through to DOM lookup` && |\n|  &&
-             `          }` && |\n|  &&
-             `          if (!x || !y) {` && |\n|  &&
-             `            const el = document.getElementById(``${target.getId()}-inner``);` && |\n|  &&
-             `            if (el) {` && |\n|  &&
-             `              if (!y) y = el.scrollTop || 0;` && |\n|  &&
-             `              if (!x) x = el.scrollLeft || 0;` && |\n|  &&
+             `            // Prefer the deepest container that actually overflows.` && |\n|  &&
+             `            const overflows =` && |\n|  &&
+             `              dom.scrollHeight > dom.clientHeight ||` && |\n|  &&
+             `              dom.scrollWidth > dom.clientWidth;` && |\n|  &&
+             `            if (overflows || !fallback) {` && |\n|  &&
+             `              fallback = { control: c, x, y };` && |\n|  &&
              `            }` && |\n|  &&
              `          }` && |\n|  &&
-             `          let id = target.getId();` && |\n|  &&
+             `          const pick = chosen || fallback;` && |\n|  &&
+             `          if (!pick) return null;` && |\n|  &&
+             `          let id = pick.control.getId();` && |\n|  &&
              `          const prefix = view.getId() + "--";` && |\n|  &&
              `          if (id.startsWith(prefix)) id = id.slice(prefix.length);` && |\n|  &&
-             `          return { ID: id, X: x, Y: y };` && |\n|  &&
+             `          return { ID: id, X: pick.x, Y: pick.y };` && |\n|  &&
              `        };` && |\n|  &&
              `        const out = {};` && |\n|  &&
              `        const slots = [` && |\n|  &&
@@ -388,6 +418,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          z-index: 9999;` && |\n|  &&
              `          display: flex;` && |\n|  &&
              `          flex-direction: column;` && |\n|  &&
+             |\n|.
+    result = result &&
              `        ``;` && |\n|  &&
              `        document.body.appendChild(container);` && |\n|  &&
              `        return container;` && |\n|  &&
@@ -418,8 +450,6 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        const h3 = document.createElement("h3");` && |\n|  &&
              `        h3.textContent = "Server Error - Please Restart The App";` && |\n|  &&
              `        h3.style.cssText = "margin: 0";` && |\n|  &&
-             |\n|.
-    result = result &&
              `        headerDiv.appendChild(h3);` && |\n|  &&
              `` && |\n|  &&
              `        const btnStyle =` && |\n|  &&

--- a/src/01/03/z2ui5_cl_app_style_css.clas.abap
+++ b/src/01/03/z2ui5_cl_app_style_css.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_style_css IMPLEMENTATION.
 
   METHOD get.
 
-    result = `/* Enter your custom styles here */` &&
+    result =              `/* Enter your custom styles here */` &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -18,1239 +18,1249 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/mvc/Controller",` && |\n| &&
-             `    "sap/ui/core/mvc/XMLView",` && |\n| &&
-             `    "sap/ui/model/json/JSONModel",` && |\n| &&
-             `    "sap/ui/core/BusyIndicator",` && |\n| &&
-             `    "sap/m/MessageBox",` && |\n| &&
-             `    "sap/m/MessageToast",` && |\n| &&
-             `    "sap/ui/core/Fragment",` && |\n| &&
-             `    "sap/m/BusyDialog",` && |\n| &&
-             `    "sap/ui/VersionInfo",` && |\n| &&
-             `    "z2ui5/cc/Server",` && |\n| &&
-             `    "sap/ui/model/odata/v2/ODataModel",` && |\n| &&
-             `    "sap/m/library",` && |\n| &&
-             `    "sap/ui/core/routing/HashChanger",` && |\n| &&
-             `    "sap/ui/util/Storage",` && |\n| &&
-             `    "sap/ui/core/Element",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (` && |\n| &&
-             `    Controller,` && |\n| &&
-             `    XMLView,` && |\n| &&
-             `    JSONModel,` && |\n| &&
-             `    BusyIndicator,` && |\n| &&
-             `    MessageBox,` && |\n| &&
-             `    MessageToast,` && |\n| &&
-             `    Fragment,` && |\n| &&
-             `    mBusyDialog,` && |\n| &&
-             `    VersionInfo,` && |\n| &&
-             `    Server,` && |\n| &&
-             `    ODataModel,` && |\n| &&
-             `    mobileLibrary,` && |\n| &&
-             `    HashChanger,` && |\n| &&
-             `    Storage,` && |\n| &&
-             `    Element,` && |\n| &&
-             `  ) => {` && |\n| &&
-             `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `    // Small utility helpers (module-private)` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      const entry = { message: message, ts: new Date().toISOString() };` && |\n| &&
-             `      if (error !== undefined) entry.error = error;` && |\n| &&
-             `      z2ui5.errors.push(entry);` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Run every callback in ``arr``, swallowing individual failures so one bad` && |\n| &&
-             `    // callback cannot break the whole event sequence.` && |\n| &&
-             `    function runCallbacks(arr, ...args) {` && |\n| &&
-             `      if (!arr) return;` && |\n| &&
-             `      for (const fn of arr) {` && |\n| &&
-             `        if (!fn) continue;` && |\n| &&
-             `        try {` && |\n| &&
-             `          fn(...args);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("runCallbacks: callback failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Parse a value as integer milliseconds, falling back to ``def`` when the` && |\n| &&
-             `    // input is empty / undefined.` && |\n| &&
-             `    function parseMs(val, def) {` && |\n| &&
-             `      return val ? +val : def;` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // DOM helpers reused across calls; kept as module-level singletons.` && |\n| &&
-             `    const _msgParser = new DOMParser();` && |\n| &&
-             `    const _sanitizeEl = document.createElement("div");` && |\n| &&
-             `    const _hashChanger = HashChanger.getInstance();` && |\n| &&
-             `    const _URLHelper = mobileLibrary.URLHelper;` && |\n| &&
-             `    const _SAFE_PROTOCOLS = new Set(["http:", "https:"]);` && |\n| &&
-             `` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `    // Security helpers` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `    // Returns true only if the URL is on the same origin and uses http/https.` && |\n| &&
-             `    function isValidRedirectURL(url) {` && |\n| &&
-             `      if (!url) return false;` && |\n| &&
-             `      try {` && |\n| &&
-             `        const parsed = new URL(url, window.location.origin);` && |\n| &&
-             `        if (parsed.origin !== window.location.origin) {` && |\n| &&
-             `          logError(``Security: Blocked redirect to different origin: ${url}``);` && |\n| &&
-             `          return false;` && |\n| &&
-             `        }` && |\n| &&
-             `        if (!_SAFE_PROTOCOLS.has(parsed.protocol)) {` && |\n| &&
-             `          logError(` && |\n| &&
-             `            ``Security: Blocked redirect with invalid protocol: ${parsed.protocol}``,` && |\n| &&
-             `          );` && |\n| &&
-             `          return false;` && |\n| &&
-             `        }` && |\n| &&
-             `        return true;` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        logError(``Security: Invalid URL format: ${url}``, e);` && |\n| &&
-             `        return false;` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    function copyToClipboard(textToCopy) {` && |\n| &&
-             `      if (navigator.clipboard && navigator.clipboard.writeText) {` && |\n| &&
-             `        navigator.clipboard.writeText(textToCopy).catch((err) => {` && |\n| &&
-             `          logError("Clipboard: writeText failed, falling back", err);` && |\n| &&
-             `          copyToClipboardFallback(textToCopy);` && |\n| &&
-             `        });` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
-             `      copyToClipboardFallback(textToCopy);` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    function copyToClipboardFallback(textToCopy) {` && |\n| &&
-             `      const textarea = document.createElement("textarea");` && |\n| &&
-             `      textarea.value = textToCopy;` && |\n| &&
-             `      textarea.setAttribute("readonly", "");` && |\n| &&
-             `      textarea.style.position = "fixed";` && |\n| &&
-             `      textarea.style.top = "-1000px";` && |\n| &&
-             `      textarea.style.opacity = "0";` && |\n| &&
-             `      document.body.appendChild(textarea);` && |\n| &&
-             `      textarea.select();` && |\n| &&
-             `      try {` && |\n| &&
-             `        if (!document.execCommand("copy")) {` && |\n| &&
-             `          logError("Clipboard: execCommand('copy') returned false");` && |\n| &&
-             `        }` && |\n| &&
-             `      } catch (err) {` && |\n| &&
-             `        logError("Clipboard: execCommand('copy') threw", err);` && |\n| &&
-             `      } finally {` && |\n| &&
-             `        document.body.removeChild(textarea);` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Turns an HTML "details" snippet from the backend into safe HTML.` && |\n| &&
-             `    // Bullet lists are preserved; everything else is reduced to plain text.` && |\n| &&
-             `    function sanitizeMessageDetails(html) {` && |\n| &&
-             `      const doc = _msgParser.parseFromString(html, "text/html");` && |\n| &&
-             `      const items = Array.from(doc.querySelectorAll("li"));` && |\n| &&
-             `      if (items.length > 0) {` && |\n| &&
-             `        const safeItems = items.map((li) => {` && |\n| &&
-             `          _sanitizeEl.textContent = li.textContent;` && |\n| &&
-             `          return ``<li>${_sanitizeEl.innerHTML}</li>``;` && |\n| &&
-             `        });` && |\n| &&
-             `        return ``<ul>${safeItems.join("")}</ul>``;` && |\n| &&
-             `      }` && |\n| &&
-             `      _sanitizeEl.textContent = doc.body.textContent;` && |\n| &&
-             `      return _sanitizeEl.innerHTML;` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `    // Launchpad / NavContainer helpers` && |\n| &&
-             `    // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `    function withCrossAppNavigator(callback) {` && |\n| &&
-             `      const nav = z2ui5.oLaunchpad && z2ui5.oLaunchpad.CrossAppNavigator;` && |\n| &&
-             `      if (!nav) {` && |\n| &&
-             `        logError("CrossAppNav: not running inside Launchpad");` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
-             `      try {` && |\n| &&
-             `        callback(nav);` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        logError("CrossAppNav: callback failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    function navigateContainer(lookup, args) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const container = lookup(args[1]);` && |\n| &&
-             `        if (container) container.to(lookup(args[2]));` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        logError("navigateContainer: navigation failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Lookup tables mapping event names / param keys to the right view.` && |\n| &&
-             `    const navContainerLookups = {` && |\n| &&
-             `      NAV_CONTAINER_TO: (id) => z2ui5.oView && z2ui5.oView.byId(id),` && |\n| &&
-             `      NEST_NAV_CONTAINER_TO: (id) =>` && |\n| &&
-             `        z2ui5.oViewNest && z2ui5.oViewNest.byId(id),` && |\n| &&
-             `      NEST2_NAV_CONTAINER_TO: (id) =>` && |\n| &&
-             `        z2ui5.oViewNest2 && z2ui5.oViewNest2.byId(id),` && |\n| &&
-             `      POPUP_NAV_CONTAINER_TO: (id) => Fragment.byId("popupId", id),` && |\n| &&
-             `      POPOVER_NAV_CONTAINER_TO: (id) => Fragment.byId("popoverId", id),` && |\n| &&
-             `    };` && |\n| &&
-             `` && |\n| &&
-             `    const viewLookups = {` && |\n| &&
-             `      MAIN: () => z2ui5.oView,` && |\n| &&
-             `      NEST: () => z2ui5.oViewNest,` && |\n| &&
-             `      NEST2: () => z2ui5.oViewNest2,` && |\n| &&
-             `      POPUP: () => z2ui5.oViewPopup,` && |\n| &&
-             `      POPOVER: () => z2ui5.oViewPopover,` && |\n| &&
-             `    };` && |\n| &&
-             `` && |\n| &&
-             `    const paramToViewKey = {` && |\n| &&
-             `      S_VIEW: "MAIN",` && |\n| &&
-             `      S_VIEW_NEST: "NEST",` && |\n| &&
-             `      S_VIEW_NEST2: "NEST2",` && |\n| &&
-             `      S_POPUP: "POPUP",` && |\n| &&
-             `      S_POPOVER: "POPOVER",` && |\n| &&
-             `    };` && |\n| &&
-             `` && |\n| &&
-             `    function applyStoredSizeLimit(viewKey, oModel) {` && |\n| &&
-             `      if (!oModel || !z2ui5.viewSizeLimits) return;` && |\n| &&
-             `      const limit = z2ui5.viewSizeLimits[viewKey];` && |\n| &&
-             `      if (limit !== undefined) oModel.setSizeLimit(limit);` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    return Controller.extend("z2ui5.controller.View1", {` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Model change tracking - remembers which /XX/ paths the user edited` && |\n| &&
-             `      // so the next roundtrip only ships the delta.` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      _trackChanges(oModel) {` && |\n| &&
-             `        oModel.attachPropertyChange((e) => {` && |\n| &&
-             `          const params = e.getParameters();` && |\n| &&
-             `          const raw = params.path;` && |\n| &&
-             `          const ctx = params.context;` && |\n| &&
-             `          if (!raw) return;` && |\n| &&
-             `          // Resolve relative paths against the binding context.` && |\n| &&
-             `          let p;` && |\n| &&
-             `          if (ctx && !raw.startsWith("/")) {` && |\n| &&
-             `            p = ``${ctx.getPath()}/${raw}``;` && |\n| &&
-             `          } else {` && |\n| &&
-             `            p = raw;` && |\n| &&
-             `          }` && |\n| &&
-             `          if (p.startsWith("/XX/")) {` && |\n| &&
-             `            if (!z2ui5.xxChangedPaths) z2ui5.xxChangedPaths = new Set();` && |\n| &&
-             `            z2ui5.xxChangedPaths.add(p);` && |\n| &&
-             `          }` && |\n| &&
-             `        });` && |\n| &&
-             `        return oModel;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onInit() {` && |\n| &&
-             `        z2ui5.oRouter.attachRouteMatched(() => {` && |\n| &&
-             `          z2ui5.checkInit = true;` && |\n| &&
-             `          Server.Roundtrip();` && |\n| &&
-             `        });` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      onAfterRendering() {` && |\n| &&
-             `        if (z2ui5.oResponse && !z2ui5.oResponse._processed) {` && |\n| &&
-             `          this._processAfterRendering();` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Runs once after each roundtrip's view has been rendered. Handles` && |\n| &&
-             `      // popups, nested views, popovers and browser-history updates.` && |\n| &&
-             `      async _processAfterRendering() {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oResponse = z2ui5.oResponse;` && |\n| &&
-             `          if (oResponse._processed) return;` && |\n| &&
-             `          oResponse._processed = true;` && |\n| &&
-             `` && |\n| &&
-             `          const PARAMS = oResponse.PARAMS;` && |\n| &&
-             `          const ID = oResponse.ID;` && |\n| &&
-             `          if (!PARAMS) return;` && |\n| &&
-             `` && |\n| &&
-             `          const S_POPUP = PARAMS.S_POPUP;` && |\n| &&
-             `          const S_VIEW_NEST = PARAMS.S_VIEW_NEST;` && |\n| &&
-             `          const S_VIEW_NEST2 = PARAMS.S_VIEW_NEST2;` && |\n| &&
-             `          const S_POPOVER = PARAMS.S_POPOVER;` && |\n| &&
-             `          const SET_APP_STATE_ACTIVE = PARAMS.SET_APP_STATE_ACTIVE;` && |\n| &&
-             `          const SET_PUSH_STATE = PARAMS.SET_PUSH_STATE;` && |\n| &&
-             `          const SET_NAV_BACK = PARAMS.SET_NAV_BACK;` && |\n| &&
-             `` && |\n| &&
-             `          if (S_POPUP && S_POPUP.CHECK_DESTROY) this.PopupDestroy();` && |\n| &&
-             `          if (S_POPOVER && S_POPOVER.CHECK_DESTROY) this.PopoverDestroy();` && |\n| &&
-             `` && |\n| &&
-             `          if (S_POPUP && S_POPUP.XML) {` && |\n| &&
-             `            this.PopupDestroy();` && |\n| &&
-             `            await this.displayFragment(S_POPUP.XML, "oViewPopup");` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (!z2ui5.checkNestAfter && S_VIEW_NEST && S_VIEW_NEST.XML) {` && |\n| &&
-             `            this.NestViewDestroy();` && |\n| &&
-             `            await this.displayNestedView(` && |\n| &&
-             `              S_VIEW_NEST.XML,` && |\n| &&
-             `              "oViewNest",` && |\n| &&
-             `              "S_VIEW_NEST",` && |\n| &&
-             `              z2ui5.oControllerNest,` && |\n| &&
-             `            );` && |\n| &&
-             `            z2ui5.checkNestAfter = true;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (!z2ui5.checkNestAfter2 && S_VIEW_NEST2 && S_VIEW_NEST2.XML) {` && |\n| &&
-             `            this.NestViewDestroy2();` && |\n| &&
-             `            await this.displayNestedView(` && |\n| &&
-             `              S_VIEW_NEST2.XML,` && |\n| &&
-             `              "oViewNest2",` && |\n| &&
-             `              "S_VIEW_NEST2",` && |\n| &&
-             `              z2ui5.oControllerNest2,` && |\n| &&
-             `            );` && |\n| &&
-             `            z2ui5.checkNestAfter2 = true;` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (S_POPOVER && S_POPOVER.XML) {` && |\n| &&
-             `            this.PopoverDestroy();` && |\n| &&
-             `            await this.displayPopover(` && |\n| &&
-             `              S_POPOVER.XML,` && |\n| &&
-             `              "oViewPopover",` && |\n| &&
-             `              S_POPOVER.OPEN_BY_ID,` && |\n| &&
-             `            );` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          // Build the state object stored in history.state, so a future` && |\n| &&
-             `          // popstate can restore the current view without a backend hit.` && |\n| &&
-             `          const oView = z2ui5.oView;` && |\n| &&
-             `          let oState = {};` && |\n| &&
-             `          if (oView) {` && |\n| &&
-             `            const model = oView.getModel();` && |\n| &&
-             `            oState = {` && |\n| &&
-             `              view: oView.mProperties.viewContent,` && |\n| &&
-             `              model: model ? model.getData() : undefined,` && |\n| &&
-             `              response: z2ui5.oResponse,` && |\n| &&
-             `            };` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          try {` && |\n| &&
-             `            if (SET_PUSH_STATE) {` && |\n| &&
-             `              const hash = _hashChanger.getHash();` && |\n| &&
-             `              const newUrl = ``${window.location.pathname}${window.location.search}#${hash}${SET_PUSH_STATE}``;` && |\n| &&
-             `              history.pushState(oState, "", newUrl);` && |\n| &&
-             `            } else {` && |\n| &&
-             `              history.replaceState(oState, "", window.location.href);` && |\n| &&
-             `            }` && |\n| &&
-             `            const newHash = SET_APP_STATE_ACTIVE` && |\n| &&
-             `              ? ``z2ui5-xapp-state=${ID || ""}``` && |\n| &&
-             `              : "";` && |\n| &&
-             `            _hashChanger.replaceHash(newHash);` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            logError("_processAfterRendering: history update failed", e);` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (SET_NAV_BACK) history.back();` && |\n| &&
-             `` && |\n| &&
-             `          runCallbacks(z2ui5.onAfterRendering);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("_processAfterRendering: unexpected error", e);` && |\n| &&
-             `          MessageBox.error(e.toLocaleString(), {` && |\n| &&
-             `            title: "Unexpected Error Occurred - App Terminated",` && |\n| &&
-             `            actions: [],` && |\n| &&
-             `            onClose: () =>` && |\n| &&
-             `              new mBusyDialog({ text: "Please Restart the App" }).open(),` && |\n| &&
-             `          });` && |\n| &&
-             `        } finally {` && |\n| &&
-             `          BusyIndicator.hide();` && |\n| &&
-             `          z2ui5.isBusy = false;` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Build the delta object sent to the backend. ``paths`` is the set of` && |\n| &&
-             `      // /XX/... paths that the user edited; ``xx`` is the full XX model data.` && |\n| &&
-             `      _buildDeltaFromPaths(paths, xx) {` && |\n| &&
-             `        const delta = {};` && |\n| &&
-             `        for (const path of paths) {` && |\n| &&
-             `          // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>"` && |\n| &&
-             `          const [attr, rowIdx, field] = path.slice(4).split("/");` && |\n| &&
-             `          const isRowField =` && |\n| &&
-             `            field !== undefined && rowIdx !== "" && !isNaN(rowIdx);` && |\n| &&
-             `          if (isRowField) {` && |\n| &&
-             `            // Table cell change -> ship only the changed cell.` && |\n| &&
-             `            if (!delta[attr] || !delta[attr].__delta) {` && |\n| &&
-             `              delta[attr] = { __delta: {} };` && |\n| &&
-             `            }` && |\n| &&
-             `            const attrDelta = delta[attr].__delta;` && |\n| &&
-             `            if (!attrDelta[rowIdx]) attrDelta[rowIdx] = {};` && |\n| &&
-             `            const row = xx[attr] && xx[attr][+rowIdx];` && |\n| &&
-             `            attrDelta[rowIdx][field] = row ? row[field] : undefined;` && |\n| &&
-             `          } else {` && |\n| &&
-             `            // Scalar change -> ship the whole attribute.` && |\n| &&
-             `            delta[attr] = xx[attr];` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `        return delta;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _createViewModel() {` && |\n| &&
-             `        const data = z2ui5.oResponse && z2ui5.oResponse.OVIEWMODEL;` && |\n| &&
-             `        return this._trackChanges(new JSONModel(data));` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Display: popups, popovers, nested views, main view` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `      async displayFragment(xml, viewProp) {` && |\n| &&
-             `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit("POPUP", oModel);` && |\n| &&
-             `        const oFragment = await Fragment.load({` && |\n| &&
-             `          definition: xml,` && |\n| &&
-             `          controller: z2ui5.oControllerPopup,` && |\n| &&
-             `          id: "popupId",` && |\n| &&
-             `        });` && |\n| &&
-             `        // The app might have been torn down while the fragment loaded.` && |\n| &&
-             `        const appAlive =` && |\n| &&
-             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n| &&
-             `        if (!appAlive) {` && |\n| &&
-             `          oFragment.destroy();` && |\n| &&
+    result =              `sap.ui.define(` && |\n|  &&
+             `  [` && |\n|  &&
+             `    "sap/ui/core/mvc/Controller",` && |\n|  &&
+             `    "sap/ui/core/mvc/XMLView",` && |\n|  &&
+             `    "sap/ui/model/json/JSONModel",` && |\n|  &&
+             `    "sap/ui/core/BusyIndicator",` && |\n|  &&
+             `    "sap/m/MessageBox",` && |\n|  &&
+             `    "sap/m/MessageToast",` && |\n|  &&
+             `    "sap/ui/core/Fragment",` && |\n|  &&
+             `    "sap/m/BusyDialog",` && |\n|  &&
+             `    "sap/ui/VersionInfo",` && |\n|  &&
+             `    "z2ui5/cc/Server",` && |\n|  &&
+             `    "sap/ui/model/odata/v2/ODataModel",` && |\n|  &&
+             `    "sap/m/library",` && |\n|  &&
+             `    "sap/ui/core/routing/HashChanger",` && |\n|  &&
+             `    "sap/ui/util/Storage",` && |\n|  &&
+             `    "sap/ui/core/Element",` && |\n|  &&
+             `  ],` && |\n|  &&
+             `  (` && |\n|  &&
+             `    Controller,` && |\n|  &&
+             `    XMLView,` && |\n|  &&
+             `    JSONModel,` && |\n|  &&
+             `    BusyIndicator,` && |\n|  &&
+             `    MessageBox,` && |\n|  &&
+             `    MessageToast,` && |\n|  &&
+             `    Fragment,` && |\n|  &&
+             `    mBusyDialog,` && |\n|  &&
+             `    VersionInfo,` && |\n|  &&
+             `    Server,` && |\n|  &&
+             `    ODataModel,` && |\n|  &&
+             `    mobileLibrary,` && |\n|  &&
+             `    HashChanger,` && |\n|  &&
+             `    Storage,` && |\n|  &&
+             `    Element,` && |\n|  &&
+             `  ) => {` && |\n|  &&
+             `    "use strict";` && |\n|  &&
+             `` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `    // Small utility helpers (module-private)` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `    // Append an entry to the global error log. We create the array on first use.` && |\n|  &&
+             `    function logError(message, error) {` && |\n|  &&
+             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n|  &&
+             `      const entry = { message: message, ts: new Date().toISOString() };` && |\n|  &&
+             `      if (error !== undefined) entry.error = error;` && |\n|  &&
+             `      z2ui5.errors.push(entry);` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // Run every callback in ``arr``, swallowing individual failures so one bad` && |\n|  &&
+             `    // callback cannot break the whole event sequence.` && |\n|  &&
+             `    function runCallbacks(arr, ...args) {` && |\n|  &&
+             `      if (!arr) return;` && |\n|  &&
+             `      for (const fn of arr) {` && |\n|  &&
+             `        if (!fn) continue;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          fn(...args);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("runCallbacks: callback failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      }` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // Parse a value as integer milliseconds, falling back to ``def`` when the` && |\n|  &&
+             `    // input is empty / undefined.` && |\n|  &&
+             `    function parseMs(val, def) {` && |\n|  &&
+             `      return val ? +val : def;` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // DOM helpers reused across calls; kept as module-level singletons.` && |\n|  &&
+             `    const _msgParser = new DOMParser();` && |\n|  &&
+             `    const _sanitizeEl = document.createElement("div");` && |\n|  &&
+             `    const _hashChanger = HashChanger.getInstance();` && |\n|  &&
+             `    const _URLHelper = mobileLibrary.URLHelper;` && |\n|  &&
+             `    const _SAFE_PROTOCOLS = new Set(["http:", "https:"]);` && |\n|  &&
+             `` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `    // Security helpers` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `    // Returns true only if the URL is on the same origin and uses http/https.` && |\n|  &&
+             `    function isValidRedirectURL(url) {` && |\n|  &&
+             `      if (!url) return false;` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const parsed = new URL(url, window.location.origin);` && |\n|  &&
+             `        if (parsed.origin !== window.location.origin) {` && |\n|  &&
+             `          logError(``Security: Blocked redirect to different origin: ${url}``);` && |\n|  &&
+             `          return false;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (!_SAFE_PROTOCOLS.has(parsed.protocol)) {` && |\n|  &&
+             `          logError(` && |\n|  &&
+             `            ``Security: Blocked redirect with invalid protocol: ${parsed.protocol}``,` && |\n|  &&
+             `          );` && |\n|  &&
+             `          return false;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        return true;` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        logError(``Security: Invalid URL format: ${url}``, e);` && |\n|  &&
+             `        return false;` && |\n|  &&
+             `      }` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    function copyToClipboard(textToCopy) {` && |\n|  &&
+             `      if (navigator.clipboard && navigator.clipboard.writeText) {` && |\n|  &&
+             `        navigator.clipboard.writeText(textToCopy).catch((err) => {` && |\n|  &&
+             `          logError("Clipboard: writeText failed, falling back", err);` && |\n|  &&
+             `          copyToClipboardFallback(textToCopy);` && |\n|  &&
+             `        });` && |\n|  &&
+             `        return;` && |\n|  &&
+             `      }` && |\n|  &&
+             `      copyToClipboardFallback(textToCopy);` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    function copyToClipboardFallback(textToCopy) {` && |\n|  &&
+             `      const textarea = document.createElement("textarea");` && |\n|  &&
+             `      textarea.value = textToCopy;` && |\n|  &&
+             `      textarea.setAttribute("readonly", "");` && |\n|  &&
+             `      textarea.style.position = "fixed";` && |\n|  &&
+             `      textarea.style.top = "-1000px";` && |\n|  &&
+             `      textarea.style.opacity = "0";` && |\n|  &&
+             `      document.body.appendChild(textarea);` && |\n|  &&
+             `      textarea.select();` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        if (!document.execCommand("copy")) {` && |\n|  &&
+             `          logError("Clipboard: execCommand('copy') returned false");` && |\n|  &&
+             `        }` && |\n|  &&
+             `      } catch (err) {` && |\n|  &&
+             `        logError("Clipboard: execCommand('copy') threw", err);` && |\n|  &&
+             `      } finally {` && |\n|  &&
+             `        document.body.removeChild(textarea);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // Turns an HTML "details" snippet from the backend into safe HTML.` && |\n|  &&
+             `    // Bullet lists are preserved; everything else is reduced to plain text.` && |\n|  &&
+             `    function sanitizeMessageDetails(html) {` && |\n|  &&
+             `      const doc = _msgParser.parseFromString(html, "text/html");` && |\n|  &&
+             `      const items = Array.from(doc.querySelectorAll("li"));` && |\n|  &&
+             `      if (items.length > 0) {` && |\n|  &&
+             `        const safeItems = items.map((li) => {` && |\n|  &&
+             `          _sanitizeEl.textContent = li.textContent;` && |\n|  &&
+             `          return ``<li>${_sanitizeEl.innerHTML}</li>``;` && |\n|  &&
+             `        });` && |\n|  &&
+             `        return ``<ul>${safeItems.join("")}</ul>``;` && |\n|  &&
+             `      }` && |\n|  &&
+             `      _sanitizeEl.textContent = doc.body.textContent;` && |\n|  &&
+             `      return _sanitizeEl.innerHTML;` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `    // Launchpad / NavContainer helpers` && |\n|  &&
+             `    // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `    function withCrossAppNavigator(callback) {` && |\n|  &&
+             `      const nav = z2ui5.oLaunchpad && z2ui5.oLaunchpad.CrossAppNavigator;` && |\n|  &&
+             `      if (!nav) {` && |\n|  &&
+             `        logError("CrossAppNav: not running inside Launchpad");` && |\n|  &&
+             `        return;` && |\n|  &&
+             `      }` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        callback(nav);` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        logError("CrossAppNav: callback failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    function navigateContainer(lookup, args) {` && |\n|  &&
+             `      try {` && |\n|  &&
+             `        const container = lookup(args[1]);` && |\n|  &&
+             `        if (container) container.to(lookup(args[2]));` && |\n|  &&
+             `      } catch (e) {` && |\n|  &&
+             `        logError("navigateContainer: navigation failed", e);` && |\n|  &&
+             `      }` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    // Lookup tables mapping event names / param keys to the right view.` && |\n|  &&
+             `    const navContainerLookups = {` && |\n|  &&
+             `      NAV_CONTAINER_TO: (id) => z2ui5.oView && z2ui5.oView.byId(id),` && |\n|  &&
+             `      NEST_NAV_CONTAINER_TO: (id) =>` && |\n|  &&
+             `        z2ui5.oViewNest && z2ui5.oViewNest.byId(id),` && |\n|  &&
+             `      NEST2_NAV_CONTAINER_TO: (id) =>` && |\n|  &&
+             `        z2ui5.oViewNest2 && z2ui5.oViewNest2.byId(id),` && |\n|  &&
+             `      POPUP_NAV_CONTAINER_TO: (id) => Fragment.byId("popupId", id),` && |\n|  &&
+             `      POPOVER_NAV_CONTAINER_TO: (id) => Fragment.byId("popoverId", id),` && |\n|  &&
+             `    };` && |\n|  &&
+             `` && |\n|  &&
+             `    const viewLookups = {` && |\n|  &&
+             `      MAIN: () => z2ui5.oView,` && |\n|  &&
+             `      NEST: () => z2ui5.oViewNest,` && |\n|  &&
+             `      NEST2: () => z2ui5.oViewNest2,` && |\n|  &&
+             `      POPUP: () => z2ui5.oViewPopup,` && |\n|  &&
+             `      POPOVER: () => z2ui5.oViewPopover,` && |\n|  &&
+             `    };` && |\n|  &&
+             `` && |\n|  &&
+             `    const paramToViewKey = {` && |\n|  &&
+             `      S_VIEW: "MAIN",` && |\n|  &&
+             `      S_VIEW_NEST: "NEST",` && |\n|  &&
+             `      S_VIEW_NEST2: "NEST2",` && |\n|  &&
+             `      S_POPUP: "POPUP",` && |\n|  &&
+             `      S_POPOVER: "POPOVER",` && |\n|  &&
+             `    };` && |\n|  &&
+             `` && |\n|  &&
+             `    function applyStoredSizeLimit(viewKey, oModel) {` && |\n|  &&
+             `      if (!oModel || !z2ui5.viewSizeLimits) return;` && |\n|  &&
+             `      const limit = z2ui5.viewSizeLimits[viewKey];` && |\n|  &&
+             `      if (limit !== undefined) oModel.setSizeLimit(limit);` && |\n|  &&
+             `    }` && |\n|  &&
+             `` && |\n|  &&
+             `    return Controller.extend("z2ui5.controller.View1", {` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // Model change tracking - remembers which /XX/ paths the user edited` && |\n|  &&
+             `      // so the next roundtrip only ships the delta.` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      _trackChanges(oModel) {` && |\n|  &&
+             `        oModel.attachPropertyChange((e) => {` && |\n|  &&
+             `          const params = e.getParameters();` && |\n|  &&
+             `          const raw = params.path;` && |\n|  &&
+             `          const ctx = params.context;` && |\n|  &&
+             `          if (!raw) return;` && |\n|  &&
+             `          // Resolve relative paths against the binding context.` && |\n|  &&
+             `          let p;` && |\n|  &&
+             `          if (ctx && !raw.startsWith("/")) {` && |\n|  &&
+             `            p = ``${ctx.getPath()}/${raw}``;` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            p = raw;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (p.startsWith("/XX/")) {` && |\n|  &&
+             `            if (!z2ui5.xxChangedPaths) z2ui5.xxChangedPaths = new Set();` && |\n|  &&
+             `            z2ui5.xxChangedPaths.add(p);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        });` && |\n|  &&
+             `        return oModel;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onInit() {` && |\n|  &&
+             `        z2ui5.oRouter.attachRouteMatched(() => {` && |\n|  &&
+             `          z2ui5.checkInit = true;` && |\n|  &&
+             `          Server.Roundtrip();` && |\n|  &&
+             `        });` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      onAfterRendering() {` && |\n|  &&
+             `        if (z2ui5.oResponse && !z2ui5.oResponse._processed) {` && |\n|  &&
+             `          this._processAfterRendering();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Runs once after each roundtrip's view has been rendered. Handles` && |\n|  &&
+             `      // popups, nested views, popovers and browser-history updates.` && |\n|  &&
+             `      async _processAfterRendering() {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oResponse = z2ui5.oResponse;` && |\n|  &&
+             `          if (oResponse._processed) return;` && |\n|  &&
+             `          oResponse._processed = true;` && |\n|  &&
+             `` && |\n|  &&
+             `          const PARAMS = oResponse.PARAMS;` && |\n|  &&
+             `          const ID = oResponse.ID;` && |\n|  &&
+             `          if (!PARAMS) return;` && |\n|  &&
+             `` && |\n|  &&
+             `          const S_POPUP = PARAMS.S_POPUP;` && |\n|  &&
+             `          const S_VIEW_NEST = PARAMS.S_VIEW_NEST;` && |\n|  &&
+             `          const S_VIEW_NEST2 = PARAMS.S_VIEW_NEST2;` && |\n|  &&
+             `          const S_POPOVER = PARAMS.S_POPOVER;` && |\n|  &&
+             `          const SET_APP_STATE_ACTIVE = PARAMS.SET_APP_STATE_ACTIVE;` && |\n|  &&
+             `          const SET_PUSH_STATE = PARAMS.SET_PUSH_STATE;` && |\n|  &&
+             `          const SET_NAV_BACK = PARAMS.SET_NAV_BACK;` && |\n|  &&
+             `` && |\n|  &&
+             `          if (S_POPUP && S_POPUP.CHECK_DESTROY) this.PopupDestroy();` && |\n|  &&
+             `          if (S_POPOVER && S_POPOVER.CHECK_DESTROY) this.PopoverDestroy();` && |\n|  &&
+             `` && |\n|  &&
+             `          if (S_POPUP && S_POPUP.XML) {` && |\n|  &&
+             `            this.PopupDestroy();` && |\n|  &&
+             `            await this.displayFragment(S_POPUP.XML, "oViewPopup");` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!z2ui5.checkNestAfter && S_VIEW_NEST && S_VIEW_NEST.XML) {` && |\n|  &&
+             `            this.NestViewDestroy();` && |\n|  &&
+             `            await this.displayNestedView(` && |\n|  &&
+             `              S_VIEW_NEST.XML,` && |\n|  &&
+             `              "oViewNest",` && |\n|  &&
+             `              "S_VIEW_NEST",` && |\n|  &&
+             `              z2ui5.oControllerNest,` && |\n|  &&
+             `            );` && |\n|  &&
+             `            z2ui5.checkNestAfter = true;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!z2ui5.checkNestAfter2 && S_VIEW_NEST2 && S_VIEW_NEST2.XML) {` && |\n|  &&
+             `            this.NestViewDestroy2();` && |\n|  &&
+             `            await this.displayNestedView(` && |\n|  &&
+             `              S_VIEW_NEST2.XML,` && |\n|  &&
+             `              "oViewNest2",` && |\n|  &&
+             `              "S_VIEW_NEST2",` && |\n|  &&
+             `              z2ui5.oControllerNest2,` && |\n|  &&
+             `            );` && |\n|  &&
+             `            z2ui5.checkNestAfter2 = true;` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (S_POPOVER && S_POPOVER.XML) {` && |\n|  &&
+             `            this.PopoverDestroy();` && |\n|  &&
+             `            await this.displayPopover(` && |\n|  &&
+             `              S_POPOVER.XML,` && |\n|  &&
+             `              "oViewPopover",` && |\n|  &&
+             `              S_POPOVER.OPEN_BY_ID,` && |\n|  &&
+             `            );` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          // Build the state object stored in history.state, so a future` && |\n|  &&
+             `          // popstate can restore the current view without a backend hit.` && |\n|  &&
+             `          const oView = z2ui5.oView;` && |\n|  &&
+             `          let oState = {};` && |\n|  &&
+             `          if (oView) {` && |\n|  &&
+             `            const model = oView.getModel();` && |\n|  &&
+             `            oState = {` && |\n|  &&
+             `              view: oView.mProperties.viewContent,` && |\n|  &&
+             `              model: model ? model.getData() : undefined,` && |\n|  &&
+             `              response: z2ui5.oResponse,` && |\n|  &&
+             `            };` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            if (SET_PUSH_STATE) {` && |\n|  &&
+             `              const hash = _hashChanger.getHash();` && |\n|  &&
+             `              const newUrl = ``${window.location.pathname}${window.location.search}#${hash}${SET_PUSH_STATE}``;` && |\n|  &&
+             `              history.pushState(oState, "", newUrl);` && |\n|  &&
+             `            } else {` && |\n|  &&
+             `              history.replaceState(oState, "", window.location.href);` && |\n|  &&
+             `            }` && |\n|  &&
+             `            const newHash = SET_APP_STATE_ACTIVE` && |\n|  &&
+             `              ? ``z2ui5-xapp-state=${ID || ""}``` && |\n|  &&
+             `              : "";` && |\n|  &&
+             `            _hashChanger.replaceHash(newHash);` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            logError("_processAfterRendering: history update failed", e);` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (SET_NAV_BACK) history.back();` && |\n|  &&
+             `` && |\n|  &&
+             `          runCallbacks(z2ui5.onAfterRendering);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("_processAfterRendering: unexpected error", e);` && |\n|  &&
+             `          MessageBox.error(e.toLocaleString(), {` && |\n|  &&
+             `            title: "Unexpected Error Occurred - App Terminated",` && |\n|  &&
+             `            actions: [],` && |\n|  &&
+             `            onClose: () =>` && |\n|  &&
+             `              new mBusyDialog({ text: "Please Restart the App" }).open(),` && |\n|  &&
+             `          });` && |\n|  &&
+             `        } finally {` && |\n|  &&
+             `          BusyIndicator.hide();` && |\n|  &&
+             `          z2ui5.isBusy = false;` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Build the delta object sent to the backend. ``paths`` is the set of` && |\n|  &&
+             `      // /XX/... paths that the user edited; ``xx`` is the full XX model data.` && |\n|  &&
+             `      _buildDeltaFromPaths(paths, xx) {` && |\n|  &&
+             `        const delta = {};` && |\n|  &&
+             `        for (const path of paths) {` && |\n|  &&
+             `          // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>"` && |\n|  &&
+             `          const [attr, rowIdx, field] = path.slice(4).split("/");` && |\n|  &&
+             `          const isRowField =` && |\n|  &&
+             `            field !== undefined && rowIdx !== "" && !isNaN(rowIdx);` && |\n|  &&
+             `          if (isRowField) {` && |\n|  &&
+             `            // Table cell change -> ship only the changed cell.` && |\n|  &&
+             `            if (!delta[attr] || !delta[attr].__delta) {` && |\n|  &&
+             `              delta[attr] = { __delta: {} };` && |\n|  &&
+             `            }` && |\n|  &&
+             `            const attrDelta = delta[attr].__delta;` && |\n|  &&
+             `            if (!attrDelta[rowIdx]) attrDelta[rowIdx] = {};` && |\n|  &&
+             `            const row = xx[attr] && xx[attr][+rowIdx];` && |\n|  &&
+             `            attrDelta[rowIdx][field] = row ? row[field] : undefined;` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            // Scalar change -> ship the whole attribute.` && |\n|  &&
+             `            delta[attr] = xx[attr];` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `        return delta;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _createViewModel() {` && |\n|  &&
+             `        const data = z2ui5.oResponse && z2ui5.oResponse.OVIEWMODEL;` && |\n|  &&
+             `        return this._trackChanges(new JSONModel(data));` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // Display: popups, popovers, nested views, main view` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `      async displayFragment(xml, viewProp) {` && |\n|  &&
+             `        const oModel = this._createViewModel();` && |\n|  &&
+             `        applyStoredSizeLimit("POPUP", oModel);` && |\n|  &&
+             `        const oFragment = await Fragment.load({` && |\n|  &&
+             `          definition: xml,` && |\n|  &&
+             `          controller: z2ui5.oControllerPopup,` && |\n|  &&
+             `          id: "popupId",` && |\n|  &&
+             `        });` && |\n|  &&
+             `        // The app might have been torn down while the fragment loaded.` && |\n|  &&
+             `        const appAlive =` && |\n|  &&
+             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n|  &&
+             `        if (!appAlive) {` && |\n|  &&
+             `          oFragment.destroy();` && |\n|  &&
              |\n|.
     result = result &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        oFragment.setModel(oModel);` && |\n| &&
-             `        oFragment.Fragment = Fragment;` && |\n| &&
-             `        z2ui5[viewProp] = oFragment;` && |\n| &&
-             `        oFragment.open();` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async displayPopover(xml, viewProp, openById) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oModel = this._createViewModel();` && |\n| &&
-             `          applyStoredSizeLimit("POPOVER", oModel);` && |\n| &&
-             `          const oFragment = await Fragment.load({` && |\n| &&
-             `            definition: xml,` && |\n| &&
-             `            controller: z2ui5.oControllerPopover,` && |\n| &&
-             `            id: "popoverId",` && |\n| &&
-             `          });` && |\n| &&
-             `          const appAlive =` && |\n| &&
-             `            z2ui5.oApp &&` && |\n| &&
-             `            (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n| &&
-             `          if (!appAlive) {` && |\n| &&
-             `            oFragment.destroy();` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          oFragment.setModel(oModel);` && |\n| &&
-             `          oFragment.Fragment = Fragment;` && |\n| &&
-             `` && |\n| &&
-             `          // Find the control to attach the popover to. We search the main` && |\n| &&
-             `          // view first, then any open popup / nested views, then the global` && |\n| &&
-             `          // UI5 control registry as a last resort.` && |\n| &&
-             `          let oControl = z2ui5.oView && z2ui5.oView.byId(openById);` && |\n| &&
-             `          if (!oControl && z2ui5.oViewPopup && z2ui5.oViewPopup.Fragment) {` && |\n| &&
-             `            oControl = z2ui5.oViewPopup.Fragment.byId("popupId", openById);` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!oControl && z2ui5.oViewNest) {` && |\n| &&
-             `            oControl = z2ui5.oViewNest.byId(openById);` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!oControl && z2ui5.oViewNest2) {` && |\n| &&
-             `            oControl = z2ui5.oViewNest2.byId(openById);` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!oControl) {` && |\n| &&
-             `            if (Element.getElementById) {` && |\n| &&
-             `              oControl = Element.getElementById(openById);` && |\n| &&
-             `            } else if (sap.ui.getCore) {` && |\n| &&
-             `              const core = sap.ui.getCore();` && |\n| &&
-             `              if (core && core.byId) oControl = core.byId(openById);` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (!oControl) {` && |\n| &&
-             `            logError(``displayPopover: openBy control '${openById}' not found``);` && |\n| &&
-             `            oFragment.destroy();` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          z2ui5[viewProp] = oFragment;` && |\n| &&
-             `          oFragment.openBy(oControl);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("displayPopover: failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async displayNestedView(xml, viewProp, viewNestId, controller) {` && |\n| &&
-             `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit(paramToViewKey[viewNestId], oModel);` && |\n| &&
-             `        const oView = await XMLView.create({` && |\n| &&
-             `          definition: xml,` && |\n| &&
-             `          controller: controller,` && |\n| &&
-             `          preprocessors: { xml: { models: { template: oModel } } },` && |\n| &&
-             `        });` && |\n| &&
-             `` && |\n| &&
-             `        const appAlive =` && |\n| &&
-             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n| &&
-             `        if (!appAlive) {` && |\n| &&
-             `          oView.destroy();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        oView.setModel(oModel);` && |\n| &&
-             `` && |\n| &&
-             `        const nestParams =` && |\n| &&
-             `          z2ui5.oResponse &&` && |\n| &&
-             `          z2ui5.oResponse.PARAMS &&` && |\n| &&
-             `          z2ui5.oResponse.PARAMS[viewNestId];` && |\n| &&
-             `        if (!nestParams) {` && |\n| &&
-             `          logError(``displayNestedView: missing PARAMS.${viewNestId}``);` && |\n| &&
-             `          oView.destroy();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        const { ID, METHOD_DESTROY, METHOD_INSERT } = nestParams;` && |\n| &&
-             `` && |\n| &&
-             `        const oParent = z2ui5.oView && z2ui5.oView.byId(ID);` && |\n| &&
-             `        if (!oParent) {` && |\n| &&
-             `          logError(` && |\n| &&
-             `            ``displayNestedView: parent control '${ID}' not found, nested view discarded``,` && |\n| &&
-             `          );` && |\n| &&
-             `          oView.destroy();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        try {` && |\n| &&
-             `          oParent[METHOD_DESTROY]();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("displayNestedView: parent destroy method failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `        try {` && |\n| &&
-             `          oParent[METHOD_INSERT](oView);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("displayNestedView: parent insert method failed", e);` && |\n| &&
-             `          oView.destroy();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        z2ui5[viewProp] = oView;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Shared destroy logic: close (if dialog/popover) and destroy the view,` && |\n| &&
-             `      // then clear the slot on z2ui5.` && |\n| &&
-             `      _destroyView(prop, tryClose) {` && |\n| &&
-             `        const view = z2ui5[prop];` && |\n| &&
-             `        if (!view) return;` && |\n| &&
-             `        if (tryClose) {` && |\n| &&
-             `          try {` && |\n| &&
-             `            if (view.close) view.close();` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            logError(``_destroyView: view.close() failed for ${prop}``, e);` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `        try {` && |\n| &&
-             `          view.destroy();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``_destroyView: view.destroy() failed for ${prop}``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `        z2ui5[prop] = null;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      PopupDestroy() {` && |\n| &&
-             `        this._destroyView("oViewPopup", true);` && |\n| &&
-             `      },` && |\n| &&
-             `      PopoverDestroy() {` && |\n| &&
-             `        this._destroyView("oViewPopover", true);` && |\n| &&
-             `      },` && |\n| &&
-             `      NestViewDestroy() {` && |\n| &&
-             `        this._destroyView("oViewNest");` && |\n| &&
-             `      },` && |\n| &&
-             `      NestViewDestroy2() {` && |\n| &&
-             `        this._destroyView("oViewNest2");` && |\n| &&
-             `      },` && |\n| &&
-             `      ViewDestroy() {` && |\n| &&
-             `        this._destroyView("oView");` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // eF: handle frontend-only events triggered by the backend response.` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      eF(...args) {` && |\n| &&
-             `        runCallbacks(z2ui5.onBeforeEventFrontend, args);` && |\n| &&
-             `` && |\n| &&
-             `        // NavContainer navigation is dispatched via lookup table.` && |\n| &&
-             `        const navLookup = navContainerLookups[args[0]];` && |\n| &&
-             `        if (navLookup) {` && |\n| &&
-             `          navigateContainer(navLookup, args);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        switch (args[0]) {` && |\n| &&
-             `          case "SET_SIZE_LIMIT":` && |\n| &&
-             `            this._evSetSizeLimit(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "HISTORY_BACK":` && |\n| &&
-             `            history.back();` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "CLIPBOARD_COPY":` && |\n| &&
-             `            copyToClipboard(args[1]);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "CLIPBOARD_APP_STATE": {` && |\n| &&
-             `            const id = z2ui5.oResponse && z2ui5.oResponse.ID;` && |\n| &&
-             `            copyToClipboard(``${window.location.href}#/z2ui5-xapp-state=${id}``);` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `          case "SET_ODATA_MODEL":` && |\n| &&
-             `            this._evSetODataModel(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "STORE_DATA":` && |\n| &&
-             `            this._evStoreData(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "DOWNLOAD_B64_FILE": {` && |\n| &&
-             `            const a = document.createElement("a");` && |\n| &&
-             `            a.href = args[1];` && |\n| &&
-             `            a.download = args[2];` && |\n| &&
-             `            a.click();` && |\n| &&
-             `            break;` && |\n| &&
-             `          }` && |\n| &&
-             `          case "CROSS_APP_NAV_TO_PREV_APP":` && |\n| &&
-             `            withCrossAppNavigator((nav) => nav.backToPreviousApp());` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "CROSS_APP_NAV_TO_EXT":` && |\n| &&
-             `            this._evCrossAppNavToExt(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "LOCATION_RELOAD":` && |\n| &&
-             `            this._evLocationReload(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "SYSTEM_LOGOUT":` && |\n| &&
-             `            this._evSystemLogout(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "OPEN_NEW_TAB":` && |\n| &&
-             `            this._evOpenNewTab(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "POPUP_CLOSE":` && |\n| &&
-             `            this.PopupDestroy();` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "POPOVER_CLOSE":` && |\n| &&
-             `            this.PopoverDestroy();` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "URLHELPER":` && |\n| &&
-             `            this._evUrlHelper(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "IMAGE_EDITOR_POPUP_CLOSE":` && |\n| &&
-             `            this._evImageEditorPopupClose();` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "SET_TITLE":` && |\n| &&
-             `            this._evSetTitle(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "SET_FOCUS":` && |\n| &&
-             `            this._evSetFocus(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "SCROLL_TO":` && |\n| &&
-             `            this._evScrollTo(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "SCROLL_INTO_VIEW":` && |\n| &&
-             `            this._evScrollIntoView(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "START_TIMER":` && |\n| &&
-             `            this._evStartTimer(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "KEYBOARD_SET_MODE":` && |\n| &&
-             `            this._evSetInputMode(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "Z2UI5":` && |\n| &&
-             `            this._evZ2ui5Custom(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "WIZARD_SET_NEXT_STEP":` && |\n| &&
-             `            this._evWizardSetNextStep(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `          case "PLAY_AUDIO":` && |\n| &&
-             `            this._evPlayAudio(args);` && |\n| &&
-             `            break;` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Individual event handlers - one per case in eF(). Splitting them out` && |\n| &&
-             `      // keeps eF() short and makes each behavior easy to find.` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `` && |\n| &&
-             `      _evSetSizeLimit(args) {` && |\n| &&
-             `        // Two call shapes:` && |\n| &&
-             `        //   ["SET_SIZE_LIMIT", "<limit>", "<viewKey>"]   -> set the limit` && |\n| &&
-             `        //   ["SET_SIZE_LIMIT", "<viewKey>"]              -> reset the limit` && |\n| &&
-             `        const hasLimit = args[2] !== undefined && args[2] !== "";` && |\n| &&
-             `        const viewKey = hasLimit ? args[2] : args[1];` && |\n| &&
-             `        const limit = hasLimit ? Number(args[1]) : NaN;` && |\n| &&
-             `        const view = viewLookups[viewKey] && viewLookups[viewKey]();` && |\n| &&
-             `        const model = view && view.getModel();` && |\n| &&
-             `` && |\n| &&
-             `        if (Number.isFinite(limit) && limit > 0) {` && |\n| &&
-             `          if (!z2ui5.viewSizeLimits) z2ui5.viewSizeLimits = {};` && |\n| &&
-             `          z2ui5.viewSizeLimits[viewKey] = limit;` && |\n| &&
-             `          if (model) {` && |\n| &&
-             `            model.setSizeLimit(limit);` && |\n| &&
-             `            model.refresh(true);` && |\n| &&
-             `          }` && |\n| &&
-             `        } else {` && |\n| &&
-             `          if (z2ui5.viewSizeLimits) delete z2ui5.viewSizeLimits[viewKey];` && |\n| &&
-             `          if (model) {` && |\n| &&
-             `            model.setSizeLimit(100);` && |\n| &&
-             `            model.refresh(true);` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evSetODataModel(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oModel = new ODataModel({` && |\n| &&
-             `            serviceUrl: args[1],` && |\n| &&
-             `            annotationURI: args[3] || "",` && |\n| &&
-             `          });` && |\n| &&
-             `          if (z2ui5.oView) z2ui5.oView.setModel(oModel, args[2] || undefined);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``SET_ODATA_MODEL: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evStoreData(args) {` && |\n| &&
-             `        const { TYPE, PREFIX, VALUE, KEY } = args[1];` && |\n| &&
-             `        try {` && |\n| &&
-             `          const storageType = Storage.Type[TYPE] || Storage.Type.session;` && |\n| &&
-             `          const oStorage = new Storage(storageType, PREFIX);` && |\n| &&
-             `          if (VALUE === "" || VALUE == null) {` && |\n| &&
-             `            oStorage.remove(KEY);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            oStorage.put(KEY, VALUE);` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``STORE_DATA: storage operation failed for key '${KEY}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evCrossAppNavToExt(args) {` && |\n| &&
-             `        withCrossAppNavigator((nav) => {` && |\n| &&
-             `          const hash =` && |\n| &&
-             `            nav.hrefForExternal({ target: args[1], params: args[2] }) || "";` && |\n| &&
-             `          if (args[3] === "EXT") {` && |\n| &&
-             `            // External redirect: replace the location while keeping the host.` && |\n| &&
-             `            const base = window.location.href.split("#")[0];` && |\n| &&
-             `            _URLHelper.redirect(``${base}${hash}``, true);` && |\n| &&
-             `          } else {` && |\n| &&
-             `            nav.toExternal({ target: { shellHash: hash } });` && |\n| &&
-             `          }` && |\n| &&
-             `        });` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evLocationReload(args) {` && |\n| &&
-             `        if (isValidRedirectURL(args[1])) {` && |\n| &&
-             `          window.location.href = args[1];` && |\n| &&
-             `        } else {` && |\n| &&
-             `          MessageBox.error(` && |\n| &&
-             `            "Invalid redirect URL. Only relative URLs to the same domain are allowed.",` && |\n| &&
-             `          );` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evSystemLogout(args) {` && |\n| &&
-             `        const logoutUrl = args[1] || "/sap/public/bc/icf/logoff";` && |\n| &&
-             `        const goToLogoutUrl = () => {` && |\n| &&
-             `          if (isValidRedirectURL(logoutUrl)) {` && |\n| &&
-             `            window.location.href = logoutUrl;` && |\n| &&
-             `          } else {` && |\n| &&
-             `            MessageBox.error(` && |\n| &&
-             `              "Invalid logout URL. Only relative URLs to the same domain are allowed.",` && |\n| &&
-             `            );` && |\n| &&
-             `          }` && |\n| &&
-             `        };` && |\n| &&
-             `        // When abap2UI5 is hosted as a BSP application,` && |\n| &&
-             `        // /sap/public/bc/icf/logoff alone does not terminate the stateful` && |\n| &&
-             `        // BSP context (sap-contextid stays bound to /sap/bc/bsp/sap/<app>/).` && |\n| &&
-             `        // Hit the BSP path with ?sap-sessioncmd=logoff first so the BSP` && |\n| &&
-             `        // runtime calls server->session->terminate( ), then go to the ICF` && |\n| &&
-             `        // logoff to also drop the SSO2 ticket.` && |\n| &&
-             `        const redirectToLogoff = () => {` && |\n| &&
-             `          const path = window.location.pathname;` && |\n| &&
-             `          if (path.indexOf("/sap/bc/bsp/") !== 0) {` && |\n| &&
-             `            goToLogoutUrl();` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          const sep = path.indexOf("?") >= 0 ? "&" : "?";` && |\n| &&
-             `          const bspKill = path + sep + "sap-sessioncmd=logoff";` && |\n| &&
-             `          let done = false;` && |\n| &&
-             `          const finish = () => {` && |\n| &&
-             `            if (done) return;` && |\n| &&
-             `            done = true;` && |\n| &&
-             `            goToLogoutUrl();` && |\n| &&
-             `          };` && |\n| &&
-             `          try {` && |\n| &&
-             `            const f = document.createElement("iframe");` && |\n| &&
-             `            f.style.display = "none";` && |\n| &&
-             `            f.src = bspKill;` && |\n| &&
-             `            f.addEventListener("load", finish);` && |\n| &&
-             `            document.body.appendChild(f);` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            finish();` && |\n| &&
-             `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          // Safety net: never wait longer than 1.5s for the BSP terminate.` && |\n| &&
-             `          setTimeout(finish, 1500);` && |\n| &&
-             `        };` && |\n| &&
-             `        try {` && |\n| &&
-             `          const launchpadLogout =` && |\n| &&
-             `            z2ui5.oLaunchpad &&` && |\n| &&
-             `            z2ui5.oLaunchpad.Container &&` && |\n| &&
-             `            z2ui5.oLaunchpad.Container.logout;` && |\n| &&
-             `          if (launchpadLogout) {` && |\n| &&
-             `            z2ui5.oLaunchpad.Container.logout();` && |\n| &&
-             `          } else {` && |\n| &&
-             `            redirectToLogoff();` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("SYSTEM_LOGOUT: ushell logout failed", e);` && |\n| &&
-             `          redirectToLogoff();` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evOpenNewTab(args) {` && |\n| &&
-             `        if (!isValidRedirectURL(args[1])) {` && |\n| &&
-             `          MessageBox.error(` && |\n| &&
-             `            "Invalid URL. Only relative URLs to the same domain are allowed.",` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        const newWindow = window.open(args[1], "_blank");` && |\n| &&
-             `        // Clear opener to prevent the new tab from accessing window.opener.` && |\n| &&
-             `        if (newWindow) newWindow.opener = null;` && |\n| &&
-             `      },` && |\n| &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        oFragment.setModel(oModel);` && |\n|  &&
+             `        oFragment.Fragment = Fragment;` && |\n|  &&
+             `        z2ui5[viewProp] = oFragment;` && |\n|  &&
+             `        oFragment.open();` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async displayPopover(xml, viewProp, openById) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oModel = this._createViewModel();` && |\n|  &&
+             `          applyStoredSizeLimit("POPOVER", oModel);` && |\n|  &&
+             `          const oFragment = await Fragment.load({` && |\n|  &&
+             `            definition: xml,` && |\n|  &&
+             `            controller: z2ui5.oControllerPopover,` && |\n|  &&
+             `            id: "popoverId",` && |\n|  &&
+             `          });` && |\n|  &&
+             `          const appAlive =` && |\n|  &&
+             `            z2ui5.oApp &&` && |\n|  &&
+             `            (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n|  &&
+             `          if (!appAlive) {` && |\n|  &&
+             `            oFragment.destroy();` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          oFragment.setModel(oModel);` && |\n|  &&
+             `          oFragment.Fragment = Fragment;` && |\n|  &&
+             `` && |\n|  &&
+             `          // Find the control to attach the popover to. We search the main` && |\n|  &&
+             `          // view first, then any open popup / nested views, then the global` && |\n|  &&
+             `          // UI5 control registry as a last resort.` && |\n|  &&
+             `          let oControl = z2ui5.oView && z2ui5.oView.byId(openById);` && |\n|  &&
+             `          if (!oControl && z2ui5.oViewPopup && z2ui5.oViewPopup.Fragment) {` && |\n|  &&
+             `            oControl = z2ui5.oViewPopup.Fragment.byId("popupId", openById);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (!oControl && z2ui5.oViewNest) {` && |\n|  &&
+             `            oControl = z2ui5.oViewNest.byId(openById);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (!oControl && z2ui5.oViewNest2) {` && |\n|  &&
+             `            oControl = z2ui5.oViewNest2.byId(openById);` && |\n|  &&
+             `          }` && |\n|  &&
+             `          if (!oControl) {` && |\n|  &&
+             `            if (Element.getElementById) {` && |\n|  &&
+             `              oControl = Element.getElementById(openById);` && |\n|  &&
+             `            } else if (sap.ui.getCore) {` && |\n|  &&
+             `              const core = sap.ui.getCore();` && |\n|  &&
+             `              if (core && core.byId) oControl = core.byId(openById);` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!oControl) {` && |\n|  &&
+             `            logError(``displayPopover: openBy control '${openById}' not found``);` && |\n|  &&
+             `            oFragment.destroy();` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          z2ui5[viewProp] = oFragment;` && |\n|  &&
+             `          oFragment.openBy(oControl);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("displayPopover: failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async displayNestedView(xml, viewProp, viewNestId, controller) {` && |\n|  &&
+             `        const oModel = this._createViewModel();` && |\n|  &&
+             `        applyStoredSizeLimit(paramToViewKey[viewNestId], oModel);` && |\n|  &&
+             `        const oView = await XMLView.create({` && |\n|  &&
+             `          definition: xml,` && |\n|  &&
+             `          controller: controller,` && |\n|  &&
+             `          preprocessors: { xml: { models: { template: oModel } } },` && |\n|  &&
+             `        });` && |\n|  &&
+             `` && |\n|  &&
+             `        const appAlive =` && |\n|  &&
+             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n|  &&
+             `        if (!appAlive) {` && |\n|  &&
+             `          oView.destroy();` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        oView.setModel(oModel);` && |\n|  &&
+             `` && |\n|  &&
+             `        const nestParams =` && |\n|  &&
+             `          z2ui5.oResponse &&` && |\n|  &&
+             `          z2ui5.oResponse.PARAMS &&` && |\n|  &&
+             `          z2ui5.oResponse.PARAMS[viewNestId];` && |\n|  &&
+             `        if (!nestParams) {` && |\n|  &&
+             `          logError(``displayNestedView: missing PARAMS.${viewNestId}``);` && |\n|  &&
+             `          oView.destroy();` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const { ID, METHOD_DESTROY, METHOD_INSERT } = nestParams;` && |\n|  &&
+             `` && |\n|  &&
+             `        const oParent = z2ui5.oView && z2ui5.oView.byId(ID);` && |\n|  &&
+             `        if (!oParent) {` && |\n|  &&
+             `          logError(` && |\n|  &&
+             `            ``displayNestedView: parent control '${ID}' not found, nested view discarded``,` && |\n|  &&
+             `          );` && |\n|  &&
+             `          oView.destroy();` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          oParent[METHOD_DESTROY]();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("displayNestedView: parent destroy method failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          oParent[METHOD_INSERT](oView);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("displayNestedView: parent insert method failed", e);` && |\n|  &&
+             `          oView.destroy();` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        z2ui5[viewProp] = oView;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Shared destroy logic: close (if dialog/popover) and destroy the view,` && |\n|  &&
+             `      // then clear the slot on z2ui5.` && |\n|  &&
+             `      _destroyView(prop, tryClose) {` && |\n|  &&
+             `        const view = z2ui5[prop];` && |\n|  &&
+             `        if (!view) return;` && |\n|  &&
+             `        if (tryClose) {` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            if (view.close) view.close();` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            logError(``_destroyView: view.close() failed for ${prop}``, e);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          view.destroy();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``_destroyView: view.destroy() failed for ${prop}``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        z2ui5[prop] = null;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      PopupDestroy() {` && |\n|  &&
+             `        this._destroyView("oViewPopup", true);` && |\n|  &&
+             `      },` && |\n|  &&
+             `      PopoverDestroy() {` && |\n|  &&
+             `        this._destroyView("oViewPopover", true);` && |\n|  &&
+             `      },` && |\n|  &&
+             `      NestViewDestroy() {` && |\n|  &&
+             `        this._destroyView("oViewNest");` && |\n|  &&
+             `      },` && |\n|  &&
+             `      NestViewDestroy2() {` && |\n|  &&
+             `        this._destroyView("oViewNest2");` && |\n|  &&
+             `      },` && |\n|  &&
+             `      ViewDestroy() {` && |\n|  &&
+             `        this._destroyView("oView");` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // eF: handle frontend-only events triggered by the backend response.` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      eF(...args) {` && |\n|  &&
+             `        runCallbacks(z2ui5.onBeforeEventFrontend, args);` && |\n|  &&
+             `` && |\n|  &&
+             `        // NavContainer navigation is dispatched via lookup table.` && |\n|  &&
+             `        const navLookup = navContainerLookups[args[0]];` && |\n|  &&
+             `        if (navLookup) {` && |\n|  &&
+             `          navigateContainer(navLookup, args);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        switch (args[0]) {` && |\n|  &&
+             `          case "SET_SIZE_LIMIT":` && |\n|  &&
+             `            this._evSetSizeLimit(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "HISTORY_BACK":` && |\n|  &&
+             `            history.back();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "CLIPBOARD_COPY":` && |\n|  &&
+             `            copyToClipboard(args[1]);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "CLIPBOARD_APP_STATE": {` && |\n|  &&
+             `            const id = z2ui5.oResponse && z2ui5.oResponse.ID;` && |\n|  &&
+             `            copyToClipboard(``${window.location.href}#/z2ui5-xapp-state=${id}``);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          case "SET_ODATA_MODEL":` && |\n|  &&
+             `            this._evSetODataModel(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "STORE_DATA":` && |\n|  &&
+             `            this._evStoreData(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "DOWNLOAD_B64_FILE": {` && |\n|  &&
+             `            const a = document.createElement("a");` && |\n|  &&
+             `            a.href = args[1];` && |\n|  &&
+             `            a.download = args[2];` && |\n|  &&
+             `            a.click();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          case "CROSS_APP_NAV_TO_PREV_APP":` && |\n|  &&
+             `            withCrossAppNavigator((nav) => nav.backToPreviousApp());` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "CROSS_APP_NAV_TO_EXT":` && |\n|  &&
+             `            this._evCrossAppNavToExt(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "LOCATION_RELOAD":` && |\n|  &&
+             `            this._evLocationReload(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "SYSTEM_LOGOUT":` && |\n|  &&
+             `            this._evSystemLogout(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "OPEN_NEW_TAB":` && |\n|  &&
+             `            this._evOpenNewTab(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "POPUP_CLOSE":` && |\n|  &&
+             `            this.PopupDestroy();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "POPOVER_CLOSE":` && |\n|  &&
+             `            this.PopoverDestroy();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "URLHELPER":` && |\n|  &&
+             `            this._evUrlHelper(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "IMAGE_EDITOR_POPUP_CLOSE":` && |\n|  &&
+             `            this._evImageEditorPopupClose();` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "SET_TITLE":` && |\n|  &&
+             `            this._evSetTitle(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "SET_FOCUS":` && |\n|  &&
+             `            this._evSetFocus(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "SCROLL_TO":` && |\n|  &&
+             `            this._evScrollTo(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "SCROLL_INTO_VIEW":` && |\n|  &&
+             `            this._evScrollIntoView(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "START_TIMER":` && |\n|  &&
+             `            this._evStartTimer(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "KEYBOARD_SET_MODE":` && |\n|  &&
+             `            this._evSetInputMode(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "Z2UI5":` && |\n|  &&
+             `            this._evZ2ui5Custom(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "WIZARD_SET_NEXT_STEP":` && |\n|  &&
+             `            this._evWizardSetNextStep(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `          case "PLAY_AUDIO":` && |\n|  &&
+             `            this._evPlayAudio(args);` && |\n|  &&
+             `            break;` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // Individual event handlers - one per case in eF(). Splitting them out` && |\n|  &&
+             `      // keeps eF() short and makes each behavior easy to find.` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSetSizeLimit(args) {` && |\n|  &&
+             `        // Two call shapes:` && |\n|  &&
+             `        //   ["SET_SIZE_LIMIT", "<limit>", "<viewKey>"]   -> set the limit` && |\n|  &&
+             `        //   ["SET_SIZE_LIMIT", "<viewKey>"]              -> reset the limit` && |\n|  &&
+             `        const hasLimit = args[2] !== undefined && args[2] !== "";` && |\n|  &&
+             `        const viewKey = hasLimit ? args[2] : args[1];` && |\n|  &&
+             `        const limit = hasLimit ? Number(args[1]) : NaN;` && |\n|  &&
+             `        const view = viewLookups[viewKey] && viewLookups[viewKey]();` && |\n|  &&
+             `        const model = view && view.getModel();` && |\n|  &&
+             `` && |\n|  &&
+             `        if (Number.isFinite(limit) && limit > 0) {` && |\n|  &&
+             `          if (!z2ui5.viewSizeLimits) z2ui5.viewSizeLimits = {};` && |\n|  &&
+             `          z2ui5.viewSizeLimits[viewKey] = limit;` && |\n|  &&
+             `          if (model) {` && |\n|  &&
+             `            model.setSizeLimit(limit);` && |\n|  &&
+             `            model.refresh(true);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          if (z2ui5.viewSizeLimits) delete z2ui5.viewSizeLimits[viewKey];` && |\n|  &&
+             `          if (model) {` && |\n|  &&
+             `            model.setSizeLimit(100);` && |\n|  &&
+             `            model.refresh(true);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSetODataModel(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oModel = new ODataModel({` && |\n|  &&
+             `            serviceUrl: args[1],` && |\n|  &&
+             `            annotationURI: args[3] || "",` && |\n|  &&
+             `          });` && |\n|  &&
+             `          if (z2ui5.oView) z2ui5.oView.setModel(oModel, args[2] || undefined);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``SET_ODATA_MODEL: failed for '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evStoreData(args) {` && |\n|  &&
+             `        const { TYPE, PREFIX, VALUE, KEY } = args[1];` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const storageType = Storage.Type[TYPE] || Storage.Type.session;` && |\n|  &&
+             `          const oStorage = new Storage(storageType, PREFIX);` && |\n|  &&
+             `          if (VALUE === "" || VALUE == null) {` && |\n|  &&
+             `            oStorage.remove(KEY);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            oStorage.put(KEY, VALUE);` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``STORE_DATA: storage operation failed for key '${KEY}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evCrossAppNavToExt(args) {` && |\n|  &&
+             `        withCrossAppNavigator((nav) => {` && |\n|  &&
+             `          const hash =` && |\n|  &&
+             `            nav.hrefForExternal({ target: args[1], params: args[2] }) || "";` && |\n|  &&
+             `          if (args[3] === "EXT") {` && |\n|  &&
+             `            // External redirect: replace the location while keeping the host.` && |\n|  &&
+             `            const base = window.location.href.split("#")[0];` && |\n|  &&
+             `            _URLHelper.redirect(``${base}${hash}``, true);` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            nav.toExternal({ target: { shellHash: hash } });` && |\n|  &&
+             `          }` && |\n|  &&
+             `        });` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evLocationReload(args) {` && |\n|  &&
+             `        if (isValidRedirectURL(args[1])) {` && |\n|  &&
+             `          window.location.href = args[1];` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          MessageBox.error(` && |\n|  &&
+             `            "Invalid redirect URL. Only relative URLs to the same domain are allowed.",` && |\n|  &&
+             `          );` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSystemLogout(args) {` && |\n|  &&
+             `        const logoutUrl = args[1] || "/sap/public/bc/icf/logoff";` && |\n|  &&
+             `        const goToLogoutUrl = () => {` && |\n|  &&
+             `          if (isValidRedirectURL(logoutUrl)) {` && |\n|  &&
+             `            window.location.href = logoutUrl;` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            MessageBox.error(` && |\n|  &&
+             `              "Invalid logout URL. Only relative URLs to the same domain are allowed.",` && |\n|  &&
+             `            );` && |\n|  &&
+             `          }` && |\n|  &&
+             `        };` && |\n|  &&
+             `        // When abap2UI5 is hosted as a BSP application,` && |\n|  &&
+             `        // /sap/public/bc/icf/logoff alone does not terminate the stateful` && |\n|  &&
+             `        // BSP context (sap-contextid stays bound to /sap/bc/bsp/sap/<app>/).` && |\n|  &&
+             `        // Hit the BSP path with ?sap-sessioncmd=logoff first so the BSP` && |\n|  &&
+             `        // runtime calls server->session->terminate( ), then go to the ICF` && |\n|  &&
+             `        // logoff to also drop the SSO2 ticket.` && |\n|  &&
+             `        const redirectToLogoff = () => {` && |\n|  &&
+             `          const path = window.location.pathname;` && |\n|  &&
+             `          if (path.indexOf("/sap/bc/bsp/") !== 0) {` && |\n|  &&
+             `            goToLogoutUrl();` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          const sep = path.indexOf("?") >= 0 ? "&" : "?";` && |\n|  &&
+             `          const bspKill = path + sep + "sap-sessioncmd=logoff";` && |\n|  &&
+             `          let done = false;` && |\n|  &&
+             `          const finish = () => {` && |\n|  &&
+             `            if (done) return;` && |\n|  &&
+             `            done = true;` && |\n|  &&
+             `            goToLogoutUrl();` && |\n|  &&
+             `          };` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const f = document.createElement("iframe");` && |\n|  &&
+             `            f.style.display = "none";` && |\n|  &&
+             `            f.src = bspKill;` && |\n|  &&
+             `            f.addEventListener("load", finish);` && |\n|  &&
+             `            document.body.appendChild(f);` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            finish();` && |\n|  &&
+             `            return;` && |\n|  &&
+             `          }` && |\n|  &&
+             `          // Safety net: never wait longer than 1.5s for the BSP terminate.` && |\n|  &&
+             `          setTimeout(finish, 1500);` && |\n|  &&
+             `        };` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const launchpadLogout =` && |\n|  &&
+             `            z2ui5.oLaunchpad &&` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container &&` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container.logout;` && |\n|  &&
+             `          if (launchpadLogout) {` && |\n|  &&
+             `            z2ui5.oLaunchpad.Container.logout();` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            redirectToLogoff();` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("SYSTEM_LOGOUT: ushell logout failed", e);` && |\n|  &&
+             `          redirectToLogoff();` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evOpenNewTab(args) {` && |\n|  &&
+             `        if (!isValidRedirectURL(args[1])) {` && |\n|  &&
+             `          MessageBox.error(` && |\n|  &&
+             `            "Invalid URL. Only relative URLs to the same domain are allowed.",` && |\n|  &&
+             `          );` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        const newWindow = window.open(args[1], "_blank");` && |\n|  &&
+             `        // Clear opener to prevent the new tab from accessing window.opener.` && |\n|  &&
+             `        if (newWindow) newWindow.opener = null;` && |\n|  &&
+             `      },` && |\n|  &&
              |\n|.
     result = result &&
-             `` && |\n| &&
-             `      _evUrlHelper(args) {` && |\n| &&
-             `        const params = args[2];` && |\n| &&
-             `        const actions = {` && |\n| &&
-             `          REDIRECT: () => _URLHelper.redirect(params.URL, params.NEW_WINDOW),` && |\n| &&
-             `          TRIGGER_EMAIL: () =>` && |\n| &&
-             `            _URLHelper.triggerEmail(` && |\n| &&
-             `              params.EMAIL,` && |\n| &&
-             `              params.SUBJECT,` && |\n| &&
-             `              params.BODY,` && |\n| &&
-             `              params.CC,` && |\n| &&
-             `              params.BCC,` && |\n| &&
-             `              params.NEW_WINDOW,` && |\n| &&
-             `            ),` && |\n| &&
-             `          TRIGGER_SMS: () => _URLHelper.triggerSms(params),` && |\n| &&
-             `          TRIGGER_TEL: () => _URLHelper.triggerTel(params),` && |\n| &&
-             `        };` && |\n| &&
-             `        try {` && |\n| &&
-             `          const fn = actions[args[1]];` && |\n| &&
-             `          if (fn) fn();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``URLHELPER: '${args[1]}' failed``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evImageEditorPopupClose() {` && |\n| &&
-             `        let image;` && |\n| &&
-             `        try {` && |\n| &&
-             `          const editor = Fragment.byId("popupId", "imageEditor");` && |\n| &&
-             `          if (editor) image = editor.getImagePngDataURL();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `        this.PopupDestroy();` && |\n| &&
-             `        this.eB(["SAVE"], image);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evStartTimer(args) {` && |\n| &&
-             `        const timerKey = args[0];` && |\n| &&
-             `        const callbackEvent = args[1];` && |\n| &&
-             `        const delay = +args[2] || 0;` && |\n| &&
-             `        if (!z2ui5.timers) z2ui5.timers = {};` && |\n| &&
-             `        clearTimeout(z2ui5.timers[timerKey]);` && |\n| &&
-             `        z2ui5.timers[timerKey] = setTimeout(() => {` && |\n| &&
-             `          delete z2ui5.timers[timerKey];` && |\n| &&
-             `          this.eB([callbackEvent]);` && |\n| &&
-             `        }, delay);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evSetInputMode(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          if (!oElement) return;` && |\n| &&
-             `          const dom = oElement.getDomRef();` && |\n| &&
-             `          if (!dom) return;` && |\n| &&
-             `          const input = dom.matches("input, textarea")` && |\n| &&
-             `            ? dom` && |\n| &&
-             `            : dom.querySelector("input, textarea");` && |\n| &&
-             `          if (!input) return;` && |\n| &&
-             `          input.setAttribute("inputmode", args[2] || "text");` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(` && |\n| &&
-             `            ``KEYBOARD_SET_MODE: setAttribute failed for '${args[1]}'``,` && |\n| &&
-             `            e,` && |\n| &&
-             `          );` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evSetFocus(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          if (!oElement) return;` && |\n| &&
-             `          const info = oElement.getFocusInfo();` && |\n| &&
-             `          if (args[2] != null && args[2] !== "") info.selectionStart = +args[2];` && |\n| &&
-             `          if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];` && |\n| &&
-             `          oElement.applyFocusInfo(info);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``SET_FOCUS: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evScrollTo(args) {` && |\n| &&
-             `        // args[1] = control id` && |\n| &&
-             `        // args[2] = scrollTop  (Y, vertical, px)` && |\n| &&
-             `        // args[3] = scrollLeft (X, horizontal, px) - optional, default 0` && |\n| &&
-             `        // args[4] = behavior - "auto" (default) | "smooth" | "instant"` && |\n| &&
-             `        // Strategy: prefer the control's scroll delegate (sap.m.Page,` && |\n| &&
-             `        // ScrollContainer etc. expose ScrollEnablement). The delegate knows` && |\n| &&
-             `        // the real scroll container, which often is NOT the control's root` && |\n| &&
-             `        // DOM element - so native Element.scrollTo on getDomRef() silently` && |\n| &&
-             `        // does nothing on a Page. ScrollEnablement.scrollTo(x, y, time)` && |\n| &&
-             `        // animates when time > 0, so "smooth" maps to a 300ms animation.` && |\n| &&
-             `        // Native Element.scrollTo is only used as a fallback for controls` && |\n| &&
-             `        // without a delegate.` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          if (!oElement) return;` && |\n| &&
-             `          const y = +args[2] || 0;` && |\n| &&
-             `          const x = +args[3] || 0;` && |\n| &&
-             `          const behavior = args[4] || "auto";` && |\n| &&
-             `          const smooth = behavior === "smooth";` && |\n| &&
-             `` && |\n| &&
-             `          let handled = false;` && |\n| &&
-             `          try {` && |\n| &&
-             `            const d =` && |\n| &&
-             `              oElement.getScrollDelegate && oElement.getScrollDelegate();` && |\n| &&
-             `            if (d && d.scrollTo) {` && |\n| &&
-             `              // ScrollEnablement / iScroll delegate: scrollTo(x, y, time)` && |\n| &&
-             `              d.scrollTo(x, y, smooth ? 300 : 0);` && |\n| &&
-             `              handled = true;` && |\n| &&
-             `            }` && |\n| &&
-             `          } catch (e) {` && |\n| &&
-             `            // fall through` && |\n| &&
-             `          }` && |\n| &&
-             `` && |\n| &&
-             `          if (!handled) {` && |\n| &&
-             `            const dom = document.getElementById(``${oElement.getId()}-inner``)` && |\n| &&
-             `              || oElement.getDomRef();` && |\n| &&
-             `            if (dom && dom.scrollTo) {` && |\n| &&
-             `              dom.scrollTo({ top: y, left: x, behavior });` && |\n| &&
-             `              handled = true;` && |\n| &&
-             `            } else if (dom) {` && |\n| &&
-             `              dom.scrollTop = y;` && |\n| &&
-             `              dom.scrollLeft = x;` && |\n| &&
-             `              handled = true;` && |\n| &&
-             `            } else if (oElement.scrollTo) {` && |\n| &&
-             `              // sap.m.Page.scrollTo(y, time) - vertical only` && |\n| &&
-             `              oElement.scrollTo(y, smooth ? 300 : 0);` && |\n| &&
-             `              handled = true;` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``SCROLL_TO: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evScrollIntoView(args) {` && |\n| &&
-             `        // args[1] = control id` && |\n| &&
-             `        // args[2] = behavior - "smooth" (default) | "auto" | "instant"` && |\n| &&
-             `        // args[3] = block    - "start"  (default) | "center" | "end" | "nearest"` && |\n| &&
-             `        // args[4] = inline   - "nearest" (default)| "start"  | "center" | "end"` && |\n| &&
-             `        // Modern declarative scroll: bring a control into the viewport,` && |\n| &&
-             `        // regardless of where the surrounding scroll container currently is.` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          if (!oElement) return;` && |\n| &&
-             `          const dom = oElement.getDomRef();` && |\n| &&
-             `          if (!dom || !dom.scrollIntoView) return;` && |\n| &&
-             `          dom.scrollIntoView({` && |\n| &&
-             `            behavior: args[2] || "smooth",` && |\n| &&
-             `            block: args[3] || "start",` && |\n| &&
-             `            inline: args[4] || "nearest",` && |\n| &&
-             `          });` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``SCROLL_INTO_VIEW: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evSetTitle(args) {` && |\n| &&
-             `        const title = args[1] == null ? "" : String(args[1]);` && |\n| &&
-             `        try {` && |\n| &&
-             `          const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;` && |\n| &&
-             `          if (shell && shell.setTitle) {` && |\n| &&
-             `            const result = shell.setTitle(title);` && |\n| &&
-             `            if (result && result.catch) {` && |\n| &&
-             `              result.catch((e) =>` && |\n| &&
-             `                logError("SET_TITLE: ShellUIService.setTitle failed", e),` && |\n| &&
-             `              );` && |\n| &&
-             `            }` && |\n| &&
-             `          } else {` && |\n| &&
-             `            document.title = title;` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("SET_TITLE: ShellUIService.setTitle failed", e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evZ2ui5Custom(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const fn = z2ui5[args[1]];` && |\n| &&
-             `          if (fn) fn(args.slice(2));` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``Z2UI5: '${args[1]}' failed``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evWizardSetNextStep(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const wiz = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          const step = z2ui5.oView && z2ui5.oView.byId(args[2]);` && |\n| &&
-             `          const nextStep = z2ui5.oView && z2ui5.oView.byId(args[3]);` && |\n| &&
-             `          if (wiz && step) wiz.discardProgress(step);` && |\n| &&
-             `          if (step && nextStep) step.setNextStep(nextStep);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``WIZARD_SET_NEXT_STEP: failed for wizard '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _evPlayAudio(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          new Audio(args[1]).play();` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``PLAY_AUDIO: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      // eB: trigger a backend roundtrip with arguments.` && |\n| &&
-             `      // ------------------------------------------------------------------` && |\n| &&
-             `      eB(...args) {` && |\n| &&
-             `        if (!navigator.onLine) {` && |\n| &&
-             `          MessageBox.alert(` && |\n| &&
-             `            "No internet connection! Please reconnect to the server and try again.",` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        // If a roundtrip is already in flight, briefly show a BusyDialog so` && |\n| &&
-             `        // the user gets visual feedback instead of a silent click. args[0][2]` && |\n| &&
-             `        // is the "ignore busy" flag set by certain background events.` && |\n| &&
-             `        if (z2ui5.isBusy && !args[0][2]) {` && |\n| &&
-             `          const oBusyDialog = new mBusyDialog();` && |\n| &&
-             `          oBusyDialog.attachEventOnce("afterClose", () =>` && |\n| &&
-             `            oBusyDialog.destroy(),` && |\n| &&
-             `          );` && |\n| &&
-             `          oBusyDialog.open();` && |\n| &&
-             `          queueMicrotask(() => oBusyDialog.close());` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.isBusy = true;` && |\n| &&
-             `        BusyIndicator.show();` && |\n| &&
-             `        z2ui5.oBody = { VIEWNAME: "MAIN" };` && |\n| &&
-             `` && |\n| &&
-             `        // Decide which view's model holds the data we need to send back. The` && |\n| &&
-             `        // mapping is: main app controller -> main view, popup controller ->` && |\n| &&
-             `        // popup view, etc.` && |\n| &&
-             `        const oModel = this._pickModelForRoundtrip(args);` && |\n| &&
-             `` && |\n| &&
-             `        runCallbacks(z2ui5.onBeforeRoundtrip);` && |\n| &&
-             `` && |\n| &&
-             `        // If the user edited /XX/ paths, send only the delta to keep the` && |\n| &&
-             `        // payload small.` && |\n| &&
-             `        if (oModel && z2ui5.xxChangedPaths && z2ui5.xxChangedPaths.size > 0) {` && |\n| &&
-             `          const data = oModel.getData();` && |\n| &&
-             `          const xx = data && data.XX;` && |\n| &&
-             `          if (xx) {` && |\n| &&
-             `            z2ui5.oBody.XX = this._buildDeltaFromPaths(` && |\n| &&
-             `              z2ui5.xxChangedPaths,` && |\n| &&
-             `              xx,` && |\n| &&
-             `            );` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oBody.ID = z2ui5.oResponse && z2ui5.oResponse.ID;` && |\n| &&
-             `        // Object arguments are stringified for transport; the event name in` && |\n| &&
-             `        // args[0] is left as-is.` && |\n| &&
-             `        z2ui5.oBody.ARGUMENTS = args.map((item, i) => {` && |\n| &&
-             `          if (i > 0 && typeof item === "object") return JSON.stringify(item);` && |\n| &&
-             `          return item;` && |\n| &&
-             `        });` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oResponseOld = z2ui5.oResponse;` && |\n| &&
-             `        Server.Roundtrip();` && |\n| &&
-             `        runCallbacks(z2ui5.onAfterRoundtrip);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _pickModelForRoundtrip(args) {` && |\n| &&
-             `        // The 4th positional flag in args[0] forces use of the main view's` && |\n| &&
-             `        // model even when called from a popup/popover controller.` && |\n| &&
-             `        if (args[0][3] || z2ui5.oController === this) {` && |\n| &&
-             `          const sView =` && |\n| &&
-             `            z2ui5.oResponse && z2ui5.oResponse.PARAMS` && |\n| &&
-             `              ? z2ui5.oResponse.PARAMS.S_VIEW` && |\n| &&
-             `              : null;` && |\n| &&
-             `          if (sView && sView.SWITCH_DEFAULT_MODEL_PATH) {` && |\n| &&
-             `            return z2ui5.oView && z2ui5.oView.getModel("http");` && |\n| &&
-             `          }` && |\n| &&
-             `          return z2ui5.oView && z2ui5.oView.getModel();` && |\n| &&
-             `        }` && |\n| &&
-             `        if (z2ui5.oControllerPopup === this) {` && |\n| &&
-             `          return z2ui5.oViewPopup && z2ui5.oViewPopup.getModel();` && |\n| &&
-             `        }` && |\n| &&
-             `        if (z2ui5.oControllerPopover === this) {` && |\n| &&
-             `          return z2ui5.oViewPopover && z2ui5.oViewPopover.getModel();` && |\n| &&
-             `        }` && |\n| &&
-             `        if (z2ui5.oControllerNest === this) {` && |\n| &&
-             `          z2ui5.oBody.VIEWNAME = "NEST";` && |\n| &&
-             `          return z2ui5.oViewNest && z2ui5.oViewNest.getModel();` && |\n| &&
-             `        }` && |\n| &&
-             `        if (z2ui5.oControllerNest2 === this) {` && |\n| &&
-             `          z2ui5.oBody.VIEWNAME = "NEST2";` && |\n| &&
-             `          return z2ui5.oViewNest2 && z2ui5.oViewNest2.getModel();` && |\n| &&
-             `        }` && |\n| &&
-             `        return undefined;` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Re-bind a model to one of the views when the response signals an` && |\n| &&
-             `      // update is required for that particular slot.` && |\n| &&
-             `      updateModelIfRequired(paramKey, oView) {` && |\n| &&
-             `        const params = z2ui5.oResponse && z2ui5.oResponse.PARAMS;` && |\n| &&
-             `        const slot = params && params[paramKey];` && |\n| &&
-             `        if (!slot || !slot.CHECK_UPDATE_MODEL) return;` && |\n| &&
-             `` && |\n| &&
-             `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);` && |\n| &&
-             `        if (oView) oView.setModel(oModel);` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      async checkSDKcompatibility(err) {` && |\n| &&
-             `        let gav;` && |\n| &&
-             `        try {` && |\n| &&
-             `          const info = await VersionInfo.load();` && |\n| &&
-             `          gav = info.gav;` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError("checkSDKcompatibility: VersionInfo.load failed", e);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        if (!gav || !gav.includes("com.sap.ui5")) {` && |\n| &&
-             `          // openui5 doesn't ship some sap.com modules - tell the user which` && |\n| &&
-             `          // module is missing so they know to switch to SAPUI5.` && |\n| &&
-             `          const missingModule = err && err._modules;` && |\n| &&
-             `          MessageBox.error(` && |\n| &&
-             `            ``openui5 SDK is loaded, module: ${missingModule} is not available in openui5``,` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        MessageBox.error(err.toLocaleString());` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Display a toast or message box. Triggered for S_MSG_TOAST and` && |\n| &&
-             `      // S_MSG_BOX entries in the server response.` && |\n| &&
-             `      showMessage(msgType, params) {` && |\n| &&
-             `        if (!params) return;` && |\n| &&
-             `        const msg = params[msgType];` && |\n| &&
-             `        if (!msg || msg.TEXT === undefined) return;` && |\n| &&
-             `` && |\n| &&
-             `        if (msgType === "S_MSG_TOAST") {` && |\n| &&
-             `          MessageToast.show(msg.TEXT, {` && |\n| &&
-             `            duration: parseMs(msg.DURATION, 3000),` && |\n| &&
-             `            width: msg.WIDTH || "15em",` && |\n| &&
-             `            onClose: msg.ONCLOSE ? () => this.eB([msg.ONCLOSE]) : null,` && |\n| &&
-             `            autoClose: !!msg.AUTOCLOSE,` && |\n| &&
-             `            animationTimingFunction: msg.ANIMATIONTIMINGFUNCTION || "ease",` && |\n| &&
-             `            animationDuration: parseMs(msg.ANIMATIONDURATION, 1000),` && |\n| &&
-             `            closeonBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,` && |\n| &&
-             `          });` && |\n| &&
-             `          if (msg.CLASS) {` && |\n| &&
-             `            const toastEl = document.querySelector(".sapMMessageToast");` && |\n| &&
-             `            if (toastEl) {` && |\n| &&
-             `              const classes = msg.CLASS.trim().split(/\s+/).filter(Boolean);` && |\n| &&
-             `              toastEl.classList.add(...classes);` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        if (msgType === "S_MSG_BOX") {` && |\n| &&
-             `          const oParams = {` && |\n| &&
-             `            styleClass: msg.STYLECLASS || "",` && |\n| &&
-             `            title: msg.TITLE || "",` && |\n| &&
-             `            onClose: msg.ONCLOSE` && |\n| &&
-             `              ? (sAction) => this.eB([msg.ONCLOSE, sAction])` && |\n| &&
-             `              : null,` && |\n| &&
-             `            actions: msg.ACTIONS || "OK",` && |\n| &&
-             `            emphasizedAction: msg.EMPHASIZEDACTION || "OK",` && |\n| &&
-             `            initialFocus: msg.INITIALFOCUS || null,` && |\n| &&
-             `            textDirection: msg.TEXTDIRECTION || "Inherit",` && |\n| &&
-             `            details: msg.DETAILS ? sanitizeMessageDetails(msg.DETAILS) : "",` && |\n| &&
-             `            closeOnNavigation: !!msg.CLOSEONNAVIGATION,` && |\n| &&
-             `          };` && |\n| &&
-             `          if (msg.ICON && msg.ICON !== "NONE") oParams.icon = msg.ICON;` && |\n| &&
-             `          const showFn = MessageBox[msg.TYPE];` && |\n| &&
-             `          if (showFn) showFn(msg.TEXT, oParams);` && |\n| &&
-             `        }` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      // Replace the main app view with the XML coming from the backend.` && |\n| &&
-             `      async displayView(xml, viewModel) {` && |\n| &&
-             `        const oViewModel = this._trackChanges(new JSONModel(viewModel));` && |\n| &&
-             `` && |\n| &&
-             `        const sView =` && |\n| &&
-             `          z2ui5.oResponse && z2ui5.oResponse.PARAMS` && |\n| &&
-             `            ? z2ui5.oResponse.PARAMS.S_VIEW` && |\n| &&
-             `            : null;` && |\n| &&
-             `        const switchPath = sView && sView.SWITCH_DEFAULT_MODEL_PATH;` && |\n| &&
-             `` && |\n| &&
-             `        // When the app wants OData as the default model, build it here and` && |\n| &&
-             `        // keep the JSON model as the named "http" model.` && |\n| &&
-             `        let oModel;` && |\n| &&
-             `        if (switchPath) {` && |\n| &&
-             `          oModel = new ODataModel({` && |\n| &&
-             `            serviceUrl: switchPath,` && |\n| &&
-             `            annotationURI: sView.SWITCHDEFAULTMODELANNOURI || "",` && |\n| &&
-             `          });` && |\n| &&
-             `        } else {` && |\n| &&
-             `          oModel = oViewModel;` && |\n| &&
-             `        }` && |\n| &&
-             `        applyStoredSizeLimit("MAIN", oModel);` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oView = await XMLView.create({` && |\n| &&
-             `          definition: xml,` && |\n| &&
+             `` && |\n|  &&
+             `      _evUrlHelper(args) {` && |\n|  &&
+             `        const params = args[2];` && |\n|  &&
+             `        const actions = {` && |\n|  &&
+             `          REDIRECT: () => _URLHelper.redirect(params.URL, params.NEW_WINDOW),` && |\n|  &&
+             `          TRIGGER_EMAIL: () =>` && |\n|  &&
+             `            _URLHelper.triggerEmail(` && |\n|  &&
+             `              params.EMAIL,` && |\n|  &&
+             `              params.SUBJECT,` && |\n|  &&
+             `              params.BODY,` && |\n|  &&
+             `              params.CC,` && |\n|  &&
+             `              params.BCC,` && |\n|  &&
+             `              params.NEW_WINDOW,` && |\n|  &&
+             `            ),` && |\n|  &&
+             `          TRIGGER_SMS: () => _URLHelper.triggerSms(params),` && |\n|  &&
+             `          TRIGGER_TEL: () => _URLHelper.triggerTel(params),` && |\n|  &&
+             `        };` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const fn = actions[args[1]];` && |\n|  &&
+             `          if (fn) fn();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``URLHELPER: '${args[1]}' failed``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evImageEditorPopupClose() {` && |\n|  &&
+             `        let image;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const editor = Fragment.byId("popupId", "imageEditor");` && |\n|  &&
+             `          if (editor) image = editor.getImagePngDataURL();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `        this.PopupDestroy();` && |\n|  &&
+             `        this.eB(["SAVE"], image);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evStartTimer(args) {` && |\n|  &&
+             `        const timerKey = args[0];` && |\n|  &&
+             `        const callbackEvent = args[1];` && |\n|  &&
+             `        const delay = +args[2] || 0;` && |\n|  &&
+             `        if (!z2ui5.timers) z2ui5.timers = {};` && |\n|  &&
+             `        clearTimeout(z2ui5.timers[timerKey]);` && |\n|  &&
+             `        z2ui5.timers[timerKey] = setTimeout(() => {` && |\n|  &&
+             `          delete z2ui5.timers[timerKey];` && |\n|  &&
+             `          this.eB([callbackEvent]);` && |\n|  &&
+             `        }, delay);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSetInputMode(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n|  &&
+             `          if (!oElement) return;` && |\n|  &&
+             `          const dom = oElement.getDomRef();` && |\n|  &&
+             `          if (!dom) return;` && |\n|  &&
+             `          const input = dom.matches("input, textarea")` && |\n|  &&
+             `            ? dom` && |\n|  &&
+             `            : dom.querySelector("input, textarea");` && |\n|  &&
+             `          if (!input) return;` && |\n|  &&
+             `          input.setAttribute("inputmode", args[2] || "text");` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(` && |\n|  &&
+             `            ``KEYBOARD_SET_MODE: setAttribute failed for '${args[1]}'``,` && |\n|  &&
+             `            e,` && |\n|  &&
+             `          );` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSetFocus(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n|  &&
+             `          if (!oElement) return;` && |\n|  &&
+             `          const info = oElement.getFocusInfo();` && |\n|  &&
+             `          if (args[2] != null && args[2] !== "") info.selectionStart = +args[2];` && |\n|  &&
+             `          if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];` && |\n|  &&
+             `          oElement.applyFocusInfo(info);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``SET_FOCUS: failed for '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evScrollTo(args) {` && |\n|  &&
+             `        // args[1] = control id` && |\n|  &&
+             `        // args[2] = scrollTop  (Y, vertical, px)` && |\n|  &&
+             `        // args[3] = scrollLeft (X, horizontal, px) - optional, default 0` && |\n|  &&
+             `        // args[4] = behavior - "auto" (default) | "smooth" | "instant"` && |\n|  &&
+             `        // Strategy: prefer the control's scroll delegate (sap.m.Page,` && |\n|  &&
+             `        // ScrollContainer etc. expose ScrollEnablement). The delegate knows` && |\n|  &&
+             `        // the real scroll container, which often is NOT the control's root` && |\n|  &&
+             `        // DOM element - so native Element.scrollTo on getDomRef() silently` && |\n|  &&
+             `        // does nothing on a Page. ScrollEnablement.scrollTo(x, y, time)` && |\n|  &&
+             `        // animates when time > 0, so "smooth" maps to a 300ms animation.` && |\n|  &&
+             `        // Native Element.scrollTo is only used as a fallback for controls` && |\n|  &&
+             `        // without a delegate.` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n|  &&
+             `          if (!oElement) return;` && |\n|  &&
+             `          const y = +args[2] || 0;` && |\n|  &&
+             `          const x = +args[3] || 0;` && |\n|  &&
+             `          const behavior = args[4] || "auto";` && |\n|  &&
+             `          const smooth = behavior === "smooth";` && |\n|  &&
+             `` && |\n|  &&
+             `          let handled = false;` && |\n|  &&
+             `          try {` && |\n|  &&
+             `            const d =` && |\n|  &&
+             `              oElement.getScrollDelegate && oElement.getScrollDelegate();` && |\n|  &&
+             `            if (d && d.scrollTo) {` && |\n|  &&
+             `              // ScrollEnablement / iScroll delegate: scrollTo(x, y, time)` && |\n|  &&
+             `              d.scrollTo(x, y, smooth ? 300 : 0);` && |\n|  &&
+             `              handled = true;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          } catch (e) {` && |\n|  &&
+             `            // fall through` && |\n|  &&
+             `          }` && |\n|  &&
+             `` && |\n|  &&
+             `          if (!handled) {` && |\n|  &&
+             `            const dom = document.getElementById(``${oElement.getId()}-inner``)` && |\n|  &&
+             `              || oElement.getDomRef();` && |\n|  &&
+             `            if (dom && dom.scrollTo) {` && |\n|  &&
+             `              dom.scrollTo({ top: y, left: x, behavior });` && |\n|  &&
+             `              handled = true;` && |\n|  &&
+             `            } else if (dom) {` && |\n|  &&
+             `              dom.scrollTop = y;` && |\n|  &&
+             `              dom.scrollLeft = x;` && |\n|  &&
+             `              handled = true;` && |\n|  &&
+             `            } else if (oElement.scrollTo) {` && |\n|  &&
+             `              // sap.m.Page.scrollTo(y, time) - vertical only` && |\n|  &&
+             `              oElement.scrollTo(y, smooth ? 300 : 0);` && |\n|  &&
+             `              handled = true;` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``SCROLL_TO: failed for '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evScrollIntoView(args) {` && |\n|  &&
+             `        // args[1] = control id` && |\n|  &&
+             `        // args[2] = behavior - "smooth" (default) | "auto" | "instant"` && |\n|  &&
+             `        // args[3] = block    - "start"  (default) | "center" | "end" | "nearest"` && |\n|  &&
+             `        // args[4] = inline   - "nearest" (default)| "start"  | "center" | "end"` && |\n|  &&
+             `        // Modern declarative scroll: bring a control into the viewport,` && |\n|  &&
+             `        // regardless of where the surrounding scroll container currently is.` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n|  &&
+             `          if (!oElement) return;` && |\n|  &&
+             `          const dom = oElement.getDomRef();` && |\n|  &&
+             `          if (!dom || !dom.scrollIntoView) return;` && |\n|  &&
+             `          dom.scrollIntoView({` && |\n|  &&
+             `            behavior: args[2] || "smooth",` && |\n|  &&
+             `            block: args[3] || "start",` && |\n|  &&
+             `            inline: args[4] || "nearest",` && |\n|  &&
+             `          });` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``SCROLL_INTO_VIEW: failed for '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evSetTitle(args) {` && |\n|  &&
+             `        const title = args[1] == null ? "" : String(args[1]);` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;` && |\n|  &&
+             `          if (shell && shell.setTitle) {` && |\n|  &&
+             `            const result = shell.setTitle(title);` && |\n|  &&
+             `            if (result && result.catch) {` && |\n|  &&
+             `              result.catch((e) =>` && |\n|  &&
+             `                logError("SET_TITLE: ShellUIService.setTitle failed", e),` && |\n|  &&
+             `              );` && |\n|  &&
+             `            }` && |\n|  &&
+             `          } else {` && |\n|  &&
+             `            document.title = title;` && |\n|  &&
+             `          }` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("SET_TITLE: ShellUIService.setTitle failed", e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evZ2ui5Custom(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const fn = z2ui5[args[1]];` && |\n|  &&
+             `          if (fn) fn(args.slice(2));` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``Z2UI5: '${args[1]}' failed``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evWizardSetNextStep(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const wiz = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n|  &&
+             `          const step = z2ui5.oView && z2ui5.oView.byId(args[2]);` && |\n|  &&
+             `          const nextStep = z2ui5.oView && z2ui5.oView.byId(args[3]);` && |\n|  &&
+             `          if (wiz && step) wiz.discardProgress(step);` && |\n|  &&
+             `          if (step && nextStep) step.setNextStep(nextStep);` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``WIZARD_SET_NEXT_STEP: failed for wizard '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _evPlayAudio(args) {` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          new Audio(args[1]).play();` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError(``PLAY_AUDIO: failed for '${args[1]}'``, e);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      // eB: trigger a backend roundtrip with arguments.` && |\n|  &&
+             `      // ------------------------------------------------------------------` && |\n|  &&
+             `      eB(...args) {` && |\n|  &&
+             `        if (!navigator.onLine) {` && |\n|  &&
+             `          MessageBox.alert(` && |\n|  &&
+             `            "No internet connection! Please reconnect to the server and try again.",` && |\n|  &&
+             `          );` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        // If a roundtrip is already in flight, briefly show a BusyDialog so` && |\n|  &&
+             `        // the user gets visual feedback instead of a silent click. args[0][2]` && |\n|  &&
+             `        // is the "ignore busy" flag set by certain background events.` && |\n|  &&
+             `        if (z2ui5.isBusy && !args[0][2]) {` && |\n|  &&
+             `          const oBusyDialog = new mBusyDialog();` && |\n|  &&
+             `          oBusyDialog.attachEventOnce("afterClose", () =>` && |\n|  &&
+             `            oBusyDialog.destroy(),` && |\n|  &&
+             `          );` && |\n|  &&
+             `          oBusyDialog.open();` && |\n|  &&
+             `          queueMicrotask(() => oBusyDialog.close());` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        // A new roundtrip overrides any pending timer - timers that fired` && |\n|  &&
+             `        // already removed themselves before calling eB, so this only cancels` && |\n|  &&
+             `        // timers that are still waiting.` && |\n|  &&
+             `        if (z2ui5.timers) {` && |\n|  &&
+             `          for (const key in z2ui5.timers) {` && |\n|  &&
+             `            clearTimeout(z2ui5.timers[key]);` && |\n|  &&
+             `            delete z2ui5.timers[key];` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.isBusy = true;` && |\n|  &&
+             `        BusyIndicator.show();` && |\n|  &&
+             `        z2ui5.oBody = { VIEWNAME: "MAIN" };` && |\n|  &&
+             `` && |\n|  &&
+             `        // Decide which view's model holds the data we need to send back. The` && |\n|  &&
+             `        // mapping is: main app controller -> main view, popup controller ->` && |\n|  &&
+             `        // popup view, etc.` && |\n|  &&
+             `        const oModel = this._pickModelForRoundtrip(args);` && |\n|  &&
+             `` && |\n|  &&
+             `        runCallbacks(z2ui5.onBeforeRoundtrip);` && |\n|  &&
+             `` && |\n|  &&
+             `        // If the user edited /XX/ paths, send only the delta to keep the` && |\n|  &&
+             `        // payload small.` && |\n|  &&
+             `        if (oModel && z2ui5.xxChangedPaths && z2ui5.xxChangedPaths.size > 0) {` && |\n|  &&
+             `          const data = oModel.getData();` && |\n|  &&
+             `          const xx = data && data.XX;` && |\n|  &&
+             `          if (xx) {` && |\n|  &&
+             `            z2ui5.oBody.XX = this._buildDeltaFromPaths(` && |\n|  &&
+             `              z2ui5.xxChangedPaths,` && |\n|  &&
+             `              xx,` && |\n|  &&
+             `            );` && |\n|  &&
+             `          }` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oBody.ID = z2ui5.oResponse && z2ui5.oResponse.ID;` && |\n|  &&
+             `        // Object arguments are stringified for transport; the event name in` && |\n|  &&
+             `        // args[0] is left as-is.` && |\n|  &&
+             `        z2ui5.oBody.ARGUMENTS = args.map((item, i) => {` && |\n|  &&
+             `          if (i > 0 && typeof item === "object") return JSON.stringify(item);` && |\n|  &&
+             `          return item;` && |\n|  &&
+             `        });` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oResponseOld = z2ui5.oResponse;` && |\n|  &&
+             `        Server.Roundtrip();` && |\n|  &&
+             `        runCallbacks(z2ui5.onAfterRoundtrip);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      _pickModelForRoundtrip(args) {` && |\n|  &&
+             `        // The 4th positional flag in args[0] forces use of the main view's` && |\n|  &&
+             `        // model even when called from a popup/popover controller.` && |\n|  &&
+             `        if (args[0][3] || z2ui5.oController === this) {` && |\n|  &&
+             `          const sView =` && |\n|  &&
+             `            z2ui5.oResponse && z2ui5.oResponse.PARAMS` && |\n|  &&
+             `              ? z2ui5.oResponse.PARAMS.S_VIEW` && |\n|  &&
+             `              : null;` && |\n|  &&
+             `          if (sView && sView.SWITCH_DEFAULT_MODEL_PATH) {` && |\n|  &&
+             `            return z2ui5.oView && z2ui5.oView.getModel("http");` && |\n|  &&
+             `          }` && |\n|  &&
+             `          return z2ui5.oView && z2ui5.oView.getModel();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (z2ui5.oControllerPopup === this) {` && |\n|  &&
+             `          return z2ui5.oViewPopup && z2ui5.oViewPopup.getModel();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (z2ui5.oControllerPopover === this) {` && |\n|  &&
+             `          return z2ui5.oViewPopover && z2ui5.oViewPopover.getModel();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (z2ui5.oControllerNest === this) {` && |\n|  &&
+             `          z2ui5.oBody.VIEWNAME = "NEST";` && |\n|  &&
+             `          return z2ui5.oViewNest && z2ui5.oViewNest.getModel();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (z2ui5.oControllerNest2 === this) {` && |\n|  &&
+             `          z2ui5.oBody.VIEWNAME = "NEST2";` && |\n|  &&
+             `          return z2ui5.oViewNest2 && z2ui5.oViewNest2.getModel();` && |\n|  &&
+             `        }` && |\n|  &&
+             `        return undefined;` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Re-bind a model to one of the views when the response signals an` && |\n|  &&
+             `      // update is required for that particular slot.` && |\n|  &&
+             `      updateModelIfRequired(paramKey, oView) {` && |\n|  &&
+             `        const params = z2ui5.oResponse && z2ui5.oResponse.PARAMS;` && |\n|  &&
+             `        const slot = params && params[paramKey];` && |\n|  &&
+             `        if (!slot || !slot.CHECK_UPDATE_MODEL) return;` && |\n|  &&
+             `` && |\n|  &&
+             `        const oModel = this._createViewModel();` && |\n|  &&
+             `        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);` && |\n|  &&
+             `        if (oView) oView.setModel(oModel);` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      async checkSDKcompatibility(err) {` && |\n|  &&
+             `        let gav;` && |\n|  &&
+             `        try {` && |\n|  &&
+             `          const info = await VersionInfo.load();` && |\n|  &&
+             `          gav = info.gav;` && |\n|  &&
+             `        } catch (e) {` && |\n|  &&
+             `          logError("checkSDKcompatibility: VersionInfo.load failed", e);` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        if (!gav || !gav.includes("com.sap.ui5")) {` && |\n|  &&
+             `          // openui5 doesn't ship some sap.com modules - tell the user which` && |\n|  &&
+             `          // module is missing so they know to switch to SAPUI5.` && |\n|  &&
+             `          const missingModule = err && err._modules;` && |\n|  &&
+             `          MessageBox.error(` && |\n|  &&
+             `            ``openui5 SDK is loaded, module: ${missingModule} is not available in openui5``,` && |\n|  &&
+             `          );` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        MessageBox.error(err.toLocaleString());` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Display a toast or message box. Triggered for S_MSG_TOAST and` && |\n|  &&
+             `      // S_MSG_BOX entries in the server response.` && |\n|  &&
+             `      showMessage(msgType, params) {` && |\n|  &&
+             `        if (!params) return;` && |\n|  &&
+             `        const msg = params[msgType];` && |\n|  &&
+             `        if (!msg || msg.TEXT === undefined) return;` && |\n|  &&
+             `` && |\n|  &&
+             `        if (msgType === "S_MSG_TOAST") {` && |\n|  &&
+             `          MessageToast.show(msg.TEXT, {` && |\n|  &&
+             `            duration: parseMs(msg.DURATION, 3000),` && |\n|  &&
+             `            width: msg.WIDTH || "15em",` && |\n|  &&
+             `            onClose: msg.ONCLOSE ? () => this.eB([msg.ONCLOSE]) : null,` && |\n|  &&
+             `            autoClose: !!msg.AUTOCLOSE,` && |\n|  &&
+             `            animationTimingFunction: msg.ANIMATIONTIMINGFUNCTION || "ease",` && |\n|  &&
+             `            animationDuration: parseMs(msg.ANIMATIONDURATION, 1000),` && |\n|  &&
+             `            closeonBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,` && |\n|  &&
+             `          });` && |\n|  &&
+             `          if (msg.CLASS) {` && |\n|  &&
+             `            const toastEl = document.querySelector(".sapMMessageToast");` && |\n|  &&
+             `            if (toastEl) {` && |\n|  &&
+             `              const classes = msg.CLASS.trim().split(/\s+/).filter(Boolean);` && |\n|  &&
+             `              toastEl.classList.add(...classes);` && |\n|  &&
+             `            }` && |\n|  &&
+             `          }` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        if (msgType === "S_MSG_BOX") {` && |\n|  &&
+             `          const oParams = {` && |\n|  &&
+             `            styleClass: msg.STYLECLASS || "",` && |\n|  &&
+             `            title: msg.TITLE || "",` && |\n|  &&
+             `            onClose: msg.ONCLOSE` && |\n|  &&
+             `              ? (sAction) => this.eB([msg.ONCLOSE, sAction])` && |\n|  &&
+             `              : null,` && |\n|  &&
+             `            actions: msg.ACTIONS || "OK",` && |\n|  &&
+             `            emphasizedAction: msg.EMPHASIZEDACTION || "OK",` && |\n|  &&
+             `            initialFocus: msg.INITIALFOCUS || null,` && |\n|  &&
+             `            textDirection: msg.TEXTDIRECTION || "Inherit",` && |\n|  &&
+             `            details: msg.DETAILS ? sanitizeMessageDetails(msg.DETAILS) : "",` && |\n|  &&
+             `            closeOnNavigation: !!msg.CLOSEONNAVIGATION,` && |\n|  &&
+             `          };` && |\n|  &&
+             `          if (msg.ICON && msg.ICON !== "NONE") oParams.icon = msg.ICON;` && |\n|  &&
+             `          const showFn = MessageBox[msg.TYPE];` && |\n|  &&
+             `          if (showFn) showFn(msg.TEXT, oParams);` && |\n|  &&
+             `        }` && |\n|  &&
+             `      },` && |\n|  &&
+             `` && |\n|  &&
+             `      // Replace the main app view with the XML coming from the backend.` && |\n|  &&
+             `      async displayView(xml, viewModel) {` && |\n|  &&
+             `        const oViewModel = this._trackChanges(new JSONModel(viewModel));` && |\n|  &&
+             `` && |\n|  &&
+             `        const sView =` && |\n|  &&
+             `          z2ui5.oResponse && z2ui5.oResponse.PARAMS` && |\n|  &&
+             `            ? z2ui5.oResponse.PARAMS.S_VIEW` && |\n|  &&
+             `            : null;` && |\n|  &&
+             `        const switchPath = sView && sView.SWITCH_DEFAULT_MODEL_PATH;` && |\n|  &&
+             `` && |\n|  &&
+             `        // When the app wants OData as the default model, build it here and` && |\n|  &&
+             `        // keep the JSON model as the named "http" model.` && |\n|  &&
+             `        let oModel;` && |\n|  &&
              |\n|.
     result = result &&
-             `          models: oModel,` && |\n| &&
-             `          controller: z2ui5.oController,` && |\n| &&
-             `          id: "mainView",` && |\n| &&
-             `          preprocessors: { xml: { models: { template: oViewModel } } },` && |\n| &&
-             `        });` && |\n| &&
-             `` && |\n| &&
-             `        // Guard against the app being destroyed during the await above.` && |\n| &&
-             `        const appAlive =` && |\n| &&
-             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n| &&
-             `        if (!appAlive) {` && |\n| &&
-             `          z2ui5.oView.destroy();` && |\n| &&
-             `          if (switchPath) oModel.destroy();` && |\n| &&
-             `          z2ui5.oView = null;` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
-             `        z2ui5.oView.setModel(z2ui5.oDeviceModel, "device");` && |\n| &&
-             `        if (switchPath) z2ui5.oView.setModel(oViewModel, "http");` && |\n| &&
-             `        z2ui5.oApp.removeAllPages();` && |\n| &&
-             `        z2ui5.oApp.insertPage(z2ui5.oView);` && |\n| &&
-             `      },` && |\n| &&
-             `    });` && |\n| &&
-             `  },` && |\n| &&
-             `);` && |\n| &&
-             `` && |\n| &&
+             `        if (switchPath) {` && |\n|  &&
+             `          oModel = new ODataModel({` && |\n|  &&
+             `            serviceUrl: switchPath,` && |\n|  &&
+             `            annotationURI: sView.SWITCHDEFAULTMODELANNOURI || "",` && |\n|  &&
+             `          });` && |\n|  &&
+             `        } else {` && |\n|  &&
+             `          oModel = oViewModel;` && |\n|  &&
+             `        }` && |\n|  &&
+             `        applyStoredSizeLimit("MAIN", oModel);` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oView = await XMLView.create({` && |\n|  &&
+             `          definition: xml,` && |\n|  &&
+             `          models: oModel,` && |\n|  &&
+             `          controller: z2ui5.oController,` && |\n|  &&
+             `          id: "mainView",` && |\n|  &&
+             `          preprocessors: { xml: { models: { template: oViewModel } } },` && |\n|  &&
+             `        });` && |\n|  &&
+             `` && |\n|  &&
+             `        // Guard against the app being destroyed during the await above.` && |\n|  &&
+             `        const appAlive =` && |\n|  &&
+             `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n|  &&
+             `        if (!appAlive) {` && |\n|  &&
+             `          z2ui5.oView.destroy();` && |\n|  &&
+             `          if (switchPath) oModel.destroy();` && |\n|  &&
+             `          z2ui5.oView = null;` && |\n|  &&
+             `          return;` && |\n|  &&
+             `        }` && |\n|  &&
+             `` && |\n|  &&
+             `        z2ui5.oView.setModel(z2ui5.oDeviceModel, "device");` && |\n|  &&
+             `        if (switchPath) z2ui5.oView.setModel(oViewModel, "http");` && |\n|  &&
+             `        z2ui5.oApp.removeAllPages();` && |\n|  &&
+             `        z2ui5.oApp.insertPage(z2ui5.oView);` && |\n|  &&
+             `      },` && |\n|  &&
+             `    });` && |\n|  &&
+             `  },` && |\n|  &&
+             `);` && |\n|  &&
+             `` && |\n|  &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_view1_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_xml.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_app_view1_xml IMPLEMENTATION.
 
   METHOD get.
 
-    result = `<mvc:View controllerName="z2ui5.controller.View1"` &&
+    result =              `<mvc:View controllerName="z2ui5.controller.View1"` &&
              `    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"` &&
              `    xmlns="sap.m">` &&
              `</mvc:View>` &&


### PR DESCRIPTION
## Summary

This PR improves the frontend scroll tracking logic and enhances timer management during roundtrips to prevent race conditions and stale callbacks.

## Key Changes

- **Enhanced `_getScrollInfo()` in Server.js**: Refactored scroll offset detection to more reliably find scrollable descendants across all view types (main view, nested views, popups, popovers). The method now properly handles cases where views exist but lack scrollable targets, keeping the request payload minimal.

- **Timer cleanup in View1.controller.js**: Added logic to cancel any pending timer when a new roundtrip is initiated. This prevents stale timer callbacks from firing after the app state has moved forward, which could cause race conditions or apply outdated model changes.

- **Code formatting alignment**: Standardized indentation in ABAP string constant declarations across multiple generated frontend resource classes (`z2ui5_cl_app_*_js.clas.abap`, `z2ui5_cl_app_*_xml.clas.abap`, etc.) for consistency.

## Implementation Details

The scroll info retrieval now iterates through all active views (main, nest, nest2, popup, popover) and extracts scroll positions only from views that have scrollable descendants. This reduces unnecessary data in the request while ensuring scroll state is properly captured for restoration.

The timer cancellation ensures that when a new event triggers a roundtrip, any previously scheduled timer is cleared before the request is sent. Timers that have already fired remove themselves before calling the event handler, so this only affects pending timers—maintaining the intended async behavior while preventing stale callbacks.

https://claude.ai/code/session_01219mWjRh7Dgh4GmfY65mwz