### PR TITLE
Add transport request management methods (create, release, copy, import, check status)

### DIFF
--- a/src/00/03/02/z2ui5_cl_util_api.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api.clas.abap
@@ -323,6 +323,41 @@ CLASS z2ui5_cl_util_api DEFINITION
       RETURNING
         VALUE(result) TYPE string ##NEEDED.
 
+    CLASS-METHODS tr_create
+      IMPORTING
+        text          TYPE clike
+        target        TYPE clike
+        type          TYPE clike DEFAULT `T`
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS tr_release
+      IMPORTING
+        trkorr       TYPE clike
+        ignore_locks TYPE abap_bool DEFAULT abap_true.
+
+    CLASS-METHODS tr_copy_objects
+      IMPORTING
+        source      TYPE clike
+        destination TYPE clike.
+
+    CLASS-METHODS tr_import
+      IMPORTING
+        trkorr         TYPE clike
+        target_system  TYPE clike
+        client         TYPE clike OPTIONAL
+        ignore_version TYPE abap_bool DEFAULT abap_true
+      RETURNING
+        VALUE(result)  TYPE i.
+
+    CLASS-METHODS tr_check_status
+      IMPORTING
+        trkorr   TYPE clike
+        system   TYPE clike
+      EXPORTING
+        imported TYPE abap_bool
+        rc       TYPE i.
+
 
   PROTECTED SECTION.
 
@@ -1100,6 +1135,120 @@ CLASS z2ui5_cl_util_api IMPLEMENTATION.
   METHOD context_get_sy.
 
     result = CORRESPONDING #( sy ).
+
+  ENDMETHOD.
+
+  METHOD tr_create.
+
+    " Create an empty transport request (default type `T` = transport of copies).
+    " Uses the released class CL_ADT_CTS_MANAGEMENT, available on standard ABAP
+    " (>= 7.51) and ABAP Cloud. Called dynamically so the source stays compilable
+    " on all targets - on releases where the class is missing a clean
+    " z2ui5_cx_util_error is raised instead of a short dump.
+    TRY.
+
+        DATA lr_header TYPE REF TO data.
+        FIELD-SYMBOLS <header> TYPE any.
+        FIELD-SYMBOLS <trkorr> TYPE any.
+        DATA lv_class TYPE string.
+
+        CREATE DATA lr_header TYPE (`TRWBO_REQUEST_HEADER`).
+        ASSIGN lr_header->* TO <header>.
+
+        lv_class = `CL_ADT_CTS_MANAGEMENT`.
+        CALL METHOD (lv_class)=>(`CREATE_EMPTY_REQUEST`)
+          EXPORTING
+            iv_type           = type
+            iv_text           = text
+            iv_target         = target
+          IMPORTING
+            es_request_header = <header>.
+
+        ASSIGN COMPONENT `TRKORR` OF STRUCTURE <header> TO <trkorr>.
+        result = <trkorr>.
+
+      CATCH cx_root INTO DATA(x).
+        RAISE EXCEPTION TYPE z2ui5_cx_util_error
+          EXPORTING
+            previous = x.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD tr_release.
+
+    " Release a transport request via the released CTS REST API
+    " (CL_CTS_REST_API_FACTORY). Works on standard ABAP and ABAP Cloud.
+    TRY.
+
+        DATA lo_api   TYPE REF TO object.
+        DATA lv_class TYPE string.
+
+        lv_class = `CL_CTS_REST_API_FACTORY`.
+        CALL METHOD (lv_class)=>(`CREATE_INSTANCE`)
+          RECEIVING
+            result = lo_api.
+
+        CALL METHOD lo_api->(`RELEASE`)
+          EXPORTING
+            iv_trkorr       = trkorr
+            iv_ignore_locks = ignore_locks.
+
+      CATCH cx_root INTO DATA(x).
+        RAISE EXCEPTION TYPE z2ui5_cx_util_error
+          EXPORTING
+            previous = x.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD tr_copy_objects.
+
+    IF context_check_abap_cloud( ).
+      z2ui5_cl_util_api_c=>tr_copy_objects( source = source destination = destination ).
+    ELSE.
+      z2ui5_cl_util_api_s=>tr_copy_objects( source = source destination = destination ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD tr_import.
+
+    IF context_check_abap_cloud( ).
+      result = z2ui5_cl_util_api_c=>tr_import(
+                 trkorr         = trkorr
+                 target_system  = target_system
+                 client         = client
+                 ignore_version = ignore_version ).
+    ELSE.
+      result = z2ui5_cl_util_api_s=>tr_import(
+                 trkorr         = trkorr
+                 target_system  = target_system
+                 client         = client
+                 ignore_version = ignore_version ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD tr_check_status.
+
+    IF context_check_abap_cloud( ).
+      z2ui5_cl_util_api_c=>tr_check_status(
+        EXPORTING
+          trkorr   = trkorr
+          system   = system
+        IMPORTING
+          imported = imported
+          rc       = rc ).
+    ELSE.
+      z2ui5_cl_util_api_s=>tr_check_status(
+        EXPORTING
+          trkorr   = trkorr
+          system   = system
+        IMPORTING
+          imported = imported
+          rc       = rc ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/00/03/02/z2ui5_cl_util_api_c.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_c.clas.abap
@@ -112,6 +112,28 @@ CLASS z2ui5_cl_util_api_c DEFINITION
       RETURNING
         VALUE(result) TYPE string ##NEEDED.
 
+    CLASS-METHODS tr_copy_objects
+      IMPORTING
+        source      TYPE clike
+        destination TYPE clike.
+
+    CLASS-METHODS tr_import
+      IMPORTING
+        trkorr         TYPE clike
+        target_system  TYPE clike
+        client         TYPE clike OPTIONAL
+        ignore_version TYPE abap_bool DEFAULT abap_true
+      RETURNING
+        VALUE(result)  TYPE i.
+
+    CLASS-METHODS tr_check_status
+      IMPORTING
+        trkorr   TYPE clike
+        system   TYPE clike
+      EXPORTING
+        imported TYPE abap_bool
+        rc       TYPE i.
+
 
   PROTECTED SECTION.
 
@@ -907,6 +929,35 @@ CLASS z2ui5_cl_util_api_c IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD bal_save.
+
+  ENDMETHOD.
+
+  METHOD tr_copy_objects.
+
+    " Copying objects between requests relies on the classic transport
+    " functions (TR_COPY_COMM) which are not released on ABAP Cloud.
+    RAISE EXCEPTION TYPE z2ui5_cx_util_error
+      EXPORTING
+        val = `tr_copy_objects is not supported on ABAP Cloud`.
+
+  ENDMETHOD.
+
+  METHOD tr_import.
+
+    " Importing transports via TMS (TMS_MGR_*) is not available on ABAP Cloud.
+    RAISE EXCEPTION TYPE z2ui5_cx_util_error
+      EXPORTING
+        val = `tr_import is not supported on ABAP Cloud`.
+
+  ENDMETHOD.
+
+  METHOD tr_check_status.
+
+    " Reading the transport log (TR_READ_GLOBAL_INFO_OF_REQUEST) is not
+    " available on ABAP Cloud.
+    RAISE EXCEPTION TYPE z2ui5_cx_util_error
+      EXPORTING
+        val = `tr_check_status is not supported on ABAP Cloud`.
 
   ENDMETHOD.
 

--- a/src/00/03/02/z2ui5_cl_util_api_s.clas.abap
+++ b/src/00/03/02/z2ui5_cl_util_api_s.clas.abap
@@ -112,6 +112,28 @@ CLASS z2ui5_cl_util_api_s DEFINITION
       RETURNING
         VALUE(result) TYPE string ##NEEDED.
 
+    CLASS-METHODS tr_copy_objects
+      IMPORTING
+        source      TYPE clike
+        destination TYPE clike.
+
+    CLASS-METHODS tr_import
+      IMPORTING
+        trkorr         TYPE clike
+        target_system  TYPE clike
+        client         TYPE clike OPTIONAL
+        ignore_version TYPE abap_bool DEFAULT abap_true
+      RETURNING
+        VALUE(result)  TYPE i.
+
+    CLASS-METHODS tr_check_status
+      IMPORTING
+        trkorr   TYPE clike
+        system   TYPE clike
+      EXPORTING
+        imported TYPE abap_bool
+        rc       TYPE i.
+
 
   PROTECTED SECTION.
 
@@ -908,6 +930,205 @@ CLASS z2ui5_cl_util_api_s IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD bal_save.
+
+  ENDMETHOD.
+
+  METHOD tr_copy_objects.
+
+    " Copy all objects/commands of a source request (and its tasks) into a
+    " target request via the classic transport functions. Called dynamically
+    " so the statement stays compilable on ABAP Cloud as well, even though the
+    " function modules only exist on-premise.
+    TRY.
+
+        DATA lr_headers TYPE REF TO data.
+        FIELD-SYMBOLS <headers> TYPE ANY TABLE.
+        FIELD-SYMBOLS <header>  TYPE any.
+        FIELD-SYMBOLS <trkorr>  TYPE any.
+        FIELD-SYMBOLS <strkorr> TYPE any.
+        DATA lv_fm TYPE string.
+
+        CREATE DATA lr_headers TYPE (`TRWBO_REQUEST_HEADERS`).
+        ASSIGN lr_headers->* TO <headers>.
+
+        lv_fm = `TR_READ_REQUEST_WITH_TASKS`.
+        CALL FUNCTION lv_fm
+          EXPORTING
+            iv_trkorr          = source
+          IMPORTING
+            et_request_headers = <headers>
+          EXCEPTIONS
+            invalid_input      = 1
+            OTHERS             = 2.
+        IF sy-subrc <> 0.
+          RAISE EXCEPTION TYPE z2ui5_cx_util_error
+            EXPORTING
+              val = `TR_READ_REQUEST_WITH_TASKS failed`.
+        ENDIF.
+
+        LOOP AT <headers> ASSIGNING <header>.
+
+          ASSIGN COMPONENT `TRKORR`  OF STRUCTURE <header> TO <trkorr>.
+          ASSIGN COMPONENT `STRKORR` OF STRUCTURE <header> TO <strkorr>.
+          IF <trkorr> <> source AND <strkorr> <> source.
+            CONTINUE.
+          ENDIF.
+
+          lv_fm = `TR_COPY_COMM`.
+          CALL FUNCTION lv_fm
+            EXPORTING
+              wi_dialog                = abap_false
+              wi_trkorr_from           = <trkorr>
+              wi_trkorr_to             = destination
+              wi_without_documentation = abap_false
+            EXCEPTIONS
+              OTHERS                   = 1.
+          IF sy-subrc <> 0.
+            RAISE EXCEPTION TYPE z2ui5_cx_util_error
+              EXPORTING
+                val = `TR_COPY_COMM failed`.
+          ENDIF.
+
+        ENDLOOP.
+
+      CATCH z2ui5_cx_util_error INTO DATA(lx_known).
+        RAISE EXCEPTION lx_known.
+      CATCH cx_root INTO DATA(x).
+        RAISE EXCEPTION TYPE z2ui5_cx_util_error
+          EXPORTING
+            previous = x.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD tr_import.
+
+    " Import a transport request into a target system via TMS. The target
+    " system may be given as `SYSTEM` or `SYSTEM.CLIENT`; an explicit client
+    " parameter takes precedence, otherwise the current client is used.
+    TRY.
+
+        DATA lv_system  TYPE c LENGTH 8.
+        DATA lv_client  TYPE c LENGTH 3.
+        DATA lv_retcode TYPE c LENGTH 4.
+        DATA lr_exc     TYPE REF TO data.
+        FIELD-SYMBOLS <exc> TYPE any.
+        DATA lv_fm TYPE string.
+
+        SPLIT target_system AT `.` INTO lv_system lv_client.
+        IF lv_client IS INITIAL.
+          IF client IS NOT INITIAL.
+            lv_client = client.
+          ELSE.
+            lv_client = sy-mandt.
+          ENDIF.
+        ENDIF.
+
+        CREATE DATA lr_exc TYPE (`STMSCALERT`).
+        ASSIGN lr_exc->* TO <exc>.
+
+        lv_fm = `TMS_MGR_REFRESH_IMPORT_QUEUES`.
+        CALL FUNCTION lv_fm
+          EXPORTING
+            iv_system    = lv_system
+            iv_monitor   = abap_true
+            iv_verbose   = abap_true
+          IMPORTING
+            es_exception = <exc>
+          EXCEPTIONS
+            OTHERS       = 99.
+        IF sy-subrc = 99.
+          RAISE EXCEPTION TYPE z2ui5_cx_util_error
+            EXPORTING
+              val = `TMS_MGR_REFRESH_IMPORT_QUEUES failed`.
+        ENDIF.
+
+        lv_fm = `TMS_MGR_IMPORT_TR_REQUEST`.
+        CALL FUNCTION lv_fm
+          EXPORTING
+            iv_system                  = lv_system
+            iv_request                 = trkorr
+            iv_client                  = lv_client
+            iv_ignore_cvers            = ignore_version
+          IMPORTING
+            ev_tp_ret_code             = lv_retcode
+          EXCEPTIONS
+            read_config_failed         = 1
+            table_of_requests_is_empty = 2
+            OTHERS                     = 3.
+        IF sy-subrc <> 0.
+          RAISE EXCEPTION TYPE z2ui5_cx_util_error
+            EXPORTING
+              val = `TMS_MGR_IMPORT_TR_REQUEST failed`.
+        ENDIF.
+
+        result = lv_retcode.
+
+      CATCH z2ui5_cx_util_error INTO DATA(lx_known).
+        RAISE EXCEPTION lx_known.
+      CATCH cx_root INTO DATA(x).
+        RAISE EXCEPTION TYPE z2ui5_cx_util_error
+          EXPORTING
+            previous = x.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD tr_check_status.
+
+    " Read the import status (imported flag + return code) of a request in a
+    " given system via the classic transport log API.
+    TRY.
+
+        DATA lr_settings TYPE REF TO data.
+        DATA lr_cofile   TYPE REF TO data.
+        DATA lr_sysline  TYPE REF TO data.
+        FIELD-SYMBOLS <settings> TYPE any.
+        FIELD-SYMBOLS <systems>  TYPE ANY TABLE.
+        FIELD-SYMBOLS <sysline>  TYPE any.
+        FIELD-SYMBOLS <cofile>   TYPE any.
+        FIELD-SYMBOLS <comp>     TYPE any.
+        DATA lv_fm TYPE string.
+
+        CREATE DATA lr_settings TYPE (`CTSLG_SETTINGS`).
+        ASSIGN lr_settings->* TO <settings>.
+        ASSIGN COMPONENT `SYSTEMS` OF STRUCTURE <settings> TO <systems>.
+
+        CREATE DATA lr_sysline LIKE LINE OF <systems>.
+        ASSIGN lr_sysline->* TO <sysline>.
+        <sysline> = system.
+        INSERT <sysline> INTO TABLE <systems>.
+
+        CREATE DATA lr_cofile TYPE (`CTSLG_COFILE`).
+        ASSIGN lr_cofile->* TO <cofile>.
+
+        lv_fm = `TR_READ_GLOBAL_INFO_OF_REQUEST`.
+        CALL FUNCTION lv_fm
+          EXPORTING
+            iv_trkorr   = trkorr
+            is_settings = <settings>
+          IMPORTING
+            es_cofile   = <cofile>.
+
+        ASSIGN COMPONENT `EXISTS` OF STRUCTURE <cofile> TO <comp>.
+        IF <comp> = abap_false.
+          RAISE EXCEPTION TYPE z2ui5_cx_util_error
+            EXPORTING
+              val = `request does not exist in target system`.
+        ENDIF.
+
+        ASSIGN COMPONENT `IMPORTED` OF STRUCTURE <cofile> TO <comp>.
+        imported = <comp>.
+        ASSIGN COMPONENT `RC` OF STRUCTURE <cofile> TO <comp>.
+        rc = <comp>.
+
+      CATCH z2ui5_cx_util_error INTO DATA(lx_known).
+        RAISE EXCEPTION lx_known.
+      CATCH cx_root INTO DATA(x).
+        RAISE EXCEPTION TYPE z2ui5_cx_util_error
+          EXPORTING
+            previous = x.
+    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary

Add comprehensive transport request (TR) management capabilities to the utility API, enabling programmatic creation, release, copying, importing, and status checking of transport requests. These methods work on both on-premise ABAP and ABAP Cloud, with graceful fallback to cloud-specific limitations where necessary.

## Key Changes

- **`tr_create()`** — Create empty transport requests using the released `CL_ADT_CTS_MANAGEMENT` class (available on ABAP 7.51+ and ABAP Cloud)
- **`tr_release()`** — Release transport requests via the released CTS REST API (`CL_CTS_REST_API_FACTORY`), works on both standard ABAP and ABAP Cloud
- **`tr_copy_objects()`** — Copy all objects/commands from a source request (and its tasks) into a target request using classic transport functions (`TR_READ_REQUEST_WITH_TASKS`, `TR_COPY_COMM`); on-premise only
- **`tr_import()`** — Import a transport request into a target system via TMS (`TMS_MGR_REFRESH_IMPORT_QUEUES`, `TMS_MGR_IMPORT_TR_REQUEST`); on-premise only
- **`tr_check_status()`** — Read import status (imported flag + return code) of a request in a given system via the transport log API (`TR_READ_GLOBAL_INFO_OF_REQUEST`); on-premise only

## Implementation Details

- **Three-class pattern:** Methods defined in public API (`z2ui5_cl_util_api`), with on-premise implementations in `z2ui5_cl_util_api_s` and cloud stubs in `z2ui5_cl_util_api_c`
- **Dynamic function/method calls:** All classic transport functions and internal classes are called dynamically via `CALL FUNCTION` and `CALL METHOD` to maintain compilability on ABAP Cloud where these APIs don't exist
- **Cloud limitations:** `tr_copy_objects()`, `tr_import()`, and `tr_check_status()` raise `z2ui5_cx_util_error` on ABAP Cloud with clear error messages
- **Robust error handling:** All methods wrap calls in TRY/CATCH blocks, converting exceptions to `z2ui5_cx_util_error` with context preservation
- **Dynamic type creation:** Uses `CREATE DATA` with type names as strings to instantiate internal structures (`TRWBO_REQUEST_HEADERS`, `CTSLG_SETTINGS`, `CTSLG_COFILE`, `STMSCALERT`) without hard dependencies
- **Field symbol assignment:** Leverages `ASSIGN COMPONENT` for safe, dynamic access to structure fields across different ABAP releases

## Target Use Cases

- Automated transport request lifecycle management in CI/CD pipelines
- Programmatic deployment workflows
- Transport request auditing and status monitoring

https://claude.ai/code/session_01CwQCcbZuUCbUdU4EXAjjUN