### PR TITLE
Add width parameter to tree_column method

### DIFF
--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -3986,11 +3986,13 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
     "! @parameter label    | (string) Header label.
     "! @parameter template | (string) Cell template (column content control).
     "! @parameter halign   | (sap.ui.core.HorizontalAlign) Begin | End | Left | Right | Center. Default: Begin.
+    "! @parameter width    | (sap.ui.core.CSSSize) Column width.
     METHODS tree_column
       IMPORTING
         label         TYPE clike
         template      TYPE clike OPTIONAL
         halign        TYPE clike DEFAULT `Begin`
+        width         TYPE clike OPTIONAL
       RETURNING
         VALUE(result) TYPE REF TO z2ui5_cl_xml_view.
 
@@ -14343,7 +14345,8 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
                        ns     = `table`
                        t_prop = VALUE #( ( n = `label`      v = label )
                                          ( n = `template`   v = template )
-                                         ( n = `hAlign`     v = halign ) ) ).
+                                         ( n = `hAlign`     v = halign )
+                                         ( n = `width`      v = width ) ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Extends the `tree_column` method in the XML view builder to support column width configuration via a new optional `width` parameter.

## Changes
- Added `width` parameter (type `clike`, optional) to the `tree_column` method signature
- Updated method documentation to describe the new parameter as `sap.ui.core.CSSSize`
- Passed the `width` parameter to the underlying XML property builder as the `width` attribute

## Details
This change allows developers to specify custom column widths when building tree table columns using the fluent XML view builder API. The parameter follows the same optional pattern as the existing `halign` parameter and integrates seamlessly with the property mapping mechanism used by other column-building methods in the framework.

https://claude.ai/code/session_01Eb9ygxbhJFvPTHpc9drd5x