### PR TITLE
Add BAL save functionality to pop-up dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,13 @@ This project follows the [SAP Clean ABAP styleguide](https://github.com/SAP/styl
   CATCH cx_root ##NO_HANDLER.
   ```
 - **API parameter types:** Use `TYPE clike` for string/char input parameters in public API methods (allows both string and char literals without conversion)
+- **Utility access:** Always call utilities via the facade `z2ui5_cl_util` — it inherits everything from `z2ui5_cl_util_api`. Never reference `z2ui5_cl_util_api` (or its environment-specific implementations `z2ui5_cl_util_api_s` / `z2ui5_cl_util_api_c`) directly outside `src/00/`
+  ```abap
+  " good
+  z2ui5_cl_util=>bal_read( ... ).
+  " bad
+  z2ui5_cl_util_api=>bal_read( ... ).
+  ```
 
 ### Naming (enforced by abaplint)
 

--- a/src/02/01/z2ui5_cl_pop_bal.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_bal.clas.abap
@@ -95,9 +95,9 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
 
   METHOD factory_by_db.
 
-    r_result = factory( i_messages   = z2ui5_cl_util_api=>bal_read( object    = i_object
-                                                                    subobject = i_subobject
-                                                                    id        = i_extnumber )
+    r_result = factory( i_messages   = z2ui5_cl_util=>bal_read( object    = i_object
+                                                                subobject = i_subobject
+                                                                id        = i_extnumber )
                         i_title      = i_title
                         i_object     = i_object
                         i_subobject  = i_subobject
@@ -167,10 +167,10 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
     ENDIF.
 
     TRY.
-        z2ui5_cl_util_api=>bal_create( object    = mv_object
-                                       subobject = mv_subobject
-                                       id        = mv_extnumber
-                                       t_log     = mt_msg_bal ).
+        z2ui5_cl_util=>bal_create( object    = mv_object
+                                   subobject = mv_subobject
+                                   id        = mv_extnumber
+                                   t_log     = mt_msg_bal ).
         client->message_toast_display( `Business Application Log saved` ).
       CATCH cx_root INTO DATA(x).
         client->message_box_display( text = x->get_text( )

--- a/src/02/01/z2ui5_cl_pop_bal.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_bal.clas.abap
@@ -21,12 +21,31 @@ CLASS z2ui5_cl_pop_bal DEFINITION PUBLIC.
       END OF ty_s_msg.
     TYPES ty_t_msg TYPE STANDARD TABLE OF ty_s_msg WITH EMPTY KEY.
 
-    DATA mt_msg TYPE ty_t_msg.
+    DATA mt_msg       TYPE ty_t_msg.
+    DATA mt_msg_bal   TYPE z2ui5_cl_util=>ty_t_msg.
+    DATA mv_object    TYPE string.
+    DATA mv_subobject TYPE string.
+    DATA mv_extnumber TYPE string.
+    DATA mv_check_save TYPE abap_bool.
 
     CLASS-METHODS factory
       IMPORTING
         i_messages      TYPE any
         i_title         TYPE string DEFAULT `abap2UI5 - Business Application Log`
+        i_object        TYPE clike OPTIONAL
+        i_subobject     TYPE clike OPTIONAL
+        i_extnumber     TYPE clike OPTIONAL
+        i_check_save    TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(r_result) TYPE REF TO z2ui5_cl_pop_bal.
+
+    CLASS-METHODS factory_by_db
+      IMPORTING
+        i_object        TYPE clike
+        i_subobject     TYPE clike OPTIONAL
+        i_extnumber     TYPE clike OPTIONAL
+        i_title         TYPE string DEFAULT `abap2UI5 - Business Application Log`
+        i_check_save    TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(r_result) TYPE REF TO z2ui5_cl_pop_bal.
 
@@ -35,6 +54,7 @@ CLASS z2ui5_cl_pop_bal DEFINITION PUBLIC.
     DATA title  TYPE string.
 
     METHODS view_display.
+    METHODS on_event_save.
 
   PRIVATE SECTION.
 ENDCLASS.
@@ -46,7 +66,9 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
 
     r_result = NEW #( ).
 
-    LOOP AT z2ui5_cl_util=>msg_get_t( i_messages ) REFERENCE INTO DATA(lr_row).
+    r_result->mt_msg_bal = z2ui5_cl_util=>msg_get_t( i_messages ).
+
+    LOOP AT r_result->mt_msg_bal REFERENCE INTO DATA(lr_row).
       INSERT VALUE ty_s_msg(
         type       = z2ui5_cl_util=>ui5_get_msg_type( lr_row->type )
         title      = lr_row->text
@@ -63,7 +85,24 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
         ) INTO TABLE r_result->mt_msg.
     ENDLOOP.
 
-    r_result->title = i_title.
+    r_result->title         = i_title.
+    r_result->mv_object     = i_object.
+    r_result->mv_subobject  = i_subobject.
+    r_result->mv_extnumber  = i_extnumber.
+    r_result->mv_check_save = i_check_save.
+
+  ENDMETHOD.
+
+  METHOD factory_by_db.
+
+    r_result = factory( i_messages   = z2ui5_cl_util_api=>bal_read( object    = i_object
+                                                                    subobject = i_subobject
+                                                                    id        = i_extnumber )
+                        i_title      = i_title
+                        i_object     = i_object
+                        i_subobject  = i_subobject
+                        i_extnumber  = i_extnumber
+                        i_check_save = i_check_save ).
 
   ENDMETHOD.
 
@@ -75,6 +114,19 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
                            contentwidth      = `50%`
                            verticalscrolling = abap_false
                            afterclose        = client->_event( `BUTTON_CONTINUE` ) ).
+
+    IF mv_check_save = abap_true.
+      popup->overflow_toolbar(
+          )->label( `Object`
+          )->input( value = client->_bind_edit( mv_object )
+                    width = `10rem`
+          )->label( `Subobject`
+          )->input( value = client->_bind_edit( mv_subobject )
+                    width = `10rem`
+          )->label( `External Number`
+          )->input( value = client->_bind_edit( mv_extnumber )
+                    width = `10rem` ).
+    ENDIF.
 
     DATA(table) = popup->table( client->_bind( mt_msg ) ).
     table->columns(
@@ -93,12 +145,37 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
        )->text( `{NUMBER}`
        )->text( `{MESSAGE}` ).
 
-    popup->buttons(
-       )->button( text  = `Continue`
-                  press = client->_event( `BUTTON_CONTINUE` )
-                  type  = `Emphasized` ).
+    DATA(buttons) = popup->buttons( ).
+    IF mv_check_save = abap_true.
+      buttons->button( text  = `Save`
+                       press = client->_event( `BUTTON_SAVE` ) ).
+    ENDIF.
+    buttons->button( text  = `Continue`
+                     press = client->_event( `BUTTON_CONTINUE` )
+                     type  = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD on_event_save.
+
+    IF mv_object IS INITIAL.
+      client->message_box_display( text = `Enter an object before saving the log`
+                                   type = `error` ).
+      RETURN.
+    ENDIF.
+
+    TRY.
+        z2ui5_cl_util_api=>bal_create( object    = mv_object
+                                       subobject = mv_subobject
+                                       id        = mv_extnumber
+                                       t_log     = mt_msg_bal ).
+        client->message_toast_display( `Business Application Log saved` ).
+      CATCH cx_root INTO DATA(x).
+        client->message_box_display( text = x->get_text( )
+                                     type = `error` ).
+    ENDTRY.
 
   ENDMETHOD.
 
@@ -108,6 +185,11 @@ CLASS z2ui5_cl_pop_bal IMPLEMENTATION.
 
     IF client->check_on_init( ).
       view_display( ).
+      RETURN.
+    ENDIF.
+
+    IF client->check_on_event( `BUTTON_SAVE` ).
+      on_event_save( ).
       RETURN.
     ENDIF.
 

--- a/src/02/01/z2ui5_cl_pop_bal.clas.testclasses.abap
+++ b/src/02/01/z2ui5_cl_pop_bal.clas.testclasses.abap
@@ -7,6 +7,9 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_factory_msg_count     FOR TESTING RAISING cx_static_check.
     METHODS test_factory_msg_type      FOR TESTING RAISING cx_static_check.
     METHODS test_factory_w_cx          FOR TESTING RAISING cx_static_check.
+    METHODS test_factory_save_key      FOR TESTING RAISING cx_static_check.
+    METHODS test_factory_msg_bal       FOR TESTING RAISING cx_static_check.
+    METHODS test_factory_by_db         FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS ltcl_test IMPLEMENTATION.
@@ -65,6 +68,59 @@ CLASS ltcl_test IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_bound( lo_pop ).
     cl_abap_unit_assert=>assert_not_initial( lo_pop->mt_msg ).
+
+  ENDMETHOD.
+
+  METHOD test_factory_save_key.
+
+    DATA lt_msg TYPE z2ui5_cl_pop_bal=>ty_t_msg.
+    lt_msg = VALUE #( ( type = `E` title = `Error msg` message = `Something failed` ) ).
+
+    DATA(lo_pop) = z2ui5_cl_pop_bal=>factory( i_messages   = lt_msg
+                                              i_object     = `TEST`
+                                              i_subobject  = `SUB`
+                                              i_extnumber  = `EXT`
+                                              i_check_save = abap_true ).
+
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_object
+                                        exp = `TEST` ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_subobject
+                                        exp = `SUB` ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_extnumber
+                                        exp = `EXT` ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_check_save
+                                        exp = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD test_factory_msg_bal.
+
+    DATA lt_msg TYPE z2ui5_cl_util=>ty_t_msg.
+    lt_msg = VALUE #( ( type = `E` id = `MSG_ID` no = `001` text = `Something failed` ) ).
+
+    DATA(lo_pop) = z2ui5_cl_pop_bal=>factory( lt_msg ).
+
+    cl_abap_unit_assert=>assert_equals( act = lines( lo_pop->mt_msg_bal )
+                                        exp = 1 ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mt_msg_bal[ 1 ]-text
+                                        exp = `Something failed` ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_check_save
+                                        exp = abap_false ).
+
+  ENDMETHOD.
+
+  METHOD test_factory_by_db.
+
+    DATA(lo_pop) = z2ui5_cl_pop_bal=>factory_by_db( i_object     = `TEST`
+                                                    i_subobject  = `SUB`
+                                                    i_extnumber  = `EXT`
+                                                    i_check_save = abap_true ).
+
+    cl_abap_unit_assert=>assert_bound( lo_pop ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_object
+                                        exp = `TEST` ).
+    cl_abap_unit_assert=>assert_equals( act = lo_pop->mv_check_save
+                                        exp = abap_true ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Extends the Business Application Log (BAL) pop-up dialog to support saving logs to the database. Adds new factory method to load logs from database and implements event handling for the save operation.

## Key Changes
- **New data members:** Added `mt_msg_bal`, `mv_object`, `mv_subobject`, `mv_extnumber`, and `mv_check_save` to store BAL metadata and control save functionality
- **Enhanced factory method:** Extended `factory()` with optional parameters for object, subobject, external number, and save flag
- **New factory_by_db method:** Added convenience method to load BAL entries from database and create pop-up in one call
- **Save UI controls:** When `i_check_save = abap_true`, displays input fields for object/subobject/external number in the pop-up toolbar
- **Save event handler:** Implemented `on_event_save()` method that validates object field and persists log entries via `z2ui5_cl_util=>bal_create()`
- **Event routing:** Added event check for `BUTTON_SAVE` in main method to trigger save handler
- **Test coverage:** Added three new unit tests covering save key parameters, BAL message storage, and factory_by_db method

## Implementation Details
- Save operation validates that object is not empty before attempting to persist
- Uses try-catch to handle any exceptions during save and displays error messages to user
- Maintains backward compatibility—save functionality is opt-in via `i_check_save` parameter
- Follows existing code patterns for utility access via `z2ui5_cl_util` facade

https://claude.ai/code/session_019wbHvXAG3yyE5X7eWXJfFE