### PR TITLE
Add URL protocol validation and event-driven app navigation

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -100,6 +100,27 @@ sap.ui.define(
       }
     }
 
+    // Returns true if the URL uses a safe (http/https) protocol. Unlike
+    // isValidRedirectURL this allows cross-origin targets, so it fits
+    // outbound redirects to external sites while still blocking dangerous
+    // schemes such as javascript:, data: or vbscript:.
+    function isSafeRedirectProtocol(url) {
+      if (!url) return false;
+      try {
+        const parsed = new URL(url, window.location.origin);
+        if (!_SAFE_PROTOCOLS.has(parsed.protocol)) {
+          logError(
+            `Security: Blocked redirect with invalid protocol: ${parsed.protocol}`,
+          );
+          return false;
+        }
+        return true;
+      } catch (e) {
+        logError(`Security: Invalid URL format: ${url}`, e);
+        return false;
+      }
+    }
+
     function copyToClipboard(textToCopy) {
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(textToCopy).catch((err) => {
@@ -802,7 +823,15 @@ sap.ui.define(
       _evUrlHelper(args) {
         const params = args[2];
         const actions = {
-          REDIRECT: () => _URLHelper.redirect(params.URL, params.NEW_WINDOW),
+          REDIRECT: () => {
+            if (!isSafeRedirectProtocol(params.URL)) {
+              MessageBox.error(
+                "Invalid redirect URL. Only http/https protocols are allowed.",
+              );
+              return;
+            }
+            _URLHelper.redirect(params.URL, params.NEW_WINDOW);
+          },
           TRIGGER_EMAIL: () =>
             _URLHelper.triggerEmail(
               params.EMAIL,

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -192,8 +192,12 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
 
     result->reset_view_update_flags( ).
 
-    IF ms_next-s_set-s_follow_up_action IS NOT INITIAL AND
+    IF ms_next-next_event IS NOT INITIAL.
+      result->ms_actual-event = ms_next-next_event.
+    ELSEIF ms_next-s_set-s_follow_up_action IS NOT INITIAL AND
         lines( ms_next-s_set-s_follow_up_action-custom_js ) > 0.
+      " backward compatibility: derive the next event from a legacy
+      " follow_up_action( _event( ) ) snippet ( deprecated mechanism )
       DATA(lv_action) = ms_next-s_set-s_follow_up_action-custom_js[ 1 ].
       SPLIT lv_action AT `.eB(['` INTO DATA(lv_dummy)
             result->ms_actual-event.

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -226,6 +226,13 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
     ENDIF.
 
     mo_action->ms_next-o_app_leave = app.
+    mo_action->ms_next-next_event  = event.
+
+    IF r_data IS NOT INITIAL.
+      CREATE DATA mo_action->ms_next-r_data LIKE r_data.
+      mo_action->ms_next-r_data = z2ui5_cl_util=>conv_copy_ref_data( r_data ).
+    ENDIF.
+
     result = nav_app_set_id( app ).
 
   ENDMETHOD.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -46,6 +46,8 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_check_on_event_empty FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_navigated   FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_call         FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_app_leave_event  FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_app_leave_r_data FOR TESTING RAISING cx_static_check.
     METHODS test_check_app_prev_stack FOR TESTING RAISING cx_static_check.
     METHODS test_set_push_state       FOR TESTING RAISING cx_static_check.
     METHODS test_set_nav_back         FOR TESTING RAISING cx_static_check.
@@ -481,6 +483,41 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_not_initial( lv_id ).
     cl_abap_unit_assert=>assert_bound( mo_action->ms_next-o_app_call ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_app_leave_event.
+
+    DATA lo_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    lo_app = NEW #( ).
+    li_client ?= mo_client.
+
+    li_client->nav_app_leave( app   = lo_app
+                              event = `MY_EVENT` ).
+
+    cl_abap_unit_assert=>assert_bound( mo_action->ms_next-o_app_leave ).
+    cl_abap_unit_assert=>assert_equals( exp = `MY_EVENT`
+                                        act = mo_action->ms_next-next_event ).
+    " the dedicated backend event must not emit any client side JS snippet
+    cl_abap_unit_assert=>assert_equals( exp = 0
+                                        act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_app_leave_r_data.
+
+    DATA lo_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lv_data TYPE string VALUE `payload`.
+    lo_app = NEW #( ).
+    li_client ?= mo_client.
+
+    li_client->nav_app_leave( app    = lo_app
+                              event  = `MY_EVENT`
+                              r_data = lv_data ).
+
+    cl_abap_unit_assert=>assert_bound( mo_action->ms_next-r_data ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -142,6 +142,7 @@ INTERFACE z2ui5_if_core_types
     BEGIN OF ty_s_next,
       o_app_call  TYPE REF TO z2ui5_if_app,
       o_app_leave TYPE REF TO z2ui5_if_app,
+      next_event  TYPE string,
       s_set       TYPE ty_s_next_frontend,
       r_data      TYPE REF TO data,
     END OF ty_s_next.

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -120,6 +120,27 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // Returns true if the URL uses a safe (http/https) protocol. Unlike` && |\n| &&
+             `    // isValidRedirectURL this allows cross-origin targets, so it fits` && |\n| &&
+             `    // outbound redirects to external sites while still blocking dangerous` && |\n| &&
+             `    // schemes such as javascript:, data: or vbscript:.` && |\n| &&
+             `    function isSafeRedirectProtocol(url) {` && |\n| &&
+             `      if (!url) return false;` && |\n| &&
+             `      try {` && |\n| &&
+             `        const parsed = new URL(url, window.location.origin);` && |\n| &&
+             `        if (!_SAFE_PROTOCOLS.has(parsed.protocol)) {` && |\n| &&
+             `          logError(` && |\n| &&
+             `            ``Security: Blocked redirect with invalid protocol: ${parsed.protocol}``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return false;` && |\n| &&
+             `        }` && |\n| &&
+             `        return true;` && |\n| &&
+             `      } catch (e) {` && |\n| &&
+             `        logError(``Security: Invalid URL format: ${url}``, e);` && |\n| &&
+             `        return false;` && |\n| &&
+             `      }` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function copyToClipboard(textToCopy) {` && |\n| &&
              `      if (navigator.clipboard && navigator.clipboard.writeText) {` && |\n| &&
              `        navigator.clipboard.writeText(textToCopy).catch((err) => {` && |\n| &&
@@ -397,6 +418,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `` && |\n| &&
              `      _createViewModel() {` && |\n| &&
+             |\n|.
+    result = result &&
              `        const data = z2ui5.oResponse && z2ui5.oResponse.OVIEWMODEL;` && |\n| &&
              `        return this._trackChanges(new JSONModel(data));` && |\n| &&
              `      },` && |\n| &&
@@ -418,8 +441,6 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          z2ui5.oApp && (!z2ui5.oApp.isDestroyed || !z2ui5.oApp.isDestroyed());` && |\n| &&
              `        if (!appAlive) {` && |\n| &&
              `          oFragment.destroy();` && |\n| &&
-             |\n|.
-    result = result &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        oFragment.setModel(oModel);` && |\n| &&
@@ -799,6 +820,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            z2ui5.oLaunchpad.Container &&` && |\n| &&
              `            z2ui5.oLaunchpad.Container.logout;` && |\n| &&
              `          if (launchpadLogout) {` && |\n| &&
+             |\n|.
+    result = result &&
              `            z2ui5.oLaunchpad.Container.logout();` && |\n| &&
              `          } else {` && |\n| &&
              `            redirectToLogoff();` && |\n| &&
@@ -820,13 +843,19 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        // Clear opener to prevent the new tab from accessing window.opener.` && |\n| &&
              `        if (newWindow) newWindow.opener = null;` && |\n| &&
              `      },` && |\n| &&
-             |\n|.
-    result = result &&
              `` && |\n| &&
              `      _evUrlHelper(args) {` && |\n| &&
              `        const params = args[2];` && |\n| &&
              `        const actions = {` && |\n| &&
-             `          REDIRECT: () => _URLHelper.redirect(params.URL, params.NEW_WINDOW),` && |\n| &&
+             `          REDIRECT: () => {` && |\n| &&
+             `            if (!isSafeRedirectProtocol(params.URL)) {` && |\n| &&
+             `              MessageBox.error(` && |\n| &&
+             `                "Invalid redirect URL. Only http/https protocols are allowed.",` && |\n| &&
+             `              );` && |\n| &&
+             `              return;` && |\n| &&
+             `            }` && |\n| &&
+             `            _URLHelper.redirect(params.URL, params.NEW_WINDOW);` && |\n| &&
+             `          },` && |\n| &&
              `          TRIGGER_EMAIL: () =>` && |\n| &&
              `            _URLHelper.triggerEmail(` && |\n| &&
              `              params.EMAIL,` && |\n| &&
@@ -1193,6 +1222,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        if (msgType === "S_MSG_BOX") {` && |\n| &&
              `          const oParams = {` && |\n| &&
              `            styleClass: msg.STYLECLASS || "",` && |\n| &&
+             |\n|.
+    result = result &&
              `            title: msg.TITLE || "",` && |\n| &&
              `            onClose: msg.ONCLOSE` && |\n| &&
              `              ? (sAction) => this.eB([msg.ONCLOSE, sAction])` && |\n| &&
@@ -1222,8 +1253,6 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `        // When the app wants OData as the default model, build it here and` && |\n| &&
              `        // keep the JSON model as the named "http" model.` && |\n| &&
-             |\n|.
-    result = result &&
              `        let oModel;` && |\n| &&
              `        if (switchPath) {` && |\n| &&
              `          oModel = new ODataModel({` && |\n| &&

--- a/src/02/01/z2ui5_cl_pop_to_confirm.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_confirm.clas.abap
@@ -98,14 +98,14 @@ CLASS z2ui5_cl_pop_to_confirm IMPLEMENTATION.
       WHEN `BUTTON_CONFIRM`.
         check_result_confirmed = abap_true.
         client->popup_destroy( ).
-        client->nav_app_leave( client->get_app_prev( ) ).
-        client->follow_up_action( client->_event( event_confirm ) ).
+        client->nav_app_leave( app   = client->get_app_prev( )
+                               event = event_confirm ).
 
       WHEN `BUTTON_CANCEL`.
         check_result_confirmed = abap_false.
         client->popup_destroy( ).
-        client->nav_app_leave( client->get_app_prev( ) ).
-        client->follow_up_action( client->_event( event_canceled ) ).
+        client->nav_app_leave( app   = client->get_app_prev( )
+                               event = event_canceled ).
     ENDCASE.
 
   ENDMETHOD.

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -161,8 +161,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
       WHEN `CANCEL`.
         client->popup_destroy( ).
-        client->nav_app_leave( ).
-        client->follow_up_action( client->_event( event_canceled ) ).
+        client->nav_app_leave( event = event_canceled ).
 
       WHEN `SEARCH`.
         on_event_search( ).
@@ -276,9 +275,8 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
     ENDLOOP.
 
     client->popup_destroy( ).
-    client->nav_app_leave( ).
-    client->follow_up_action( client->_event( val    = event_confirmed
-                                              r_data = <table_result> ) ).
+    client->nav_app_leave( event  = event_confirmed
+                           r_data = <table_result> ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -130,6 +130,9 @@ INTERFACE z2ui5_if_client
   METHODS nav_app_leave
     IMPORTING
       VALUE(app)    TYPE REF TO z2ui5_if_app OPTIONAL
+      event         TYPE clike                OPTIONAL
+      r_data        TYPE data                 OPTIONAL
+        PREFERRED PARAMETER app
     RETURNING
       VALUE(result) TYPE string.
 


### PR DESCRIPTION
## Summary

This PR enhances security and improves the app navigation API by introducing URL protocol validation for redirects and adding event-driven parameters to the `nav_app_leave()` method.

## Key Changes

### Security: URL Protocol Validation
- Added `isSafeRedirectProtocol()` function to validate redirect URLs against a whitelist of safe protocols (http/https)
- Blocks dangerous schemes like `javascript:`, `data:`, and `vbscript:` before executing redirects
- Integrated validation into the `_evUrlHelper()` REDIRECT action with user-facing error messaging
- Applied to both the generated ABAP view controller and the standalone JavaScript controller

### API Enhancement: Event-Driven Navigation
- Extended `nav_app_leave()` signature to accept optional `event` and `r_data` parameters
- `event`: Specifies the next event to trigger when leaving the app (replaces the deprecated `follow_up_action(_event())` pattern)
- `r_data`: Allows passing return data back to the calling app
- Updated core action processing to prioritize `next_event` over legacy follow-up action snippets for backward compatibility
- Refactored built-in popup apps (`z2ui5_cl_pop_to_confirm`, `z2ui5_cl_pop_to_select`) to use the new event-driven API

### Testing
- Added two new unit tests for `nav_app_leave()`:
  - `test_nav_app_leave_event`: Validates event parameter binding
  - `test_nav_app_leave_r_data`: Validates return data handling

## Implementation Details

- The `isSafeRedirectProtocol()` function uses the URL constructor with a fallback origin to safely parse URLs and extract the protocol
- Protocol validation is case-insensitive via the `_SAFE_PROTOCOLS` Set
- The action layer now checks `next_event` first before falling back to legacy follow-up action parsing, ensuring smooth migration
- All changes maintain backward compatibility with existing code using the deprecated `follow_up_action()` pattern

https://claude.ai/code/session_018iCbq2yfGjTkPEgw57bRr8