### PR TITLE
docs: clarify strict rules for auto-generated src/01/03/ files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,11 @@ test: add unit tests for utility class
 ## Important Rules for AI Assistants
 
 1. **Do not modify `src/00/`** — mirrored from external projects, synced by automated workflows.
-2. **Never manually edit `src/01/03/`** — auto-generated from `app/webapp/` via `auto_app2abap`.
+2. **NEVER manually edit any ABAP file under `src/01/03/`.** These files are the embedded frontend (auto-generated from `app/webapp/` via the `app2abap` job — see `.github/app2abap/trans2abap.js` and the `create_app2abap.yaml` workflow). The **only** allowed way to update them is:
+   - Change the source under `app/webapp/`
+   - Run the `app2abap` job (`npm run auto_app2abap` locally, or trigger the `create_app2abap.yaml` workflow)
+   - Commit the regenerated `src/01/03/` files as the job produced them
+   Direct edits to `src/01/03/*.abap` are forbidden — no manual tweaks, no "small fixes", no formatting changes, nothing. The job may be invoked, but the files must never be touched by hand or by any other means.
 3. **Always run `npx abaplint`** before considering changes complete.
 4. **Multi-environment compatibility** — code must work on NW 7.02, standard ABAP, and ABAP Cloud.
 5. **The public API (`src/02/`) is a stable contract — never change or remove existing public attributes, methods, or constants.** This folder is consumed directly by thousands of downstream apps. Specifically:


### PR DESCRIPTION
## Summary

Updated `CLAUDE.md` to provide clearer, more explicit guidance on the prohibition against manually editing auto-generated ABAP files in `src/01/03/`. The embedded frontend resources in this directory are generated from `app/webapp/` via the `app2abap` job and must never be modified by hand.

## Changes

- **Expanded rule #2** with detailed explanation of why `src/01/03/` files are off-limits
- **Added explicit workflow** for the only permitted way to update these files:
  - Modify source under `app/webapp/`
  - Run the `app2abap` job locally (`npm run auto_app2abap`) or trigger the `create_app2abap.yaml` workflow
  - Commit the regenerated files as produced by the job
- **Emphasized the absolute prohibition** against direct edits, manual tweaks, formatting changes, or any other hand modifications
- **Referenced implementation details** (`.github/app2abap/trans2abap.js` and the `create_app2abap.yaml` workflow) to help developers understand the automation

## Rationale

This clarification prevents accidental corruption of auto-generated code and ensures the single source of truth remains in `app/webapp/`. The stricter language and explicit workflow guidance should reduce confusion and support for contributors unfamiliar with the project structure.

https://claude.ai/code/session_01UFoJcMkWomtCC72pHR4ivd