### PR TITLE
fix: remove hard dependency on sap/ui/core/Theming for UI5 < 1.118

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -5,7 +5,6 @@ sap.ui.define(
     "z2ui5/core/Server",
     "sap/ui/VersionInfo",
     "z2ui5/core/DebugTool",
-    "sap/ui/core/Theming",
     "z2ui5/core/Lib",
     "z2ui5/core/AppState",
     "z2ui5/Util",
@@ -16,7 +15,6 @@ sap.ui.define(
     Server,
     VersionInfo,
     DebugTool,
-    Theming,
     Lib,
     AppState,
     DateUtil,
@@ -151,12 +149,30 @@ sap.ui.define(
               VERSION: info.version,
               BUILDTIMESTAMP: info.buildTimestamp,
               GAV: info.gav,
-              THEME: Theming ? Theming.getTheme() : "",
+              THEME: this._getTheme(),
             };
           }
         } catch (e) {
           Lib.logError("Component: VersionInfo load failed", e);
         }
+      },
+
+      _getTheme() {
+        // sap/ui/core/Theming only exists since UI5 1.118, so it must not be
+        // a hard dependency of this module - older bootstraps (e.g. 1.108)
+        // would fail to load the component. On 1.118+ the core itself loads
+        // Theming, so the probing require finds it; otherwise fall back to
+        // the legacy Configuration API.
+        try {
+          const Theming = sap.ui.require("sap/ui/core/Theming");
+          if (Theming?.getTheme) return Theming.getTheme();
+          if (sap.ui.getCore) {
+            return sap.ui.getCore().getConfiguration().getTheme();
+          }
+        } catch (e) {
+          Lib.logError("Component: reading theme failed", e);
+        }
+        return "";
       },
 
       _onUnload() {

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -25,7 +25,6 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `    "z2ui5/core/Server",` && |\n| &&
              `    "sap/ui/VersionInfo",` && |\n| &&
              `    "z2ui5/core/DebugTool",` && |\n| &&
-             `    "sap/ui/core/Theming",` && |\n| &&
              `    "z2ui5/core/Lib",` && |\n| &&
              `    "z2ui5/core/AppState",` && |\n| &&
              `    "z2ui5/Util",` && |\n| &&
@@ -36,7 +35,6 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `    Server,` && |\n| &&
              `    VersionInfo,` && |\n| &&
              `    DebugTool,` && |\n| &&
-             `    Theming,` && |\n| &&
              `    Lib,` && |\n| &&
              `    AppState,` && |\n| &&
              `    DateUtil,` && |\n| &&
@@ -171,12 +169,30 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `              VERSION: info.version,` && |\n| &&
              `              BUILDTIMESTAMP: info.buildTimestamp,` && |\n| &&
              `              GAV: info.gav,` && |\n| &&
-             `              THEME: Theming ? Theming.getTheme() : "",` && |\n| &&
+             `              THEME: this._getTheme(),` && |\n| &&
              `            };` && |\n| &&
              `          }` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          Lib.logError("Component: VersionInfo load failed", e);` && |\n| &&
              `        }` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      _getTheme() {` && |\n| &&
+             `        // sap/ui/core/Theming only exists since UI5 1.118, so it must not be` && |\n| &&
+             `        // a hard dependency of this module - older bootstraps (e.g. 1.108)` && |\n| &&
+             `        // would fail to load the component. On 1.118+ the core itself loads` && |\n| &&
+             `        // Theming, so the probing require finds it; otherwise fall back to` && |\n| &&
+             `        // the legacy Configuration API.` && |\n| &&
+             `        try {` && |\n| &&
+             `          const Theming = sap.ui.require("sap/ui/core/Theming");` && |\n| &&
+             `          if (Theming?.getTheme) return Theming.getTheme();` && |\n| &&
+             `          if (sap.ui.getCore) {` && |\n| &&
+             `            return sap.ui.getCore().getConfiguration().getTheme();` && |\n| &&
+             `          }` && |\n| &&
+             `        } catch (e) {` && |\n| &&
+             `          Lib.logError("Component: reading theme failed", e);` && |\n| &&
+             `        }` && |\n| &&
+             `        return "";` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      _onUnload() {` && |\n| &&


### PR DESCRIPTION
sap/ui/core/Theming only exists since UI5 1.118, so requiring it in the Component.js dependency array breaks bootstraps with older UI5 versions (e.g. 1.108) with a script load error. Probe the module at runtime instead and fall back to the legacy Configuration API on older releases.

https://claude.ai/code/session_01HssDLQvzWgvdrxwiUqfQ8T