### PR TITLE
Preload CodeEditor modules to avoid CSP violations

### DIFF
--- a/app/webapp/core/DebugTool.js
+++ b/app/webapp/core/DebugTool.js
@@ -73,6 +73,24 @@ sap.ui.define(
       return slot?.XML;
     }
 
+    // Preload the sap.ui.codeeditor modules used by the fragment. On older
+    // UI5 releases (e.g. 1.71) Fragment.load still processes the XML with
+    // the sync strategy, so an unloaded CodeEditor would be fetched via
+    // synchronous XHR and executed with eval - which a Content-Security-
+    // Policy without 'unsafe-eval' blocks. Requiring the modules
+    // asynchronously up front makes the sync lookup a cache hit.
+    function preloadCodeEditor() {
+      return new Promise((resolve) => {
+        sap.ui.require(
+          ["sap/ui/codeeditor/library", "sap/ui/codeeditor/CodeEditor"],
+          () => resolve(),
+          // On failure continue anyway and let Fragment.load surface the
+          // real error.
+          () => resolve(),
+        );
+      });
+    }
+
     // What each dropdown entry shows: either a JSON source or an XML source
     // (the latter optionally with the rendered DOM for the templating
     // toggle). The "SOURCE" entry is handled separately in onItemSelect.
@@ -218,6 +236,7 @@ sap.ui.define(
         this._showPending = true;
         try {
           if (!this.oDialog) {
+            await preloadCodeEditor();
             this.oDialog = await Fragment.load({
               name: "z2ui5.core.DebugTool",
               controller: this,

--- a/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_debugtool_js.clas.abap
@@ -93,6 +93,24 @@ CLASS z2ui5_cl_app_debugtool_js IMPLEMENTATION.
              `      return slot?.XML;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // Preload the sap.ui.codeeditor modules used by the fragment. On older` && |\n| &&
+             `    // UI5 releases (e.g. 1.71) Fragment.load still processes the XML with` && |\n| &&
+             `    // the sync strategy, so an unloaded CodeEditor would be fetched via` && |\n| &&
+             `    // synchronous XHR and executed with eval - which a Content-Security-` && |\n| &&
+             `    // Policy without 'unsafe-eval' blocks. Requiring the modules` && |\n| &&
+             `    // asynchronously up front makes the sync lookup a cache hit.` && |\n| &&
+             `    function preloadCodeEditor() {` && |\n| &&
+             `      return new Promise((resolve) => {` && |\n| &&
+             `        sap.ui.require(` && |\n| &&
+             `          ["sap/ui/codeeditor/library", "sap/ui/codeeditor/CodeEditor"],` && |\n| &&
+             `          () => resolve(),` && |\n| &&
+             `          // On failure continue anyway and let Fragment.load surface the` && |\n| &&
+             `          // real error.` && |\n| &&
+             `          () => resolve(),` && |\n| &&
+             `        );` && |\n| &&
+             `      });` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // What each dropdown entry shows: either a JSON source or an XML source` && |\n| &&
              `    // (the latter optionally with the rendered DOM for the templating` && |\n| &&
              `    // toggle). The "SOURCE" entry is handled separately in onItemSelect.` && |\n| &&
@@ -238,6 +256,7 @@ CLASS z2ui5_cl_app_debugtool_js IMPLEMENTATION.
              `        this._showPending = true;` && |\n| &&
              `        try {` && |\n| &&
              `          if (!this.oDialog) {` && |\n| &&
+             `            await preloadCodeEditor();` && |\n| &&
              `            this.oDialog = await Fragment.load({` && |\n| &&
              `              name: "z2ui5.core.DebugTool",` && |\n| &&
              `              controller: this,` && |\n| &&


### PR DESCRIPTION
## Summary
Adds preloading of SAP UI5 CodeEditor modules before Fragment.load to prevent Content-Security-Policy violations on older UI5 releases.

## Changes
- Added `preloadCodeEditor()` function that asynchronously requires the CodeEditor modules (`sap/ui/codeeditor/library` and `sap/ui/codeeditor/CodeEditor`) before the debug dialog is loaded
- Call `preloadCodeEditor()` before `Fragment.load()` in the dialog initialization flow
- Gracefully handles module loading failures and allows Fragment.load to surface any real errors

## Implementation Details
On older UI5 releases (e.g. 1.71), Fragment.load processes XML synchronously, which would cause unloaded CodeEditor modules to be fetched via synchronous XHR and executed with `eval()`. This violates Content-Security-Policy directives that don't include `'unsafe-eval'`. By preloading the modules asynchronously upfront, the subsequent synchronous lookup becomes a cache hit, avoiding the CSP violation.

https://claude.ai/code/session_01Q1dk2oXp15qFKe35RTuY3D