### PR TITLE
fix: escape CSS braces in CL_DEMO_OUTPUT popup HTML

### DIFF
--- a/src/02/01/z2ui5_cl_pop_demo_output.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_demo_output.clas.abap
@@ -51,6 +51,14 @@ CLASS z2ui5_cl_pop_demo_output IMPLEMENTATION.
       CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
+    " CL_DEMO_OUTPUT emits a full HTML document including a <style> block.
+    " UI5 interprets `{` / `}` inside the core:HTML `content` attribute as
+    " data-binding expressions, so the CSS braces break the binding parser.
+    " Escape them with a leading backslash - UI5's documented way to mark a
+    " brace as a literal character, rendered without the backslash.
+    r_result->html = replace( val = r_result->html sub = `{` with = `\{` occ = 0 ).
+    r_result->html = replace( val = r_result->html sub = `}` with = `\}` occ = 0 ).
+
   ENDMETHOD.
 
   METHOD view_display.


### PR DESCRIPTION
## Problem

Launching the new `z2ui5_cl_pop_demo_output` popup (e.g. via sample `z2ui5_cl_demo_app_365`) terminated with:

```
Error found in Fragment (id: 'popupId').
XML node: '<core:HTML ... content="...">'
SyntaxError: Expected ',' instead of 'p'
```

## Cause

`CL_DEMO_OUTPUT->get()` returns a full HTML document including a `<style>` block. That entire string is placed into the `content="..."` attribute of the `core:HTML` control. UI5 interprets `{ ... }` in **attribute values** as data-binding expressions, so the CSS rules (`body { font-family: Arial; ... }`) are fed to the binding parser, which fails.

The popup's own `get_style()` block is unaffected because it is rendered as a real `<html:style>` *element*, not as an attribute value.

## Fix

Escape the curly braces with a leading backslash (`\{` / `\}`) in `factory` right after retrieving the HTML. This is UI5's documented mechanism to mark a brace as a literal character; the backslash is consumed by the binding parser, so the rendered HTML keeps the correct braces.

```abap
r_result->html = replace( val = r_result->html sub = `{` with = `\{` occ = 0 ).
r_result->html = replace( val = r_result->html sub = `}` with = `\}` occ = 0 ).
```

## Validation

- `npx abaplint` — 0 issues, 242 files analyzed.

https://claude.ai/code/session_01HKUvEyRrxN5kdcDzspTUFg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKUvEyRrxN5kdcDzspTUFg)_