### PR TITLE
Refactor action method to separate interface

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -2,6 +2,7 @@ CLASS z2ui5_cl_core_client DEFINITION PUBLIC FINAL.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_client.
+    INTERFACES z2ui5_if_action.
 
     DATA mo_action TYPE REF TO z2ui5_cl_core_action.
 
@@ -34,6 +35,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
     mo_action = action.
     mo_srv_bind = NEW #( mo_action->mo_app ).
     mo_srv_event = NEW #( ).
+    z2ui5_if_client~action = me.
 
   ENDMETHOD.
 
@@ -43,7 +45,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD z2ui5_if_client~action.
+  METHOD z2ui5_if_action~gen.
 
     DATA lv_val TYPE string.
     lv_val = val.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -345,9 +345,9 @@ CLASS ltcl_test_client IMPLEMENTATION.
     DATA li_client TYPE REF TO z2ui5_if_client.
     li_client ?= mo_client.
 
-    li_client->action( val   = z2ui5_if_client=>cs_event-set_title
-                       t_arg = VALUE #( ( `My Title` ) ) ).
-    li_client->action( z2ui5_if_client=>cs_event-history_back ).
+    li_client->action->gen( val   = z2ui5_if_client=>cs_event-set_title
+                            t_arg = VALUE #( ( `My Title` ) ) ).
+    li_client->action->gen( z2ui5_if_client=>cs_event-history_back ).
 
     cl_abap_unit_assert=>assert_equals( exp = 2
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
@@ -365,7 +365,7 @@ CLASS ltcl_test_client IMPLEMENTATION.
     li_client ?= mo_client.
 
     TRY.
-        li_client->action( `EVT'); alert(1);//` ).
+        li_client->action->gen( `EVT'); alert(1);//` ).
       CATCH z2ui5_cx_util_error.
         lv_raised = abap_true.
     ENDTRY.
@@ -384,7 +384,7 @@ CLASS ltcl_test_client IMPLEMENTATION.
     li_client ?= mo_client.
 
     TRY.
-        li_client->action( `` ).
+        li_client->action->gen( `` ).
       CATCH z2ui5_cx_util_error.
         lv_raised = abap_true.
     ENDTRY.

--- a/src/02/z2ui5_if_action.intf.abap
+++ b/src/02/z2ui5_if_action.intf.abap
@@ -1,0 +1,9 @@
+INTERFACE z2ui5_if_action
+  PUBLIC.
+
+  METHODS gen
+    IMPORTING
+      val   TYPE clike
+      t_arg TYPE string_table OPTIONAL.
+
+ENDINTERFACE.

--- a/src/02/z2ui5_if_action.intf.xml
+++ b/src/02/z2ui5_if_action.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>Z2UI5_IF_ACTION</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abap2UI5 - action</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -223,10 +223,7 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val TYPE string.
 
-  METHODS action
-    IMPORTING
-      val   TYPE clike
-      t_arg TYPE string_table OPTIONAL.
+  DATA action TYPE REF TO z2ui5_if_action.
 
   METHODS check_on_event
     IMPORTING


### PR DESCRIPTION
## Summary

Extract the `action` method from `z2ui5_if_client` into a dedicated `z2ui5_if_action` interface, and expose it as a data attribute on the client. This improves separation of concerns and allows the action functionality to be independently implemented and tested.

## Changes

- **New interface `z2ui5_if_action`** with a single `gen()` method that accepts an event value and optional arguments
- **Updated `z2ui5_if_client`** to expose `action` as a `DATA` attribute (reference to `z2ui5_if_action`) instead of a direct method
- **Updated `z2ui5_cl_core_client`** to:
  - Implement both `z2ui5_if_client` and `z2ui5_if_action`
  - Initialize `z2ui5_if_client~action` to reference itself (`me`) in the constructor
  - Rename the method implementation from `z2ui5_if_client~action` to `z2ui5_if_action~gen`
- **Updated all call sites** in unit tests to use the new fluent syntax: `li_client->action->gen(...)` instead of `li_client->action(...)`

## Implementation Details

The refactoring maintains full backward compatibility in behavior while changing the API surface. The client now delegates action handling through composition rather than direct method invocation, enabling cleaner separation between the client interface and action generation logic.

https://claude.ai/code/session_0123tcSwjTWxoGTG6YossyaN