### PR TITLE
Add popup demo output class for displaying CL_DEMO_OUTPUT

### DIFF
--- a/src/02/01/z2ui5_cl_pop_demo_output.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_demo_output.clas.abap
@@ -1,0 +1,196 @@
+CLASS z2ui5_cl_pop_demo_output DEFINITION PUBLIC FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    CLASS-METHODS factory
+      IMPORTING
+        i_output        TYPE REF TO object
+        i_title         TYPE string DEFAULT `Output`
+        i_icon          TYPE string DEFAULT `sap-icon://textFormatting`
+        i_button_text   TYPE string DEFAULT `OK`
+        i_stretch       TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(r_result) TYPE REF TO z2ui5_cl_pop_demo_output.
+
+  PROTECTED SECTION.
+    DATA client              TYPE REF TO z2ui5_if_client.
+    DATA title               TYPE string.
+    DATA icon                TYPE string.
+    DATA html                TYPE string.
+    DATA button_text_confirm TYPE string.
+    DATA stretch             TYPE abap_bool.
+
+    METHODS view_display.
+
+    METHODS get_style
+      RETURNING
+        VALUE(result) TYPE string.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_pop_demo_output IMPLEMENTATION.
+
+  METHOD factory.
+
+    r_result = NEW #( ).
+    r_result->title               = i_title.
+    r_result->icon                = i_icon.
+    r_result->button_text_confirm = i_button_text.
+    r_result->stretch             = i_stretch.
+
+    " CL_DEMO_OUTPUT is typed generically for compatibility - it is not
+    " available on every ABAP release / environment. The HTML output is
+    " extracted dynamically via its GET( ) method.
+    TRY.
+        CALL METHOD i_output->('GET')
+          RECEIVING
+            result = r_result->html.
+      CATCH cx_root ##NO_HANDLER.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD view_display.
+
+    DATA(popup) = z2ui5_cl_xml_view=>factory_popup( )->dialog(
+                      title         = title
+                      icon          = icon
+                      stretch       = stretch
+                      contentheight = `100%`
+                      contentwidth  = `100%`
+                      afterclose    = client->_event( `BUTTON_CONFIRM` )
+              )->content(
+                  )->vbox( `sapUiMediumMargin`
+                      )->_cc_plain_xml( get_style( )
+                      )->html( html
+              )->get_parent( )->get_parent( )->get_parent(
+              )->buttons(
+                  )->button( text  = COND #( WHEN stretch = abap_true THEN `Popup` ELSE `Fullscreen` )
+                             icon  = COND #( WHEN stretch = abap_true THEN `sap-icon://exit-full-screen` ELSE `sap-icon://full-screen` )
+                             press = client->_event( `TOGGLE_FULLSCREEN` )
+                  )->button( text  = button_text_confirm
+                             press = client->_event( `BUTTON_CONFIRM` )
+                             type  = `Emphasized` ).
+
+    client->popup_display( popup->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+
+    IF client->check_on_init( ).
+      view_display( ).
+      RETURN.
+    ENDIF.
+
+    IF client->check_on_event( `TOGGLE_FULLSCREEN` ).
+      stretch = xsdbool( stretch = abap_false ).
+      view_display( ).
+      RETURN.
+    ENDIF.
+
+    IF client->check_on_event( `BUTTON_CONFIRM` ).
+      client->popup_destroy( ).
+      client->nav_app_leave( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD get_style.
+
+    result =  `<html:style type="text/css">` && |\n| &&
+              `  body {` && |\n| &&
+              `    font-family: Arial;` && |\n| &&
+              `    font-size: 90%;` && |\n| &&
+              `  }` && |\n| &&
+              `  table {` && |\n| &&
+              `    font-family: Arial;` && |\n| &&
+              `    font-size: 90%;` && |\n| &&
+              `  }` && |\n| &&
+              `  caption {` && |\n| &&
+              `    font-family: Arial;` && |\n| &&
+              `    font-size: 90%;` && |\n| &&
+              `    font-weight: bold;` && |\n| &&
+              `    text-align: left;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.heading1 {` && |\n| &&
+              `    font-size: 150%;` && |\n| &&
+              `    color: #000080;` && |\n| &&
+              `    font-weight: bold;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.heading2 {` && |\n| &&
+              `    font-size: 135%;` && |\n| &&
+              `    color: #000080;` && |\n| &&
+              `    font-weight: bold;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.heading3 {` && |\n| &&
+              `    font-size: 120%;` && |\n| &&
+              `    color: #000080;` && |\n| &&
+              `    font-weight: bold;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.heading4 {` && |\n| &&
+              `    font-size: 105%;` && |\n| &&
+              `    color: #000080;` && |\n| &&
+              `    font-weight: bold;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.normal {` && |\n| &&
+              `    font-family: Arial;` && |\n| &&
+              `    font-size: 100%;` && |\n| &&
+              `    color: #000000;` && |\n| &&
+              `    font-weight: normal;` && |\n| &&
+              `    white-space: pre;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.nonprop {` && |\n| &&
+              `    font-family: Courier New;` && |\n| &&
+              `    font-size: 100%;` && |\n| &&
+              `    color: #000000;` && |\n| &&
+              `    font-weight: 400;` && |\n| &&
+              `    white-space: pre;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.nowrap {` && |\n| &&
+              `    white-space: nowrap;` && |\n| &&
+              `  }` && |\n| &&
+              `  span.nprpnwrp {` && |\n| &&
+              `    font-family: Courier New;` && |\n| &&
+              `    font-size: 100%;` && |\n| &&
+              `    color: #000000;` && |\n| &&
+              `    font-weight: 400;` && |\n| &&
+              `    white-space: nowrap;` && |\n| &&
+              `  }` && |\n| &&
+              `  tr.header {` && |\n| &&
+              `    background-color: #D1D1D1;` && |\n| &&
+              `  }` && |\n| &&
+              `  tr.body {` && |\n| &&
+              `    background-color: #F4F4F4;` && |\n| &&
+              `  }` && |\n| &&
+              `  th {` && |\n| &&
+              `    text-align: left;` && |\n| &&
+              `  }` && |\n| &&
+              `  table.nested_table {` && |\n| &&
+              `    border: 1px solid #D1D1D1;` && |\n| &&
+              `    border-collapse: collapse;` && |\n| &&
+              `    padding: 4px;` && |\n| &&
+              `    text-align: center;` && |\n| &&
+              `  }` && |\n| &&
+              `  .nested_table td {` && |\n| &&
+              `    border: 1px solid #D1D1D1;` && |\n| &&
+              `    border-collapse: collapse;` && |\n| &&
+              `    padding: 4px;` && |\n| &&
+              `    text-align: left;` && |\n| &&
+              `  }` && |\n| &&
+              `  .nested_table th {` && |\n| &&
+              `    border: 1px solid #D1D1D1;` && |\n| &&
+              `    border-collapse: collapse;` && |\n| &&
+              `    background-color: #D1D1D1;` && |\n| &&
+              `    padding: 4px;` && |\n| &&
+              `  }` && |\n| &&
+              `</html:style>`.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/02/01/z2ui5_cl_pop_demo_output.clas.testclasses.abap
+++ b/src/02/01/z2ui5_cl_pop_demo_output.clas.testclasses.abap
@@ -1,0 +1,58 @@
+
+CLASS ltcl_output_stub DEFINITION FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS get
+      RETURNING
+        VALUE(result) TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS ltcl_output_stub IMPLEMENTATION.
+
+  METHOD get.
+
+    result = `<p><span class="heading1">Hello cl_demo_output</span></p>`.
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltcl_test DEFINITION FINAL
+  FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+
+  PRIVATE SECTION.
+
+    METHODS test_factory          FOR TESTING RAISING cx_static_check.
+    METHODS test_factory_custom   FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD test_factory.
+
+    DATA(lo_pop) = z2ui5_cl_pop_demo_output=>factory( NEW ltcl_output_stub( ) ).
+    cl_abap_unit_assert=>assert_bound( lo_pop ).
+
+  ENDMETHOD.
+
+  METHOD test_factory_custom.
+
+    DATA(lo_pop) = z2ui5_cl_pop_demo_output=>factory(
+      i_output      = NEW ltcl_output_stub( )
+      i_title       = `My Output`
+      i_icon        = `sap-icon://hint`
+      i_button_text = `Close`
+      i_stretch     = abap_true ).
+
+    cl_abap_unit_assert=>assert_bound( lo_pop ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/02/01/z2ui5_cl_pop_demo_output.clas.xml
+++ b/src/02/01/z2ui5_cl_pop_demo_output.clas.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_POP_DEMO_OUTPUT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ui - popup demo output</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary

Adds a new popup application class `z2ui5_cl_pop_demo_output` that wraps SAP's `CL_DEMO_OUTPUT` and displays its HTML content within a modal dialog popup. This enables framework users to leverage existing demo output formatting within abap2UI5 applications.

## Key Changes

- **New class `z2ui5_cl_pop_demo_output`** — Implements `z2ui5_if_app` to display HTML output from `CL_DEMO_OUTPUT` in a styled popup dialog
  - Factory method accepts output object, title, icon, button text, and stretch mode
  - Dynamically extracts HTML via `CL_DEMO_OUTPUT->GET()` method (generic typing for compatibility across ABAP releases)
  - Supports fullscreen/popup toggle via `TOGGLE_FULLSCREEN` event
  - Includes comprehensive CSS styling for headings, tables, captions, and monospace text (matching `CL_DEMO_OUTPUT` formatting)
  - Handles popup lifecycle: init, toggle, and confirm/close events

- **Unit tests** — Two test methods validating factory instantiation with default and custom parameters

- **Metadata** — Class descriptor with unit test flag enabled

## Implementation Details

- Generic typing (`REF TO object`) for `i_output` parameter ensures compatibility with systems where `CL_DEMO_OUTPUT` may not be available
- Safe extraction of HTML via `TRY/CATCH` to handle missing or incompatible output objects gracefully
- CSS styling embedded as plain XML to preserve `CL_DEMO_OUTPUT` visual formatting (fonts, colors, spacing)
- Popup uses fluent XML view builder pattern consistent with framework conventions
- Fullscreen toggle switches `stretch` flag and rebuilds view without closing dialog

https://claude.ai/code/session_01FJbbe6gt9bQ49f3L6VznYs