### PR TITLE
Fix delta encoding for deeply nested table paths (tree tables)

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -377,9 +377,14 @@ sap.ui.define(
         const delta = {};
         for (const path of paths) {
           // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>"
-          const [attr, rowIdx, field] = path.slice(4).split("/");
+          const parts = path.slice(4).split("/");
+          const [attr, rowIdx, field] = parts;
+          // Only a flat table cell (exactly attr/row/field) qualifies for a
+          // delta. Deeper paths (e.g. tree tables: attr/row/<subtable>/<row>/<field>)
+          // fall back to shipping the whole attribute, which the backend applies
+          // via corresponding-based deserialization.
           const isRowField =
-            field !== undefined && rowIdx !== "" && !isNaN(rowIdx);
+            parts.length === 3 && rowIdx !== "" && !isNaN(rowIdx);
           if (isRowField) {
             // Table cell change -> ship only the changed cell.
             if (!delta[attr] || !delta[attr].__delta) {

--- a/node/tests/buildDeltaFromPaths.spec.js
+++ b/node/tests/buildDeltaFromPaths.spec.js
@@ -7,7 +7,7 @@ function _buildDeltaFromPaths(paths, xx) {
     for (let path of paths) {
         let parts = path.substring(4).split('/');
         let attr = parts[0];
-        if (parts.length >= 3 && !isNaN(parts[1])) {
+        if (parts.length === 3 && !isNaN(parts[1])) {
             if (!delta[attr] || !delta[attr]["__delta"]) {
                 delta[attr] = { "__delta": {} };
             }
@@ -203,13 +203,44 @@ test.describe('Edge cases', () => {
         });
     });
 
-    test('deeply nested path (4+ parts) uses first 3 parts for delta', () => {
+    test('deeply nested path (4+ parts) falls back to full array', () => {
         // "/XX/TABLE1/0/COL1/deep" → parts = ["TABLE1","0","COL1","deep"]
-        // parts.length >= 3 ✓, !isNaN("0") ✓ → delta with parts[2] = "COL1"
+        // parts.length !== 3 → cannot be expressed as a flat cell delta, so the
+        // whole attribute is shipped instead.
         const paths = new Set(['/XX/TABLE1/0/COL1/deep']);
         const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+        expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    });
+});
+
+// ── 5b. Tree table (nested sub-table) edits ─────────────────────────────
+test.describe('Tree table nested edits → full array fallback', () => {
+
+    const TREE_XX = {
+        MT_TREE: [
+            {
+                USER: "Manager", ENABLED: false, VALIDATED: false,
+                NODES: [
+                    { USER: "Employee 1", ENABLED: true, VALIDATED: false },
+                    { USER: "Employee 2", ENABLED: true, VALIDATED: false },
+                ],
+            },
+        ],
+    };
+
+    test('checkbox on a tree child node ships the whole attribute', () => {
+        // UI5 tree table edit path: /XX/MT_TREE/0/NODES/1/VALIDATED
+        // parts = ["MT_TREE","0","NODES","1","VALIDATED"] → length 5 → fallback.
+        const paths = new Set(['/XX/MT_TREE/0/NODES/1/VALIDATED']);
+        const result = _buildDeltaFromPaths(paths, TREE_XX);
+        expect(result).toEqual({ MT_TREE: TREE_XX.MT_TREE });
+    });
+
+    test('edit on a tree root node still uses a flat cell delta', () => {
+        const paths = new Set(['/XX/MT_TREE/0/VALIDATED']);
+        const result = _buildDeltaFromPaths(paths, TREE_XX);
         expect(result).toEqual({
-            TABLE1: { __delta: { "0": { COL1: "A1" } } }
+            MT_TREE: { __delta: { "0": { VALIDATED: false } } }
         });
     });
 });

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -397,9 +397,14 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        const delta = {};` && |\n| &&
              `        for (const path of paths) {` && |\n| &&
              `          // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>"` && |\n| &&
-             `          const [attr, rowIdx, field] = path.slice(4).split("/");` && |\n| &&
+             `          const parts = path.slice(4).split("/");` && |\n| &&
+             `          const [attr, rowIdx, field] = parts;` && |\n| &&
+             `          // Only a flat table cell (exactly attr/row/field) qualifies for a` && |\n| &&
+             `          // delta. Deeper paths (e.g. tree tables: attr/row/<subtable>/<row>/<field>)` && |\n| &&
+             `          // fall back to shipping the whole attribute, which the backend applies` && |\n| &&
+             `          // via corresponding-based deserialization.` && |\n| &&
              `          const isRowField =` && |\n| &&
-             `            field !== undefined && rowIdx !== "" && !isNaN(rowIdx);` && |\n| &&
+             `            parts.length === 3 && rowIdx !== "" && !isNaN(rowIdx);` && |\n| &&
              `          if (isRowField) {` && |\n| &&
              `            // Table cell change -> ship only the changed cell.` && |\n| &&
              `            if (!delta[attr] || !delta[attr].__delta) {` && |\n| &&
@@ -413,13 +418,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            // Scalar change -> ship the whole attribute.` && |\n| &&
              `            delta[attr] = xx[attr];` && |\n| &&
              `          }` && |\n| &&
+             |\n|.
+    result = result &&
              `        }` && |\n| &&
              `        return delta;` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      _createViewModel() {` && |\n| &&
-             |\n|.
-    result = result &&
              `        const data = z2ui5.oResponse && z2ui5.oResponse.OVIEWMODEL;` && |\n| &&
              `        return this._trackChanges(new JSONModel(data));` && |\n| &&
              `      },` && |\n| &&
@@ -815,13 +820,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          setTimeout(finish, 1500);` && |\n| &&
              `        };` && |\n| &&
              `        try {` && |\n| &&
+             |\n|.
+    result = result &&
              `          const launchpadLogout =` && |\n| &&
              `            z2ui5.oLaunchpad &&` && |\n| &&
              `            z2ui5.oLaunchpad.Container &&` && |\n| &&
              `            z2ui5.oLaunchpad.Container.logout;` && |\n| &&
              `          if (launchpadLogout) {` && |\n| &&
-             |\n|.
-    result = result &&
              `            z2ui5.oLaunchpad.Container.logout();` && |\n| &&
              `          } else {` && |\n| &&
              `            redirectToLogoff();` && |\n| &&
@@ -1217,13 +1222,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            }` && |\n| &&
              `          }` && |\n| &&
              `          return;` && |\n| &&
+             |\n|.
+    result = result &&
              `        }` && |\n| &&
              `` && |\n| &&
              `        if (msgType === "S_MSG_BOX") {` && |\n| &&
              `          const oParams = {` && |\n| &&
              `            styleClass: msg.STYLECLASS || "",` && |\n| &&
-             |\n|.
-    result = result &&
              `            title: msg.TITLE || "",` && |\n| &&
              `            onClose: msg.ONCLOSE` && |\n| &&
              `              ? (sAction) => this.eB([msg.ONCLOSE, sAction])` && |\n| &&


### PR DESCRIPTION
## Summary

Fix the delta encoding logic to correctly handle deeply nested paths (4+ parts) that cannot be expressed as flat table cell deltas. These paths now fall back to shipping the whole attribute instead of incorrectly truncating to the first 3 parts.

## Changes

- **Test spec (`buildDeltaFromPaths.spec.js`):**
  - Changed condition from `parts.length >= 3` to `parts.length === 3` to enforce strict 3-part matching for flat cell deltas
  - Updated test case "deeply nested path (4+ parts)" to verify fallback behavior (ship whole attribute)
  - Added comprehensive test suite for tree table nested edits, covering:
    - Checkbox edits on tree child nodes (5-part paths) → fallback to full array
    - Edits on tree root nodes (3-part paths) → continue using flat cell delta

- **Frontend code (`View1.controller.js` and ABAP-embedded equivalent):**
  - Refactored to store `path.slice(4).split("/")` in `parts` variable for clarity
  - Changed `isRowField` condition from `field !== undefined && rowIdx !== "" && !isNaN(rowIdx)` to `parts.length === 3 && rowIdx !== "" && !isNaN(rowIdx)`
  - Added explanatory comments clarifying that only exactly 3-part paths (attr/row/field) qualify for delta encoding; deeper paths (e.g., tree tables with nested subtables) fall back to shipping the whole attribute via corresponding-based deserialization

## Implementation Details

The fix ensures that:
- **Flat tables** (3-part paths like `/XX/TABLE1/0/COL1`) continue to use efficient delta encoding
- **Tree tables** with nested structures (5+ part paths like `/XX/MT_TREE/0/NODES/1/VALIDATED`) correctly fall back to shipping the entire attribute, allowing the backend to apply changes via corresponding-based deserialization
- The logic is now explicit and maintainable with clear comments explaining the design rationale

https://claude.ai/code/session_01H1j2cJjJHKMFoxYpbGzoaq