### PR TITLE
refactor: unify fatal error display into single overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,8 @@ npm run unit                  # Unit tests
 |---|---|
 | `npx abaplint .github/abaplint/auto_abaplint_fix.jsonc --fix` | Auto-fix formatting |
 | `npm run express` | Start dev server on port 3000 |
-| `npm run auto_app2abap` | Convert `app/webapp/` frontend files into ABAP string constants in `src/01/03/` |
+| `npm run app2abap` | **Canonical** full regeneration pipeline: Prettier (`app` format) → generate → abaplint normalize. Use this after editing `app/webapp/` so only truly-changed `src/01/03/` files differ |
+| `npm run auto_app2abap` | Generate ABAP string constants from `app/webapp/` (raw, **un-normalized** — prefer `npm run app2abap` instead) |
 | `npm run auto_abaplint` | Run the auto-fix config directly |
 | `npm run rename` | Test namespace-rename transformation via abaplint |
 | `npm run syfixes` | Replace `RAISE EXCEPTION TYPE cx_sy_itab_line_not_found` with `ASSERT 1 = 0` (compatibility step for 7.02 downport) |
@@ -344,9 +345,18 @@ These rules apply to AI assistants **modifying the framework** (this repo). For 
 1. **Do not modify `src/00/`** — mirrored from external projects, synced by automated workflows.
 2. **NEVER manually edit any ABAP file under `src/01/03/`.** These files are the embedded frontend (auto-generated from `app/webapp/` via the `app2abap` job — see `.github/app2abap/trans2abap.js` and the `create_app2abap.yaml` workflow). The **only** allowed way to update them is:
    - Change the source under `app/webapp/`
-   - Run the `app2abap` job (`npm run auto_app2abap` locally, or trigger the `create_app2abap.yaml` workflow)
+   - Run **`npm run app2abap`** locally (or trigger the `create_app2abap.yaml` workflow). This single command runs the full pipeline in the correct order — `npm --prefix app run format` (Prettier) → `npm run auto_app2abap` (generate) → `npm run auto_abaplint` (normalize) — exactly as CI does. Running `auto_app2abap` on its own produces **un-normalized** ABAP that differs from the committed form in *every* `src/01/03/` file (alignment/whitespace drift); the `auto_abaplint` step reverts that drift so only the files whose `app/webapp/` source actually changed remain modified.
    - Commit the regenerated `src/01/03/` files as the job produced them
    Direct edits to `src/01/03/*.abap` are forbidden — no manual tweaks, no "small fixes", no formatting changes, nothing. The job may be invoked, but the files must never be touched by hand or by any other means.
+   - **Keep diffs minimal — avoid Prettier reflow:** when you add or remove a module dependency in a `sap.ui.define([...], (...) => {` block, Prettier may collapse the call onto one line (or expand it), which **reindents the entire module body** and rewrites every line of the file (and its embedded `src/01/03/` constant). To prevent this, freeze the `define` header with a `// prettier-ignore` directive so the dependency list stays multi-line:
+     ```js
+     // Keep this define multi-line: with a single dependency Prettier would
+     // collapse it onto one line and reindent the entire module body.
+     // prettier-ignore
+     sap.ui.define(
+       ["sap/ui/core/BusyIndicator"],
+       (BusyIndicator) => {
+     ```
 3. **Always run `npx abaplint`** before considering changes complete.
 4. **Multi-environment compatibility** — code must work on NW 7.02, standard ABAP, and ABAP Cloud.
 5. **The public API (`src/02/`) is a stable contract — never change or remove existing public attributes, methods, or constants.** This folder is consumed directly by thousands of downstream apps. Specifically:

--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -1,6 +1,9 @@
+// Keep this define multi-line: with a single dependency prettier would
+// collapse it onto one line and reindent the entire module body.
+// prettier-ignore
 sap.ui.define(
-  ["sap/ui/core/BusyIndicator", "sap/m/MessageBox"],
-  (BusyIndicator, MessageBox) => {
+  ["sap/ui/core/BusyIndicator"],
+  (BusyIndicator) => {
     "use strict";
 
     // Errors longer than this are truncated before being shown to the user,
@@ -371,7 +374,7 @@ sap.ui.define(
           if (msg.includes("openui5") && msg.includes("script load error")) {
             oController.checkSDKcompatibility(e);
           } else {
-            MessageBox.error(e.toLocaleString());
+            this.responseError(e);
           }
         }
       },
@@ -420,11 +423,20 @@ sap.ui.define(
         return container;
       },
 
-      responseError(response) {
+      // Unified fatal-error overlay. Shown whenever the app reaches an
+      // unrecoverable state - a failed roundtrip (network, HTTP != 2xx, bad
+      // JSON, backend dump) or a client-side failure (invalid view XML,
+      // post-render crash, missing SDK module). The only way out is a restart,
+      // hence the Refresh / Logout actions. Built from raw DOM so it still
+      // works when the UI5 core itself is in a broken state.
+      // `response` may be a string or an Error object; `title` overrides the
+      // default header text.
+      responseError(response, title) {
         BusyIndicator.hide();
         z2ui5.isBusy = false;
 
-        const full = String(response);
+        const full =
+          response && response.stack ? String(response.stack) : String(response);
         let errorMessage;
         if (full.length > ERROR_MAX_LENGTH) {
           errorMessage =
@@ -443,7 +455,7 @@ sap.ui.define(
           "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";
 
         const h3 = document.createElement("h3");
-        h3.textContent = "Server Error - Please Restart The App";
+        h3.textContent = title || "Application Error - Please Restart The App";
         h3.style.cssText = "margin: 0";
         headerDiv.appendChild(h3);
 

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -359,12 +359,7 @@ sap.ui.define(
           runCallbacks(z2ui5.onAfterRendering);
         } catch (e) {
           logError("_processAfterRendering: unexpected error", e);
-          MessageBox.error(e.toLocaleString(), {
-            title: "Unexpected Error Occurred - App Terminated",
-            actions: [],
-            onClose: () =>
-              new mBusyDialog({ text: "Please Restart the App" }).open(),
-          });
+          Server.responseError(e, "Unexpected Error Occurred - App Terminated");
         } finally {
           BusyIndicator.hide();
           z2ui5.isBusy = false;
@@ -1214,12 +1209,12 @@ sap.ui.define(
           // openui5 doesn't ship some sap.com modules - tell the user which
           // module is missing so they know to switch to SAPUI5.
           const missingModule = err && err._modules;
-          MessageBox.error(
+          Server.responseError(
             `openui5 SDK is loaded, module: ${missingModule} is not available in openui5`,
           );
           return;
         }
-        MessageBox.error(err.toLocaleString());
+        Server.responseError(err);
       },
 
       // Display a toast or message box. Triggered for S_MSG_TOAST and

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "abaplintpathfix": "sed -i 's|\"files\": \"/\\.\\.\\/\\.\\.\\/src\\/\\*\\*\\/\\*\\.\\*\"|\"files\": \"/src/**/*.*\"|g' abaplint.jsonc",
     "auto_downport": "abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && npm run strip_trailing_ws && cp -r src node/downport && cp -f .github/abaplint/abap_702.jsonc abaplint.jsonc && npm run abaplintpathfix",
     "auto_app2abap": "node .github/app2abap/trans2abap.js",
+    "app2abap": "npm --prefix app run format && npm run auto_app2abap && npm run auto_abaplint",
     "auto_abaplint": "npx abaplint .github/abaplint/auto_abaplint_fix.jsonc --fix",
     "auto_transpile": "rm -rf node/output && cp node/srv/*.abap node/downport && abap_transpile ./node/setup/abap_transpile.json",
     "rename": "npm ci && abaplint .github/abaplint/rename_test.jsonc --rename",

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -18,9 +18,12 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
-             `  ["sap/ui/core/BusyIndicator", "sap/m/MessageBox"],` && |\n| &&
-             `  (BusyIndicator, MessageBox) => {` && |\n| &&
+    result = `// Keep this define multi-line: with a single dependency prettier would` && |\n| &&
+             `// collapse it onto one line and reindent the entire module body.` && |\n| &&
+             `// prettier-ignore` && |\n| &&
+             `sap.ui.define(` && |\n| &&
+             `  ["sap/ui/core/BusyIndicator"],` && |\n| &&
+             `  (BusyIndicator) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
              `    // Errors longer than this are truncated before being shown to the user,` && |\n| &&
@@ -391,7 +394,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          if (msg.includes("openui5") && msg.includes("script load error")) {` && |\n| &&
              `            oController.checkSDKcompatibility(e);` && |\n| &&
              `          } else {` && |\n| &&
-             `            MessageBox.error(e.toLocaleString());` && |\n| &&
+             `            this.responseError(e);` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
@@ -415,11 +418,11 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
+             |\n|.
+    result = result &&
              `      _getOrCreateErrorContainer() {` && |\n| &&
              `        const existing = document.getElementById("serverErrorContainer");` && |\n| &&
              `        if (existing) return existing;` && |\n| &&
-             |\n|.
-    result = result &&
              `` && |\n| &&
              `        const container = document.createElement("div");` && |\n| &&
              `        container.id = "serverErrorContainer";` && |\n| &&
@@ -442,11 +445,20 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        return container;` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
-             `      responseError(response) {` && |\n| &&
+             `      // Unified fatal-error overlay. Shown whenever the app reaches an` && |\n| &&
+             `      // unrecoverable state - a failed roundtrip (network, HTTP != 2xx, bad` && |\n| &&
+             `      // JSON, backend dump) or a client-side failure (invalid view XML,` && |\n| &&
+             `      // post-render crash, missing SDK module). The only way out is a restart,` && |\n| &&
+             `      // hence the Refresh / Logout actions. Built from raw DOM so it still` && |\n| &&
+             `      // works when the UI5 core itself is in a broken state.` && |\n| &&
+             `      // ``response`` may be a string or an Error object; ``title`` overrides the` && |\n| &&
+             `      // default header text.` && |\n| &&
+             `      responseError(response, title) {` && |\n| &&
              `        BusyIndicator.hide();` && |\n| &&
              `        z2ui5.isBusy = false;` && |\n| &&
              `` && |\n| &&
-             `        const full = String(response);` && |\n| &&
+             `        const full =` && |\n| &&
+             `          response && response.stack ? String(response.stack) : String(response);` && |\n| &&
              `        let errorMessage;` && |\n| &&
              `        if (full.length > ERROR_MAX_LENGTH) {` && |\n| &&
              `          errorMessage =` && |\n| &&
@@ -465,7 +477,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";` && |\n| &&
              `` && |\n| &&
              `        const h3 = document.createElement("h3");` && |\n| &&
-             `        h3.textContent = "Server Error - Please Restart The App";` && |\n| &&
+             `        h3.textContent = title || "Application Error - Please Restart The App";` && |\n| &&
              `        h3.style.cssText = "margin: 0";` && |\n| &&
              `        headerDiv.appendChild(h3);` && |\n| &&
              `` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -379,12 +379,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          runCallbacks(z2ui5.onAfterRendering);` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          logError("_processAfterRendering: unexpected error", e);` && |\n| &&
-             `          MessageBox.error(e.toLocaleString(), {` && |\n| &&
-             `            title: "Unexpected Error Occurred - App Terminated",` && |\n| &&
-             `            actions: [],` && |\n| &&
-             `            onClose: () =>` && |\n| &&
-             `              new mBusyDialog({ text: "Please Restart the App" }).open(),` && |\n| &&
-             `          });` && |\n| &&
+             `          Server.responseError(e, "Unexpected Error Occurred - App Terminated");` && |\n| &&
              `        } finally {` && |\n| &&
              `          BusyIndicator.hide();` && |\n| &&
              `          z2ui5.isBusy = false;` && |\n| &&
@@ -418,13 +413,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          const [attr, rowIdx, field] = parts;` && |\n| &&
              `          // Only a flat table cell (exactly attr/row/field) qualifies for a` && |\n| &&
              `          // delta. Deeper paths (e.g. tree tables: attr/row/<subtable>/<row>/<field>)` && |\n| &&
-             |\n|.
-    result = result &&
              `          // fall back to shipping the whole attribute, which the backend applies` && |\n| &&
              `          // via corresponding-based deserialization.` && |\n| &&
              `          const isRowField =` && |\n| &&
              `            parts.length === 3 && rowIdx !== "" && !isNaN(rowIdx);` && |\n| &&
              `          if (isRowField) {` && |\n| &&
+             |\n|.
+    result = result &&
              `            // Table cell change -> ship only the changed cell.` && |\n| &&
              `            if (!delta[attr] || !delta[attr].__delta) {` && |\n| &&
              `              delta[attr] = { __delta: {} };` && |\n| &&
@@ -820,13 +815,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          }` && |\n| &&
              `          const sep = path.indexOf("?") >= 0 ? "&" : "?";` && |\n| &&
              `          const bspKill = path + sep + "sap-sessioncmd=logoff";` && |\n| &&
-             |\n|.
-    result = result &&
              `          let done = false;` && |\n| &&
              `          const finish = () => {` && |\n| &&
              `            if (done) return;` && |\n| &&
              `            done = true;` && |\n| &&
              `            goToLogoutUrl();` && |\n| &&
+             |\n|.
+    result = result &&
              `          };` && |\n| &&
              `          try {` && |\n| &&
              `            const f = document.createElement("iframe");` && |\n| &&
@@ -1222,13 +1217,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `        const oModel = this._createViewModel();` && |\n| &&
              `        applyStoredSizeLimit(paramToViewKey[paramKey], oModel);` && |\n| &&
-             |\n|.
-    result = result &&
              `        if (oView) oView.setModel(oModel);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      async checkSDKcompatibility(err) {` && |\n| &&
              `        let gav;` && |\n| &&
+             |\n|.
+    result = result &&
              `        try {` && |\n| &&
              `          const info = await VersionInfo.load();` && |\n| &&
              `          gav = info.gav;` && |\n| &&
@@ -1240,12 +1235,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          // openui5 doesn't ship some sap.com modules - tell the user which` && |\n| &&
              `          // module is missing so they know to switch to SAPUI5.` && |\n| &&
              `          const missingModule = err && err._modules;` && |\n| &&
-             `          MessageBox.error(` && |\n| &&
+             `          Server.responseError(` && |\n| &&
              `            ``openui5 SDK is loaded, module: ${missingModule} is not available in openui5``,` && |\n| &&
              `          );` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        MessageBox.error(err.toLocaleString());` && |\n| &&
+             `        Server.responseError(err);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // Display a toast or message box. Triggered for S_MSG_TOAST and` && |\n| &&


### PR DESCRIPTION
## Summary

Two related changes:

### 1. Unify the fatal-error UI (`refactor`)
Previously, error situations surfaced through several different UIs depending on where they originated. This routes all **unrecoverable** errors through the existing full-screen error overlay (`Server.responseError`), so there is now **one** consistent "restart the app" error UI:

- `responseSuccess` catch (invalid view XML render) → overlay
- `_processAfterRendering` catch ("App Terminated") → overlay
- `checkSDKcompatibility` (missing openui5 module) → overlay

`responseError` now accepts an `Error` object (preferring its stack) and an optional title override. The neutral default title **"Application Error – Please Restart The App"** replaces the HTTP-specific "Server Error" wording, since the overlay now also serves client-side failures. It is built from raw DOM, so it keeps working even when the UI5 core itself is in a broken state.

**Intentionally kept separate / unchanged:**
- `z2ui5_cl_pop_error` — the developer-facing dialog for *recoverable*, app-handled exceptions.
- Validation/notification `MessageBox`es (invalid URL, offline) and the backend-driven `S_MSG_BOX` — these are not fatal, the app continues.

Net result: two error UIs with clear semantics — `z2ui5_cl_pop_error` ("handled, keep going") vs. the overlay ("app is dead, restart").

### 2. Keep regeneration diffs minimal (`chore`)
Running `auto_app2abap` alone emits **un-normalized** ABAP that drifts from the committed form in *every* `src/01/03/` file. The correct sequence (format → generate → abaplint normalize) only existed as three separate steps in `create_app2abap.yaml`, so partial runs produced noisy whitespace-only diffs across the whole embedded frontend.

- New **`npm run app2abap`** script chains all three steps exactly as CI does → only files whose `app/webapp/` source actually changed remain modified.
- Documented as the canonical regeneration command in `CLAUDE.md`.
- Added a `// prettier-ignore` convention for `sap.ui.define` headers, so changing a module dependency no longer reflows (reindents) an entire file. This PR's `Server.js` uses it — that's why dropping the unused `MessageBox` import stays a minimal diff instead of rewriting every line.

## Validation
- `npx abaplint` → **0 issues, 242 files**
- `prettier --check` on changed JS → clean
- `npm run app2abap` end-to-end → working tree clean apart from intended changes (no `src/01/03/` drift)
- Embedded `src/01/03/` constants regenerated via the pipeline (not hand-edited)

https://claude.ai/code/session_013eYQk8vLBdHC9be31TBVAC

---
_Generated by [Claude Code](https://claude.ai/code/session_013eYQk8vLBdHC9be31TBVAC)_