### PR TITLE
Split SET_TITLE into document and launchpad variants

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -661,6 +661,9 @@ sap.ui.define(
           case "SET_TITLE":
             this._evSetTitle(args);
             break;
+          case "SET_TITLE_LAUNCHPAD":
+            this._evSetTitleLaunchpad(args);
+            break;
           case "SET_FOCUS":
             this._evSetFocus(args);
             break;
@@ -1030,19 +1033,29 @@ sap.ui.define(
       _evSetTitle(args) {
         const title = args[1] == null ? "" : String(args[1]);
         try {
+          document.title = title;
+        } catch (e) {
+          logError("SET_TITLE: setting document.title failed", e);
+        }
+      },
+
+      _evSetTitleLaunchpad(args) {
+        const title = args[1] == null ? "" : String(args[1]);
+        try {
           const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;
           if (shell && shell.setTitle) {
             const result = shell.setTitle(title);
             if (result && result.catch) {
               result.catch((e) =>
-                logError("SET_TITLE: ShellUIService.setTitle failed", e),
+                logError(
+                  "SET_TITLE_LAUNCHPAD: ShellUIService.setTitle failed",
+                  e,
+                ),
               );
             }
-          } else {
-            document.title = title;
           }
         } catch (e) {
-          logError("SET_TITLE: ShellUIService.setTitle failed", e);
+          logError("SET_TITLE_LAUNCHPAD: ShellUIService.setTitle failed", e);
         }
       },
 

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -683,6 +683,9 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          case "SET_TITLE":` && |\n| &&
              `            this._evSetTitle(args);` && |\n| &&
              `            break;` && |\n| &&
+             `          case "SET_TITLE_LAUNCHPAD":` && |\n| &&
+             `            this._evSetTitleLaunchpad(args);` && |\n| &&
+             `            break;` && |\n| &&
              `          case "SET_FOCUS":` && |\n| &&
              `            this._evSetFocus(args);` && |\n| &&
              `            break;` && |\n| &&
@@ -817,11 +820,11 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          }` && |\n| &&
              `          const sep = path.indexOf("?") >= 0 ? "&" : "?";` && |\n| &&
              `          const bspKill = path + sep + "sap-sessioncmd=logoff";` && |\n| &&
+             |\n|.
+    result = result &&
              `          let done = false;` && |\n| &&
              `          const finish = () => {` && |\n| &&
              `            if (done) return;` && |\n| &&
-             |\n|.
-    result = result &&
              `            done = true;` && |\n| &&
              `            goToLogoutUrl();` && |\n| &&
              `          };` && |\n| &&
@@ -1054,19 +1057,32 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      _evSetTitle(args) {` && |\n| &&
              `        const title = args[1] == null ? "" : String(args[1]);` && |\n| &&
              `        try {` && |\n| &&
+             `          document.title = title;` && |\n| &&
+             `        } catch (e) {` && |\n| &&
+             `          logError("SET_TITLE: setting document.title failed", e);` && |\n| &&
+             `        }` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      _evSetTitleLaunchpad(args) {` && |\n| &&
+             `        const title = args[1] == null ? "" : String(args[1]);` && |\n| &&
+             `        try {` && |\n| &&
              `          const shell = z2ui5.oLaunchpad && z2ui5.oLaunchpad.ShellUIService;` && |\n| &&
              `          if (shell && shell.setTitle) {` && |\n| &&
              `            const result = shell.setTitle(title);` && |\n| &&
              `            if (result && result.catch) {` && |\n| &&
              `              result.catch((e) =>` && |\n| &&
-             `                logError("SET_TITLE: ShellUIService.setTitle failed", e),` && |\n| &&
+             `                logError(` && |\n| &&
+             `                  "SET_TITLE_LAUNCHPAD: ShellUIService.setTitle failed",` && |\n| &&
+             `                  e,` && |\n| &&
+             `                ),` && |\n| &&
              `              );` && |\n| &&
              `            }` && |\n| &&
-             `          } else {` && |\n| &&
-             `            document.title = title;` && |\n| &&
              `          }` && |\n| &&
              `        } catch (e) {` && |\n| &&
-             `          logError("SET_TITLE: ShellUIService.setTitle failed", e);` && |\n| &&
+             `          logError(` && |\n| &&
+             `            "SET_TITLE_LAUNCHPAD: ShellUIService.setTitle failed",` && |\n| &&
+             `            e,` && |\n| &&
+             `          );` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -1206,6 +1222,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        const params = z2ui5.oResponse && z2ui5.oResponse.PARAMS;` && |\n| &&
              `        const slot = params && params[paramKey];` && |\n| &&
              `        if (!slot || !slot.CHECK_UPDATE_MODEL) return;` && |\n| &&
+             |\n|.
+    result = result &&
              `` && |\n| &&
              `        const oModel = this._createViewModel();` && |\n| &&
              `        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);` && |\n| &&
@@ -1222,8 +1240,6 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        if (!gav || !gav.includes("com.sap.ui5")) {` && |\n| &&
-             |\n|.
-    result = result &&
              `          // openui5 doesn't ship some sap.com modules - tell the user which` && |\n| &&
              `          // module is missing so they know to switch to SAPUI5.` && |\n| &&
              `          const missingModule = err && err._modules;` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -25,6 +25,7 @@ INTERFACE z2ui5_if_client
       image_editor_popup_close  TYPE string VALUE `IMAGE_EDITOR_POPUP_CLOSE`,
       system_logout             TYPE string VALUE `SYSTEM_LOGOUT`,
       set_title                 TYPE string VALUE `SET_TITLE`,
+      set_title_launchpad       TYPE string VALUE `SET_TITLE_LAUNCHPAD`,
       set_focus                 TYPE string VALUE `SET_FOCUS`,
       scroll_to                 TYPE string VALUE `SCROLL_TO`,
       scroll_into_view          TYPE string VALUE `SCROLL_INTO_VIEW`,


### PR DESCRIPTION
## Summary

Refactors the title-setting functionality to distinguish between setting the browser document title and setting the SAP Fiori Launchpad shell title. Introduces a new `SET_TITLE_LAUNCHPAD` event type while preserving the existing `SET_TITLE` for direct document title manipulation.

## Key Changes

- **New event type:** Added `SET_TITLE_LAUNCHPAD` constant to `z2ui5_if_client` interface
- **Split handler logic:** 
  - `_evSetTitle()` now sets `document.title` directly with error handling
  - `_evSetTitleLaunchpad()` handles launchpad shell integration via `ShellUIService.setTitle()`
- **Improved error messages:** Updated error log messages to reflect which variant failed
- **Event routing:** Added case handler for `SET_TITLE_LAUNCHPAD` in the main event dispatcher
- **Code cleanup:** Improved formatting of multi-line error logging calls

## Implementation Details

The original `_evSetTitle()` method attempted both document title and launchpad shell title in a single function with a fallback pattern. This change separates concerns:

- Apps targeting standalone mode or needing direct document title control use `SET_TITLE`
- Apps running in SAP Fiori Launchpad use `SET_TITLE_LAUNCHPAD` for proper shell integration
- Both variants include try-catch error handling with descriptive logging

Changes applied to both the ABAP source (`z2ui5_cl_app_view1_js`) and the mirrored JavaScript controller (`View1.controller.js`).

https://claude.ai/code/session_01WhEpSgUeevCxuF32PAF11r