### PR TITLE
Improve SET_FOCUS reliability with deferred rendering retry

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -901,16 +901,39 @@ sap.ui.define(
       },
 
       _evSetFocus(args) {
-        try {
-          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);
-          if (!oElement) return;
-          const info = oElement.getFocusInfo();
-          if (args[2] != null && args[2] !== "") info.selectionStart = +args[2];
-          if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];
-          oElement.applyFocusInfo(info);
-        } catch (e) {
-          logError(`SET_FOCUS: failed for '${args[1]}'`, e);
-        }
+        // Try to focus the target control now. Returns true once the focus was
+        // applied (or a hard error stopped us), false while the control is not
+        // rendered yet and we should retry after the next rendering cycle.
+        const applyFocus = () => {
+          try {
+            const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);
+            if (!oElement) return false;
+            // On init SET_FOCUS arrives together with a full view rebuild, so
+            // the control exists but is not in the DOM yet - defer in that case.
+            if (oElement.getDomRef && !oElement.getDomRef()) return false;
+            const info = oElement.getFocusInfo();
+            if (args[2] != null && args[2] !== "")
+              info.selectionStart = +args[2];
+            if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];
+            oElement.applyFocusInfo(info);
+            return true;
+          } catch (e) {
+            logError(`SET_FOCUS: failed for '${args[1]}'`, e);
+            return true;
+          }
+        };
+
+        if (applyFocus()) return;
+
+        // Control not rendered yet (initial view build): retry after rendering,
+        // mirroring the previous z2ui5.Focus control behavior.
+        let attempts = 0;
+        const onAfterRendering = () => {
+          if (applyFocus() || ++attempts >= 5) {
+            Rendering.detachAfterRendering(onAfterRendering);
+          }
+        };
+        Rendering.attachAfterRendering(onAfterRendering);
       },
 
       _evScrollTo(args) {

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -925,16 +925,39 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `` && |\n| &&
              `      _evSetFocus(args) {` && |\n| &&
-             `        try {` && |\n| &&
-             `          const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
-             `          if (!oElement) return;` && |\n| &&
-             `          const info = oElement.getFocusInfo();` && |\n| &&
-             `          if (args[2] != null && args[2] !== "") info.selectionStart = +args[2];` && |\n| &&
-             `          if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];` && |\n| &&
-             `          oElement.applyFocusInfo(info);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          logError(``SET_FOCUS: failed for '${args[1]}'``, e);` && |\n| &&
-             `        }` && |\n| &&
+             `        // Try to focus the target control now. Returns true once the focus was` && |\n| &&
+             `        // applied (or a hard error stopped us), false while the control is not` && |\n| &&
+             `        // rendered yet and we should retry after the next rendering cycle.` && |\n| &&
+             `        const applyFocus = () => {` && |\n| &&
+             `          try {` && |\n| &&
+             `            const oElement = z2ui5.oView && z2ui5.oView.byId(args[1]);` && |\n| &&
+             `            if (!oElement) return false;` && |\n| &&
+             `            // On init SET_FOCUS arrives together with a full view rebuild, so` && |\n| &&
+             `            // the control exists but is not in the DOM yet - defer in that case.` && |\n| &&
+             `            if (oElement.getDomRef && !oElement.getDomRef()) return false;` && |\n| &&
+             `            const info = oElement.getFocusInfo();` && |\n| &&
+             `            if (args[2] != null && args[2] !== "")` && |\n| &&
+             `              info.selectionStart = +args[2];` && |\n| &&
+             `            if (args[3] != null && args[3] !== "") info.selectionEnd = +args[3];` && |\n| &&
+             `            oElement.applyFocusInfo(info);` && |\n| &&
+             `            return true;` && |\n| &&
+             `          } catch (e) {` && |\n| &&
+             `            logError(``SET_FOCUS: failed for '${args[1]}'``, e);` && |\n| &&
+             `            return true;` && |\n| &&
+             `          }` && |\n| &&
+             `        };` && |\n| &&
+             `` && |\n| &&
+             `        if (applyFocus()) return;` && |\n| &&
+             `` && |\n| &&
+             `        // Control not rendered yet (initial view build): retry after rendering,` && |\n| &&
+             `        // mirroring the previous z2ui5.Focus control behavior.` && |\n| &&
+             `        let attempts = 0;` && |\n| &&
+             `        const onAfterRendering = () => {` && |\n| &&
+             `          if (applyFocus() || ++attempts >= 5) {` && |\n| &&
+             `            Rendering.detachAfterRendering(onAfterRendering);` && |\n| &&
+             `          }` && |\n| &&
+             `        };` && |\n| &&
+             `        Rendering.attachAfterRendering(onAfterRendering);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      _evScrollTo(args) {` && |\n| &&
@@ -1199,6 +1222,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `      // Display a toast or message box. Triggered for S_MSG_TOAST and` && |\n| &&
              `      // S_MSG_BOX entries in the server response.` && |\n| &&
+             |\n|.
+    result = result &&
              `      showMessage(msgType, params) {` && |\n| &&
              `        if (!params) return;` && |\n| &&
              `        const msg = params[msgType];` && |\n| &&
@@ -1222,8 +1247,6 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            }` && |\n| &&
              `          }` && |\n| &&
              `          return;` && |\n| &&
-             |\n|.
-    result = result &&
              `        }` && |\n| &&
              `` && |\n| &&
              `        if (msgType === "S_MSG_BOX") {` && |\n| &&


### PR DESCRIPTION
## Summary

Enhance the `_evSetFocus` method to handle focus requests that arrive during initial view builds, when controls exist in the object tree but are not yet rendered in the DOM. The fix defers focus application to the next rendering cycle if the control is not yet in the DOM, mirroring the previous `z2ui5.Focus` control behavior.

## Changes

- **Refactored `_evSetFocus` logic** into an `applyFocus()` helper function that returns a boolean indicating success or deferral
  - Returns `false` if the control is not found or not yet in the DOM (via `getDomRef()` check)
  - Returns `true` once focus is applied or a hard error occurs
  
- **Added rendering cycle retry mechanism**
  - If initial focus attempt fails (control not rendered), attach an `onAfterRendering` listener
  - Retry focus application on each rendering cycle, up to 5 attempts
  - Detach listener once focus succeeds or attempt limit is reached
  
- **Improved code documentation** with inline comments explaining the deferred focus behavior and DOM readiness check

## Implementation Details

The fix addresses a race condition where `SET_FOCUS` events arrive together with full view rebuilds during app initialization. The control object exists but has not yet been inserted into the DOM, causing focus operations to fail silently. By deferring to the next rendering cycle and retrying, focus is reliably applied once the control is rendered.

The retry limit of 5 attempts prevents infinite loops while providing sufficient opportunity for the control to render in typical scenarios.

https://claude.ai/code/session_01E2Tz15NXMhjaV4QwyFS8LW