### PR TITLE
Extract error logging into shared Logger module

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -6,19 +6,12 @@ sap.ui.define(
     "sap/ui/VersionInfo",
     "z2ui5/cc/DebugTool",
     "sap/ui/core/Theming",
+    "z2ui5/cc/Logger",
   ],
-  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming) => {
+  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming, Logger) => {
     "use strict";
 
-    // Append an entry to the global error log. We create the array on first use.
-    function logError(message, error) {
-      if (!z2ui5.errors) z2ui5.errors = [];
-      z2ui5.errors.push({
-        message: message,
-        error: error,
-        ts: new Date().toISOString(),
-      });
-    }
+    const logError = Logger.logError;
 
     return UIComponent.extend("z2ui5.Component", {
       metadata: {

--- a/app/webapp/cc/DebugTool.js
+++ b/app/webapp/cc/DebugTool.js
@@ -3,19 +3,12 @@ sap.ui.define(
     "sap/ui/core/Control",
     "sap/ui/core/Fragment",
     "sap/ui/model/json/JSONModel",
+    "z2ui5/cc/Logger",
   ],
-  (Control, Fragment, JSONModel) => {
+  (Control, Fragment, JSONModel, Logger) => {
     "use strict";
 
-    // Append an entry to the global error log. We create the array on first use.
-    function logError(message, error) {
-      if (!z2ui5.errors) z2ui5.errors = [];
-      z2ui5.errors.push({
-        message: message,
-        error: error,
-        ts: new Date().toISOString(),
-      });
-    }
+    const logError = Logger.logError;
 
     // Pretty-print any value (object, array, primitive) as indented JSON.
     // `null` is used as a fallback so undefined values still produce output.

--- a/app/webapp/cc/Logger.js
+++ b/app/webapp/cc/Logger.js
@@ -1,0 +1,16 @@
+sap.ui.define([], () => {
+  "use strict";
+
+  // Append an entry to the global error log. We create the array on first use.
+  // `error` is only added when defined, so the log never contains a stray
+  // `error: undefined` field.
+  function logError(message, error) {
+    if (typeof z2ui5 === "undefined") return;
+    if (!z2ui5.errors) z2ui5.errors = [];
+    const entry = { message: message, ts: new Date().toISOString() };
+    if (error !== undefined) entry.error = error;
+    z2ui5.errors.push(entry);
+  }
+
+  return { logError: logError };
+});

--- a/app/webapp/cc/Server.js
+++ b/app/webapp/cc/Server.js
@@ -1,9 +1,9 @@
-// Keep this define multi-line: with a single dependency prettier would
-// collapse it onto one line and reindent the entire module body.
+// Keep this define multi-line so prettier does not reindent the entire
+// module body.
 // prettier-ignore
 sap.ui.define(
-  ["sap/ui/core/BusyIndicator"],
-  (BusyIndicator) => {
+  ["sap/ui/core/BusyIndicator", "z2ui5/cc/Logger"],
+  (BusyIndicator, Logger) => {
     "use strict";
 
     // Errors longer than this are truncated before being shown to the user,
@@ -11,15 +11,7 @@ sap.ui.define(
     const ERROR_MAX_LENGTH = 50000;
     const _MSG_TYPES = Object.freeze(["S_MSG_TOAST", "S_MSG_BOX"]);
 
-    // Append an entry to the global error log. We create the array on first use.
-    function logError(message, error) {
-      if (!z2ui5.errors) z2ui5.errors = [];
-      z2ui5.errors.push({
-        message: message,
-        error: error,
-        ts: new Date().toISOString(),
-      });
-    }
+    const logError = Logger.logError;
 
     // A usable stateful session id ("sap-contextid"). We must never put a
     // missing value on the wire: an empty or - via string coercion of a

--- a/app/webapp/controller/App.controller.js
+++ b/app/webapp/controller/App.controller.js
@@ -1,5 +1,19 @@
-// Append an entry to the global error log. We create the array on first use.
+// Append an entry to the global error log. This delegates to the shared
+// z2ui5/cc/Logger module, which is loaded transitively via Server / View1.
+// The control definitions below live in their own sap.ui.define blocks and
+// share this single file-scope helper, so we resolve the module lazily
+// (the lookup only succeeds once it is loaded) and keep an inline fallback
+// for the rare case a control logs before the module is available.
+let _loggerImpl;
 function _logError(message, error) {
+  if (!_loggerImpl) {
+    const Logger = sap.ui.require("z2ui5/cc/Logger");
+    if (Logger) _loggerImpl = Logger.logError;
+  }
+  if (_loggerImpl) {
+    _loggerImpl(message, error);
+    return;
+  }
   if (!z2ui5.errors) z2ui5.errors = [];
   const entry = { message: message, ts: new Date().toISOString() };
   if (error !== undefined) entry.error = error;

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -15,6 +15,7 @@ sap.ui.define(
     "sap/ui/core/routing/HashChanger",
     "sap/ui/util/Storage",
     "sap/ui/core/Element",
+    "z2ui5/cc/Logger",
   ],
   (
     Controller,
@@ -32,6 +33,7 @@ sap.ui.define(
     HashChanger,
     Storage,
     Element,
+    Logger,
   ) => {
     "use strict";
 
@@ -39,13 +41,7 @@ sap.ui.define(
     // Small utility helpers (module-private)
     // ------------------------------------------------------------------
 
-    // Append an entry to the global error log. We create the array on first use.
-    function logError(message, error) {
-      if (!z2ui5.errors) z2ui5.errors = [];
-      const entry = { message: message, ts: new Date().toISOString() };
-      if (error !== undefined) entry.error = error;
-      z2ui5.errors.push(entry);
-    }
+    const logError = Logger.logError;
 
     // Run every callback in `arr`, swallowing individual failures so one bad
     // callback cannot break the whole event sequence.

--- a/src/01/03/z2ui5_cl_app_app_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_js.clas.abap
@@ -18,8 +18,22 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `// Append an entry to the global error log. We create the array on first use.` && |\n| &&
+    result = `// Append an entry to the global error log. This delegates to the shared` && |\n| &&
+             `// z2ui5/cc/Logger module, which is loaded transitively via Server / View1.` && |\n| &&
+             `// The control definitions below live in their own sap.ui.define blocks and` && |\n| &&
+             `// share this single file-scope helper, so we resolve the module lazily` && |\n| &&
+             `// (the lookup only succeeds once it is loaded) and keep an inline fallback` && |\n| &&
+             `// for the rare case a control logs before the module is available.` && |\n| &&
+             `let _loggerImpl;` && |\n| &&
              `function _logError(message, error) {` && |\n| &&
+             `  if (!_loggerImpl) {` && |\n| &&
+             `    const Logger = sap.ui.require("z2ui5/cc/Logger");` && |\n| &&
+             `    if (Logger) _loggerImpl = Logger.logError;` && |\n| &&
+             `  }` && |\n| &&
+             `  if (_loggerImpl) {` && |\n| &&
+             `    _loggerImpl(message, error);` && |\n| &&
+             `    return;` && |\n| &&
+             `  }` && |\n| &&
              `  if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
              `  const entry = { message: message, ts: new Date().toISOString() };` && |\n| &&
              `  if (error !== undefined) entry.error = error;` && |\n| &&
@@ -404,6 +418,8 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `    setBackend() {` && |\n| &&
              `      const items = this.getProperty("items");` && |\n| &&
              `      if (!items) return;` && |\n| &&
+             |\n|.
+    result = result &&
              `      try {` && |\n| &&
              `        // Resolve the binding path so we can mark only changed entries` && |\n| &&
              `        // as dirty in xxChangedPaths.` && |\n| &&
@@ -418,8 +434,6 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `          const scrollTop = this._getScrollTop(item);` && |\n| &&
              `          if (item.V !== scrollTop) {` && |\n| &&
              `            item.V = scrollTop;` && |\n| &&
-             |\n|.
-    result = result &&
              `            if (bindingPath && z2ui5.xxChangedPaths) {` && |\n| &&
              `              z2ui5.xxChangedPaths.add(``${bindingPath}/${index}/V``);` && |\n| &&
              `            }` && |\n| &&
@@ -806,6 +820,8 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `          tooltip: {` && |\n| &&
              `            type: "string",` && |\n| &&
              `            defaultValue: "",` && |\n| &&
+             |\n|.
+    result = result &&
              `          },` && |\n| &&
              `          fileType: {` && |\n| &&
              `            type: "string",` && |\n| &&
@@ -820,8 +836,6 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `            defaultValue: "",` && |\n| &&
              `          },` && |\n| &&
              `          style: {` && |\n| &&
-             |\n|.
-    result = result &&
              `            type: "string",` && |\n| &&
              `            defaultValue: "",` && |\n| &&
              `          },` && |\n| &&
@@ -1208,6 +1222,8 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `        this.setProperty("rangeData", enrichedRanges);` && |\n| &&
              `        this.fireChange();` && |\n| &&
              `      },` && |\n| &&
+             |\n|.
+    result = result &&
              `      async setRangeData(aRangeData) {` && |\n| &&
              `        this.setProperty("rangeData", aRangeData);` && |\n| &&
              `        try {` && |\n| &&
@@ -1222,8 +1238,6 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `            for (const [key, value] of Object.entries(oRangeData)) {` && |\n| &&
              `              const lower = key.toLowerCase();` && |\n| &&
              `              const finalKey = lower === "keyfield" ? "keyField" : lower;` && |\n| &&
-             |\n|.
-    result = result &&
              `              out[finalKey] = value;` && |\n| &&
              `            }` && |\n| &&
              `            return out;` && |\n| &&
@@ -1610,6 +1624,8 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `` && |\n| &&
              `        for (const oCol of columns) {` && |\n| &&
              `          if (` && |\n| &&
+             |\n|.
+    result = result &&
              `            oCol.getFilterProperty &&` && |\n| &&
              `            oCol.getFilterProperty() === sProperty` && |\n| &&
              `          ) {` && |\n| &&
@@ -1624,8 +1640,6 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `      try {` && |\n| &&
              `        const oTable = this._getTable();` && |\n| &&
              `        if (!oTable) return;` && |\n| &&
-             |\n|.
-    result = result &&
              `        this._applyWhenRendered(oTable, () => applyFn(oTable));` && |\n| &&
              `      } catch (e) {` && |\n| &&
              `        _logError(errorMsg, e);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -26,19 +26,12 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `    "sap/ui/VersionInfo",` && |\n| &&
              `    "z2ui5/cc/DebugTool",` && |\n| &&
              `    "sap/ui/core/Theming",` && |\n| &&
+             `    "z2ui5/cc/Logger",` && |\n| &&
              `  ],` && |\n| &&
-             `  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming) => {` && |\n| &&
+             `  (UIComponent, Models, Server, VersionInfo, DebugTool, Theming, Logger) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
+             `    const logError = Logger.logError;` && |\n| &&
              `` && |\n| &&
              `    return UIComponent.extend("z2ui5.Component", {` && |\n| &&
              `      metadata: {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
@@ -23,19 +23,12 @@ CLASS z2ui5_cl_app_debugtool_js IMPLEMENTATION.
              `    "sap/ui/core/Control",` && |\n| &&
              `    "sap/ui/core/Fragment",` && |\n| &&
              `    "sap/ui/model/json/JSONModel",` && |\n| &&
+             `    "z2ui5/cc/Logger",` && |\n| &&
              `  ],` && |\n| &&
-             `  (Control, Fragment, JSONModel) => {` && |\n| &&
+             `  (Control, Fragment, JSONModel, Logger) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
+             `    const logError = Logger.logError;` && |\n| &&
              `` && |\n| &&
              `    // Pretty-print any value (object, array, primitive) as indented JSON.` && |\n| &&
              `    // ``null`` is used as a fallback so undefined values still produce output.` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_logger_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_logger_js.clas.abap
@@ -1,0 +1,42 @@
+CLASS z2ui5_cl_app_logger_js DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      RETURNING
+        VALUE(result) TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_app_logger_js IMPLEMENTATION.
+
+  METHOD get.
+
+    result = `sap.ui.define([], () => {` && |\n| &&
+             `  "use strict";` && |\n| &&
+             `` && |\n| &&
+             `  // Append an entry to the global error log. We create the array on first use.` && |\n| &&
+             `  // ``error`` is only added when defined, so the log never contains a stray` && |\n| &&
+             `  // ``error: undefined`` field.` && |\n| &&
+             `  function logError(message, error) {` && |\n| &&
+             `    if (typeof z2ui5 === "undefined") return;` && |\n| &&
+             `    if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
+             `    const entry = { message: message, ts: new Date().toISOString() };` && |\n| &&
+             `    if (error !== undefined) entry.error = error;` && |\n| &&
+             `    z2ui5.errors.push(entry);` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
+             `  return { logError: logError };` && |\n| &&
+             `});` && |\n| &&
+             `` && |\n| &&
+              ``.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/03/z2ui5_cl_app_logger_js.clas.xml
+++ b/src/01/03/z2ui5_cl_app_logger_js.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_APP_LOGGER_JS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Z2UI5_CL_APP_LOGGER_JS (generated)</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -18,12 +18,12 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `// Keep this define multi-line: with a single dependency prettier would` && |\n| &&
-             `// collapse it onto one line and reindent the entire module body.` && |\n| &&
+    result = `// Keep this define multi-line so prettier does not reindent the entire` && |\n| &&
+             `// module body.` && |\n| &&
              `// prettier-ignore` && |\n| &&
              `sap.ui.define(` && |\n| &&
-             `  ["sap/ui/core/BusyIndicator"],` && |\n| &&
-             `  (BusyIndicator) => {` && |\n| &&
+             `  ["sap/ui/core/BusyIndicator", "z2ui5/cc/Logger"],` && |\n| &&
+             `  (BusyIndicator, Logger) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
              `    // Errors longer than this are truncated before being shown to the user,` && |\n| &&
@@ -31,15 +31,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `    const ERROR_MAX_LENGTH = 50000;` && |\n| &&
              `    const _MSG_TYPES = Object.freeze(["S_MSG_TOAST", "S_MSG_BOX"]);` && |\n| &&
              `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      z2ui5.errors.push({` && |\n| &&
-             `        message: message,` && |\n| &&
-             `        error: error,` && |\n| &&
-             `        ts: new Date().toISOString(),` && |\n| &&
-             `      });` && |\n| &&
-             `    }` && |\n| &&
+             `    const logError = Logger.logError;` && |\n| &&
              `` && |\n| &&
              `    // A usable stateful session id ("sap-contextid"). We must never put a` && |\n| &&
              `    // missing value on the wire: an empty or - via string coercion of a` && |\n| &&
@@ -418,8 +410,6 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
-             |\n|.
-    result = result &&
              `      _getOrCreateErrorContainer() {` && |\n| &&
              `        const existing = document.getElementById("serverErrorContainer");` && |\n| &&
              `        if (existing) return existing;` && |\n| &&
@@ -428,6 +418,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        container.id = "serverErrorContainer";` && |\n| &&
              `        container.style.cssText = ``` && |\n| &&
              `          position: fixed;` && |\n| &&
+             |\n|.
+    result = result &&
              `          top: 50%;` && |\n| &&
              `          left: 50%;` && |\n| &&
              `          transform: translate(-50%, -50%);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -35,6 +35,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `    "sap/ui/core/routing/HashChanger",` && |\n| &&
              `    "sap/ui/util/Storage",` && |\n| &&
              `    "sap/ui/core/Element",` && |\n| &&
+             `    "z2ui5/cc/Logger",` && |\n| &&
              `  ],` && |\n| &&
              `  (` && |\n| &&
              `    Controller,` && |\n| &&
@@ -52,6 +53,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `    HashChanger,` && |\n| &&
              `    Storage,` && |\n| &&
              `    Element,` && |\n| &&
+             `    Logger,` && |\n| &&
              `  ) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
@@ -59,13 +61,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `    // Small utility helpers (module-private)` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
-             `    // Append an entry to the global error log. We create the array on first use.` && |\n| &&
-             `    function logError(message, error) {` && |\n| &&
-             `      if (!z2ui5.errors) z2ui5.errors = [];` && |\n| &&
-             `      const entry = { message: message, ts: new Date().toISOString() };` && |\n| &&
-             `      if (error !== undefined) entry.error = error;` && |\n| &&
-             `      z2ui5.errors.push(entry);` && |\n| &&
-             `    }` && |\n| &&
+             `    const logError = Logger.logError;` && |\n| &&
              `` && |\n| &&
              `    // Run every callback in ``arr``, swallowing individual failures so one bad` && |\n| &&
              `    // callback cannot break the whole event sequence.` && |\n| &&
@@ -418,12 +414,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          const isRowField =` && |\n| &&
              `            parts.length === 3 && rowIdx !== "" && !isNaN(rowIdx);` && |\n| &&
              `          if (isRowField) {` && |\n| &&
-             |\n|.
-    result = result &&
              `            // Table cell change -> ship only the changed cell.` && |\n| &&
              `            if (!delta[attr] || !delta[attr].__delta) {` && |\n| &&
              `              delta[attr] = { __delta: {} };` && |\n| &&
              `            }` && |\n| &&
+             |\n|.
+    result = result &&
              `            const attrDelta = delta[attr].__delta;` && |\n| &&
              `            if (!attrDelta[rowIdx]) attrDelta[rowIdx] = {};` && |\n| &&
              `            const row = xx[attr] && xx[attr][+rowIdx];` && |\n| &&
@@ -820,12 +816,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            if (done) return;` && |\n| &&
              `            done = true;` && |\n| &&
              `            goToLogoutUrl();` && |\n| &&
-             |\n|.
-    result = result &&
              `          };` && |\n| &&
              `          try {` && |\n| &&
              `            const f = document.createElement("iframe");` && |\n| &&
              `            f.style.display = "none";` && |\n| &&
+             |\n|.
+    result = result &&
              `            f.src = bspKill;` && |\n| &&
              `            f.addEventListener("load", finish);` && |\n| &&
              `            document.body.appendChild(f);` && |\n| &&
@@ -1222,12 +1218,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `      async checkSDKcompatibility(err) {` && |\n| &&
              `        let gav;` && |\n| &&
-             |\n|.
-    result = result &&
              `        try {` && |\n| &&
              `          const info = await VersionInfo.load();` && |\n| &&
              `          gav = info.gav;` && |\n| &&
              `        } catch (e) {` && |\n| &&
+             |\n|.
+    result = result &&
              `          logError("checkSDKcompatibility: VersionInfo.load failed", e);` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -139,6 +139,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
              |      "z2ui5/controller/App.controller.js": function()\{{ z2ui5_cl_app_app_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/view/View1.view.xml": '{ z2ui5_cl_app_view1_xml=>get( ) }',| && |\n| &&
              |      "z2ui5/controller/View1.controller.js": function()\{{ z2ui5_cl_app_view1_js=>get( ) }\},| && |\n| &&
+             |      "z2ui5/cc/Logger.js": function()\{{ z2ui5_cl_app_logger_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/Server.js": function()\{{ z2ui5_cl_app_server_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/DebugTool.fragment.xml": '{ z2ui5_cl_app_debugtool_xml=>get( ) }',| && |\n| &&
              |      "z2ui5/cc/DebugTool.js": function()\{{ z2ui5_cl_app_debugtool_js=>get( ) }\},| && |\n| &&


### PR DESCRIPTION
## Summary

Refactor error logging across the framework by extracting the `logError` function into a dedicated, reusable `Logger` module (`z2ui5/cc/Logger`). This eliminates code duplication and provides a single source of truth for error handling.

## Key Changes

- **New Logger module** (`z2ui5_cl_app_logger_js` / `app/webapp/cc/Logger.js`): Centralized error logging with safe handling of undefined `z2ui5` global and conditional `error` field inclusion
- **Server module** (`z2ui5_cl_app_server_js` / `app/webapp/cc/Server.js`): Now imports and uses `Logger.logError` instead of defining its own implementation
- **View1 controller** (`z2ui5_cl_app_view1_js` / `app/webapp/controller/View1.controller.js`): Imports Logger and delegates to shared implementation
- **Component** (`z2ui5_cl_app_component_js` / `app/webapp/Component.js`): Imports Logger and uses shared implementation
- **DebugTool** (`z2ui5_cl_app_debugtool_js` / `app/webapp/cc/DebugTool.js`): Imports Logger and uses shared implementation
- **App controller** (`z2ui5_cl_app_app_js` / `app/webapp/controller/App.controller.js`): Implements lazy-loading fallback pattern via `sap.ui.require()` to handle cases where Logger may not yet be loaded, with inline fallback for early errors

## Implementation Details

- The Logger module is loaded transitively through Server and View1, ensuring availability for most code paths
- App controller uses lazy resolution (`sap.ui.require`) to safely handle the rare case where a control logs before the Logger module is available
- Logger safely checks for `z2ui5` global existence before attempting to log, preventing errors in edge cases
- Error entries only include the `error` field when defined, avoiding `error: undefined` in the log
- All error timestamps use ISO 8601 format (`toISOString()`)
- Minor formatting adjustments to generated JavaScript code for consistency

https://claude.ai/code/session_01Y2gvzwEt5kogxJkY8R74L7