### PR TITLE
Cache struct attributes to improve binding performance

### DIFF
--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -648,6 +648,15 @@ CLASS z2ui5_cl_util DEFINITION
 
     CLASS-DATA mt_bool_cache TYPE HASHED TABLE OF ty_s_bool_cache WITH UNIQUE KEY absolute_name.
 
+    TYPES:
+      BEGIN OF ty_s_attri_cache,
+        absolute_name TYPE string,
+        o_struct      TYPE REF TO cl_abap_structdescr,
+        t_attri       TYPE cl_abap_structdescr=>component_table,
+      END OF ty_s_attri_cache.
+
+    CLASS-DATA mt_attri_cache TYPE HASHED TABLE OF ty_s_attri_cache WITH UNIQUE KEY absolute_name.
+
     CLASS-METHODS filter_get_sql_cond_by_range
       IMPORTING
         fieldname     TYPE clike
@@ -1261,6 +1270,16 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
         lo_struct ?= lo_type.
     ENDCASE.
 
+    " descriptor instances are singletons per type, so the identity check
+    " guards against absolute names reused by other (local/anonymous) types
+    DATA(lv_absolute_name) = CONV string( lo_struct->absolute_name ).
+    READ TABLE mt_attri_cache REFERENCE INTO DATA(lr_cache)
+         WITH TABLE KEY absolute_name = lv_absolute_name.
+    IF sy-subrc = 0 AND lr_cache->o_struct = lo_struct.
+      result = lr_cache->t_attri.
+      RETURN.
+    ENDIF.
+
     DATA(comps) = lo_struct->get_components( ).
 
     LOOP AT comps REFERENCE INTO DATA(lr_comp).
@@ -1272,6 +1291,15 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
         APPEND LINES OF lt_attri TO result.
       ENDIF.
     ENDLOOP.
+
+    IF lr_cache IS BOUND.
+      lr_cache->o_struct = lo_struct.
+      lr_cache->t_attri  = result.
+    ELSE.
+      INSERT VALUE #( absolute_name = lv_absolute_name
+                      o_struct      = lo_struct
+                      t_attri       = result ) INTO TABLE mt_attri_cache.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -43,20 +43,6 @@ CLASS z2ui5_cl_core_srv_bind DEFINITION PUBLIC FINAL.
     METHODS check_raise_new.
 
   PRIVATE SECTION.
-    TYPES:
-      BEGIN OF ty_s_attri_cache,
-        type_name TYPE string,
-        t_attri   TYPE cl_abap_structdescr=>component_table,
-      END OF ty_s_attri_cache.
-    TYPES ty_t_attri_cache TYPE HASHED TABLE OF ty_s_attri_cache WITH UNIQUE KEY type_name.
-
-    DATA mt_attri_cache TYPE ty_t_attri_cache.
-
-    METHODS rtti_get_t_attri_cached
-      IMPORTING
-        val           TYPE REF TO data
-      RETURNING
-        VALUE(result) TYPE cl_abap_structdescr=>component_table.
 ENDCLASS.
 
 
@@ -73,7 +59,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     ASSIGN ms_config-tab->* TO <tab>.
     ASSIGN <tab>[ ms_config-tab_index ] TO <row>.
 
-    DATA(lt_attri) = rtti_get_t_attri_cached( ms_config-tab ).
+    DATA(lt_attri) = z2ui5_cl_util=>rtti_get_t_attri_by_any( ms_config-tab ).
     LOOP AT lt_attri ASSIGNING FIELD-SYMBOL(<comp>).
 
       ASSIGN COMPONENT <comp>-name OF STRUCTURE <row> TO <ele>.
@@ -90,23 +76,6 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     RAISE EXCEPTION TYPE z2ui5_cx_util_error
       EXPORTING
         val = `BINDING_ERROR_TAB_CELL_LEVEL - No class attribute for binding found - Please check if the bound values are public attributes of your class`.
-
-  ENDMETHOD.
-
-  METHOD rtti_get_t_attri_cached.
-
-    DATA(lv_type_name) = CONV string(
-        cl_abap_typedescr=>describe_by_data_ref( val )->absolute_name ).
-
-    READ TABLE mt_attri_cache REFERENCE INTO DATA(lr_cache)
-         WITH TABLE KEY type_name = lv_type_name.
-    IF sy-subrc <> 0.
-      INSERT VALUE #( type_name = lv_type_name
-                      t_attri   = z2ui5_cl_util=>rtti_get_t_attri_by_any( val ) )
-             INTO TABLE mt_attri_cache REFERENCE INTO lr_cache.
-    ENDIF.
-
-    result = lr_cache->t_attri.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -43,6 +43,20 @@ CLASS z2ui5_cl_core_srv_bind DEFINITION PUBLIC FINAL.
     METHODS check_raise_new.
 
   PRIVATE SECTION.
+    TYPES:
+      BEGIN OF ty_s_attri_cache,
+        type_name TYPE string,
+        t_attri   TYPE cl_abap_structdescr=>component_table,
+      END OF ty_s_attri_cache.
+    TYPES ty_t_attri_cache TYPE HASHED TABLE OF ty_s_attri_cache WITH UNIQUE KEY type_name.
+
+    DATA mt_attri_cache TYPE ty_t_attri_cache.
+
+    METHODS rtti_get_t_attri_cached
+      IMPORTING
+        val           TYPE REF TO data
+      RETURNING
+        VALUE(result) TYPE cl_abap_structdescr=>component_table.
 ENDCLASS.
 
 
@@ -59,7 +73,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     ASSIGN ms_config-tab->* TO <tab>.
     ASSIGN <tab>[ ms_config-tab_index ] TO <row>.
 
-    DATA(lt_attri) = z2ui5_cl_util=>rtti_get_t_attri_by_any( ms_config-tab ).
+    DATA(lt_attri) = rtti_get_t_attri_cached( ms_config-tab ).
     LOOP AT lt_attri ASSIGNING FIELD-SYMBOL(<comp>).
 
       ASSIGN COMPONENT <comp>-name OF STRUCTURE <row> TO <ele>.
@@ -76,6 +90,23 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     RAISE EXCEPTION TYPE z2ui5_cx_util_error
       EXPORTING
         val = `BINDING_ERROR_TAB_CELL_LEVEL - No class attribute for binding found - Please check if the bound values are public attributes of your class`.
+
+  ENDMETHOD.
+
+  METHOD rtti_get_t_attri_cached.
+
+    DATA(lv_type_name) = CONV string(
+        cl_abap_typedescr=>describe_by_data_ref( val )->absolute_name ).
+
+    READ TABLE mt_attri_cache REFERENCE INTO DATA(lr_cache)
+         WITH TABLE KEY type_name = lv_type_name.
+    IF sy-subrc <> 0.
+      INSERT VALUE #( type_name = lv_type_name
+                      t_attri   = z2ui5_cl_util=>rtti_get_t_attri_by_any( val ) )
+             INTO TABLE mt_attri_cache REFERENCE INTO lr_cache.
+    ENDIF.
+
+    result = lr_cache->t_attri.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Adds caching of ABAP struct attribute metadata to avoid repeated reflection calls during data binding operations. This improves performance when the same struct type is bound multiple times across roundtrips.

## Key Changes
- **New cache structure** (`ty_s_attri_cache`): Stores struct descriptor, absolute name, and resolved component table
- **New class-level cache** (`mt_attri_cache`): Hashed table indexed by absolute name for O(1) lookups
- **Cache validation**: Uses identity check (`o_struct = lo_struct`) to guard against absolute name reuse by different local/anonymous types
- **Cache population**: On first access, struct components are resolved and cached; on subsequent accesses, cached components are returned immediately
- **Cache updates**: Existing cache entries are updated in-place; new entries are inserted as needed

## Implementation Details
The caching is integrated into the struct attribute resolution logic:
1. Before calling `get_components()`, check if the struct is already cached by absolute name
2. Verify the cached descriptor is the same object (identity check) to handle name collisions
3. If cache hit, return cached components immediately
4. If cache miss, resolve components normally, then store in cache for future use

This optimization is particularly beneficial for data binding scenarios where the same struct types are processed repeatedly across multiple roundtrips.

https://claude.ai/code/session_012qmhfAX5EXwupmhKPqoHgR