### PR TITLE
Add abap2UI5 Claude Code plugin with skill, templates, and reference docs

### DIFF
--- a/abap2ui5-claude-plugin/.claude-plugin/marketplace.json
+++ b/abap2ui5-claude-plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "abap2ui5",
+  "owner": {
+    "name": "abap2UI5 community"
+  },
+  "description": "Claude Code plugins for building abap2UI5 applications in ABAP.",
+  "plugins": [
+    {
+      "name": "abap2ui5-app",
+      "source": "./",
+      "description": "Build abap2UI5 apps in pure ABAP: views, binding, events, navigation, popups, with a mined recipe + control catalog.",
+      "category": "development",
+      "keywords": ["abap", "abap2ui5", "ui5", "sap"]
+    }
+  ]
+}

--- a/abap2ui5-claude-plugin/.claude-plugin/plugin.json
+++ b/abap2ui5-claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "abap2ui5-app",
+  "displayName": "abap2UI5 App Builder",
+  "description": "Build abap2UI5 applications in pure ABAP — fluent z2ui5_cl_xml_view views, data binding, events, navigation, popups, plus a recipe and control catalog mined from the official samples.",
+  "version": "0.1.0",
+  "author": {
+    "name": "abap2UI5 community"
+  },
+  "homepage": "https://abap2ui5.org",
+  "repository": "https://github.com/abap2UI5/abap2UI5",
+  "license": "MIT",
+  "keywords": ["abap", "abap2ui5", "ui5", "sap", "fiori"]
+}

--- a/abap2ui5-claude-plugin/README.md
+++ b/abap2ui5-claude-plugin/README.md
@@ -1,0 +1,57 @@
+# abap2UI5 App Builder — Claude Code plugin
+
+A portable [Claude Code](https://claude.com/claude-code) plugin that helps you
+build [abap2UI5](https://abap2ui5.org) applications in **pure ABAP** — UI5 apps
+with no JavaScript, OData or RAP. It ships one skill, `abap2ui5-app`, backed by a
+control catalog, recipe book and example index mined from the ~360 official
+samples.
+
+## What it does
+When you ask Claude Code to "build an abap2UI5 app with a table", "add a popover",
+"scaffold a UI5 form in ABAP", etc., the skill activates and walks the build:
+1. Clarify the app (class name, package, on-prem vs cloud).
+2. Find the closest worked example in the official samples and adapt it.
+3. Pick the right structure (small app in `main( )` vs dispatcher + methods).
+4. Write the `z2ui5_if_app` class with correct views, binding and events.
+5. Wire the HTTP/ICF entry point (first app only) and run it.
+6. Validate (abaplint if configured) and verify two-way bindings round-trip.
+
+## Install
+
+This repo is a plugin **marketplace**. In Claude Code:
+
+```
+/plugin marketplace add abap2UI5/abap2UI5     # or your fork / git URL
+/plugin install abap2ui5-app@abap2ui5
+```
+
+Or load it for a single session without installing:
+
+```
+claude --plugin-dir /path/to/abap2ui5-claude-plugin
+```
+
+Once installed the skill is available as `/abap2ui5-app:abap2ui5-app` and is
+auto-suggested when your request matches.
+
+## Contents
+```
+.claude-plugin/
+  plugin.json            # plugin manifest
+  marketplace.json       # marketplace listing (this repo)
+skills/abap2ui5-app/
+  SKILL.md               # the workflow
+  reference/
+    setup.md             # install framework + ICF/HTTP wiring + run
+    examples-index.md    # which official demo shows which feature
+    controls.md          # ranked fluent control + client API catalog
+    recipes.md           # patterns: tables, popups, nav, binding, events, files
+    conventions.md       # abap2UI5 essentials + ABAP style flavors
+  templates/
+    app_simple.clas.abap     # small app, everything in main( )
+    app_canonical.clas.abap  # larger app, dispatcher + methods
+```
+
+## License
+MIT. abap2UI5 is an independent open-source project — see
+<https://github.com/abap2UI5/abap2UI5>.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/SKILL.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: abap2ui5-app
+description: >-
+  Build an abap2UI5 application in pure ABAP — an ABAP class implementing
+  z2ui5_if_app with a main( ) method, rendering UI5 views via the fluent
+  z2ui5_cl_xml_view builder, with data binding, events, navigation and popups.
+  No JavaScript, OData or RAP. Use whenever the user wants to create, scaffold,
+  extend or debug an abap2UI5 app, view, table, form, popup, popover, or any UI5
+  control written in ABAP — on-premise (NW 7.02+) or ABAP Cloud. Also covers
+  wiring the HTTP/ICF entry point and choosing the right control.
+---
+
+# Building an abap2UI5 application
+
+abap2UI5 lets you build SAP UI5 apps purely in ABAP. Every app is **one ABAP
+class** implementing `z2ui5_if_app` with a single `main( client )` method that
+the framework calls on every HTTP roundtrip. The browser loads a generic UI5
+shell once, then exchanges JSON with your ABAP class. You build views with the
+fluent `z2ui5_cl_xml_view` builder (or the generic `z2ui5_cl_util_xml`), bind
+ABAP variables to controls, and react to events — all in ABAP.
+
+This skill carries a **control catalog** and **recipe book** mined from the ~360
+official samples, so you build from proven patterns rather than guesswork.
+
+## Step 0 — Prerequisites (check once per project)
+The abap2UI5 framework must be installed in the system (pull
+`https://github.com/abap2UI5/abap2UI5` via abapGit) and reachable over HTTP.
+If the user is starting from nothing, see **`reference/setup.md`** for installing
+the framework, wiring the HTTP/ICF entry point, and running the app. You don't
+need to re-do this for every app — once the framework + one ICF handler exist,
+new apps are just new classes.
+
+## Step 1 — Clarify the app
+Before writing code, settle:
+- **Class name & namespace** — the user's own (e.g. `ZCL_MY_APP`,
+  `/NS/CL_APP`). Do NOT use the `z2ui5_cl_demo_app_*` demo naming; that is only
+  for the samples repo.
+- **Package / where it lives** in their project.
+- **Target** — on-premise vs ABAP Cloud (affects the HTTP handler factory and
+  some available controls; the app class itself is identical).
+- **What it does** — the screens, data, and actions.
+
+Ask only what you can't infer. If the user already has a project with ABAP
+conventions, match them.
+
+## Step 2 — Find the closest worked example
+Map the user's intent to **`reference/examples-index.md`** (every UI feature →
+the demo class that shows it) and **`reference/recipes.md`** (copy-paste patterns:
+tables, popups, navigation, binding, events, file up/download, custom controls).
+The examples live in the public `abap2UI5/samples` repo
+(`src/z2ui5_cl_demo_app_<NNN>.clas.abap`) — read the named one to see a complete,
+working implementation, then adapt it to the user's class name and data. For the
+available controls and client methods, use **`reference/controls.md`**. Don't
+invent method names — confirm them against a sample or the catalog.
+
+## Step 3 — Choose the structure by size
+- **`main( )` stays small (< ~50 lines)** → write everything inside `main`,
+  using the lifecycle `IF / ELSEIF` chain. Start from
+  **`templates/app_simple.clas.abap`**.
+- **Larger** → make `main` a dispatcher that calls `on_init` / `on_event`
+  (/ `on_navigation`), and add `view_display` / `data_read` / `data_update` as
+  needed. Start from **`templates/app_canonical.clas.abap`**.
+Never over-structure a small app; never cram a large one into `main`.
+
+## Step 4 — Write the app class
+- Implement `INTERFACES z2ui5_if_app.`; the entry point is
+  `METHOD z2ui5_if_app~main.` with the signature
+  `IMPORTING client TYPE REF TO z2ui5_if_client`.
+- Drive flow with the lifecycle checks, chained with `ELSEIF`:
+  `client->check_on_init( )` → `check_on_navigated( )` → `check_on_event( )`.
+- Build the view with `z2ui5_cl_xml_view=>factory( )`, then call
+  `client->view_display( view->stringify( ) )` as a standalone final statement.
+- Bind data: `client->_bind_edit( var )` for two-way (editable),
+  `client->_bind( var )` for read-only (display / list items).
+- See **`reference/conventions.md`** for the abap2UI5 essentials and the two
+  established ABAP style flavors (framework-style vs samples-style) — follow the
+  user's existing project standards; otherwise default to the framework style.
+
+## Step 5 — Wire & run
+If this is the project's first app, ensure an HTTP entry point exists
+(`z2ui5_cl_http_handler=>factory( )` on-prem / `factory_cloud( )` in the cloud,
+bound to an ICF service node — see **`reference/setup.md`**). Then run the app by
+opening the ICF service URL (or the launchpad tile) in a browser and exercise the
+flow.
+
+## Step 6 — Validate
+- If the project uses **abaplint** (`abaplint.jsonc`), run `npx abaplint` and fix
+  all issues — clean lint is the bar.
+- Eyeball the view-builder indentation against the conventions.
+- Confirm two-way bindings round-trip (edit in the UI → value arrives in ABAP).
+
+## Golden rules
+- **Read a real example before writing.** The examples-index maps every feature
+  to one.
+- **One class = one app**, implementing `z2ui5_if_app~main`.
+- **`_bind_edit` = editable/two-way, `_bind` = read-only.** Picking the wrong one
+  is the most common bug.
+- **Don't invent control or client-method names** — confirm in `controls.md` /a
+  sample, else use the generic builder (`z2ui5_cl_util_xml` / `_generic`).
+- **Match the project's ABAP conventions**; don't impose the demo naming.
+
+## Reference files
+| File | When to read |
+|---|---|
+| `reference/setup.md` | First app in a project: install + ICF/HTTP wiring + run |
+| `reference/examples-index.md` | Find the demo class that shows a given feature |
+| `reference/controls.md` | Pick the right fluent control / client method |
+| `reference/recipes.md` | Patterns: tables, popups, nav, binding, events, files, custom controls |
+| `reference/conventions.md` | abap2UI5 essentials + the two ABAP style flavors |
+| `templates/*` | Starting points for the app class |
+
+> Deeper framework internals and the canonical app-building guide:
+> <https://abap2ui5.github.io/docs/advanced/agent.html> and the core repo's
+> `AGENTS.md` at <https://github.com/abap2UI5/abap2UI5>.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/controls.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/controls.md
@@ -1,0 +1,101 @@
+# Control & Client-API Vocabulary
+
+Ranked by real usage across the 360 sample apps. Use this to pick the right
+fluent method. Names are the `z2ui5_cl_xml_view` builder methods (each wraps one
+UI5 control) and the `client->` methods. **Do not invent method names** — if a
+control is missing here, either find it in a sample or fall back to the generic
+builder (`_generic` / `z2ui5_cl_util_xml`).
+
+## Most-used view-builder methods
+
+> Chain-navigation helpers (not controls): `get_parent` returns the parent node
+> to continue the chain (by far the most frequent call — it is how you add a
+> child and walk back up to attach the next sibling); `get` returns the current
+> node; `stringify` emits the final XML. `_`, `__`, `_generic`, `_z2ui5`,
+> `_cc_*` are escape hatches for raw XML / custom controls.
+
+| Method | Purpose | Canonical sample |
+|---|---|---|
+| `text` | Text label / table cell | app_183 |
+| `button` | Button | app_125 |
+| `label` | Form field caption | app_125 |
+| `page` | Scrollable page (title, nav-button) | app_125 |
+| `input` | Single-line text entry | app_125 |
+| `content` | Aggregation slot (`form` / `layout`) | app_125 |
+| `column` | Responsive-table column header | app_183 |
+| `shell` | Top-level app frame | app_125 |
+| `link` | Hyperlink | app_181 |
+| `title` | Section/heading title | app_300 |
+| `layout_data` | Grid/flex layout data wrapper | app_277 |
+| `toolbar_spacer` | Pushes toolbar items apart | app_183 |
+| `items` | items aggregation (lists/tables) | app_183 |
+| `overflow_toolbar` | Responsive toolbar | app_183 |
+| `vbox` / `hbox` / `flex_box` | Flex containers | app_277 |
+| `simple_form` | Responsive label/field form | app_125 |
+| `column_list_item` | One responsive-table row | app_183 |
+| `quick_view_page` | Quick-view card body | app_129 |
+| `icon_tab_filter` | One tab of an IconTabBar | app_181 |
+| `ui_template` | Template binding for repeated aggregation | app_183 |
+| `object_status` | Colored status text/icon | app_300 |
+| `item` | Generic item (select/segmented) | app_181 |
+| `tile_content` / `generic_tile` / `numeric_content` | Dashboard tiles | app_277 |
+| `cells` | cells aggregation of a row | app_183 |
+| `checkbox` | Boolean toggle | app_300 |
+| `segmented_button` / `segmented_button_item` | Segment control | app_181 |
+| `radio_button` | Single radio option | app_181 |
+| `object_page_sub_section` / `blocks` | Object-page blocks | app_300 |
+| `vertical_layout` | Stacked layout | app_181 |
+| `panel` | Titled collapsible container | app_181 |
+| `toolbar` / `header_toolbar` / `footer` | Bars | app_183 |
+| `switch` | On/off slider | app_181 |
+| `object_attribute` / `object_number` | Object header attributes | app_300 |
+| `message_strip` | Inline message banner | app_238 |
+| `avatar` | Image/initials avatar | app_017 |
+| `text_area` | Multi-line entry | app_021 |
+| `table` | Responsive `sap.m.Table` | app_183 |
+| `select` / `combobox` / `multi_input` | Dropdowns | app_288 |
+| `slider` / `range_slider` / `step_input` | Numeric input | app_237 |
+| `icon` | Icon | app_268 |
+| `html` | Raw embedded HTML | app_242 |
+| `code_editor` | Code editor | app_035 |
+| `date_picker` / `date_time_picker` / `time_picker` | Date/time | app_002 |
+| `progress_indicator` | Progress bar | app_022 |
+
+**More (lower frequency):** `splitter_layout_data`, `grid` / `grid_data`,
+`dynamic_page_title`, `dialog`, `mask_input`, `search_field`, `toggle_button`,
+`timer`, `generic_tag`, `info_label`, `standard_list_item`, `action_list_item`,
+`input_list_item`, `rating_indicator`, `feed_input`, `wizard`, `planning_calendar`,
+`ui_table` / `ui_column` / `ui_template` (sap.ui.table), `tree_table` /
+`tree_column` (tree). ~300 distinct methods exist — read a sample to confirm
+exact names and aggregation slots.
+
+## Client methods (`z2ui5_if_client`)
+
+| Method | Purpose |
+|---|---|
+| `_event( val [, t_arg] )` | Register a backend event; returns binding for `press`/event attrs |
+| `_event_client( val )` | Pure frontend event, no roundtrip (e.g. `cs_event-popup_close`) |
+| `_event_nav_app_leave( )` | Bind back-navigation (pops app stack), no roundtrip |
+| `_bind_edit( val [, path] )` | Two-way binding `{/XX/attr}` for editable controls |
+| `_bind( val [, path] )` | One-way read-only binding `{/attr}` (display, list items) |
+| `view_display( xml )` | Render the main view |
+| `view_model_update( )` | Push updated bound data to the existing view |
+| `view_destroy( )` | Destroy the main view |
+| `check_on_init( )` | True on the first roundtrip |
+| `check_on_event( [name] )` | True when a (named) event fired |
+| `check_on_navigated( )` | True when returning from a sub-app/popup |
+| `check_app_prev_stack( )` | True if a previous app exists (drives `shownavbutton`) |
+| `get( )` | Read request context: `-event`, `-t_event_arg`, `-s_draft-*` |
+| `get_event_arg( )` / `get( )-t_event_arg` | Read args passed with the event (1-based) |
+| `message_toast_display( text )` | Transient toast |
+| `message_box_display( text [, type] )` | Modal message box |
+| `nav_app_call( app )` | Push/navigate to a sub-app |
+| `nav_app_leave( [app] )` | Pop the app stack (manual back) |
+| `get_app( id )` / `get_app_prev( )` | Get a referenced app instance |
+| `popup_display( xml )` / `popup_model_update( )` / `popup_destroy( )` | Modal dialog lifecycle |
+| `popover_display( xml, by_id )` / `popover_destroy( )` | Anchored popover lifecycle |
+| `nest_view_display( xml )` / `nest_view_model_update( )` | Nested sub-view |
+| `set_session_stateful( val )` | Keep session state across roundtrips |
+| `follow_up_action( val )` | Queue a follow-up frontend action |
+| `cs_event` / `cs_view` | Predefined event-id / view-name constants |
+| `action->gen( val, t_arg )` | Generic client action (download, scroll, …) |

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/conventions.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/conventions.md
@@ -1,0 +1,76 @@
+# Conventions
+
+There are **abap2UI5 essentials** that always apply, and **ABAP style** which
+depends on your project. Match the conventions of the project you're working in
+(if it has an `abaplint.jsonc`, that is the source of truth). Below: the
+essentials first, then the two established style flavors so you can pick.
+
+## abap2UI5 essentials (always)
+- One class per app: `INTERFACES z2ui5_if_app.`, entry point
+  `METHOD z2ui5_if_app~main.` (`IMPORTING client TYPE REF TO z2ui5_if_client`).
+- Drive flow with the lifecycle checks, **chained with `ELSEIF`**, never separate
+  `IF`s:
+  ```abap
+  IF client->check_on_init( ).         " first roundtrip
+    ...
+  ELSEIF client->check_on_navigated( ). " returned from a sub-app/popup
+    ...
+  ELSEIF client->check_on_event( ).     " a user event fired
+    ...
+  ENDIF.
+  ```
+  For a specific event, `check_on_event( 'SAVE' )`; for many events, a
+  `CASE client->get( )-event.`.
+- Never use an init flag (`mv_init`, `is_initialized`, …) — use
+  `client->check_on_init( )`.
+- **Binding direction is the #1 source of bugs:** `_bind_edit( var )` = two-way
+  (editable, read back next roundtrip); `_bind( var )` = read-only (display, list
+  / combo / suggestion items). Use `path = abap_true` when only the binding path
+  is needed inside a JSON literal (`items` / `rows`).
+- Build the view with `z2ui5_cl_xml_view=>factory( )`, finish with
+  `client->view_display( view->stringify( ) )` as a **standalone final
+  statement** — never nested in the fluent chain.
+- Indent the fluent chain to mirror the XML hierarchy: descending into a child
+  indents deeper; siblings stay at the same level. One control parameter → inline;
+  two or more → one per line, aligned.
+- Back navigation: bind `navbuttonpress = client->_event_nav_app_leave( )` +
+  `shownavbutton = client->check_app_prev_stack( )` directly in the view.
+- App-to-app: push with `client->nav_app_call( NEW zcl_other( ) )` (set public
+  attributes on the instance first to pass parameters); read results back in the
+  `check_on_navigated` branch via `CAST zcl_other( client->get_app_prev( ) )`.
+
+## Deprecated / avoid
+- Prefer the fluent `z2ui5_cl_xml_view` or the generic `z2ui5_cl_util_xml`
+  builder over hand-assembling XML strings.
+- Avoid `boolc( )` — use `xsdbool( )`.
+- The canonical, always-current list of deprecated controls and patterns is in
+  the official guide: <https://abap2ui5.github.io/docs/advanced/agent.html>.
+
+## ABAP style — match the project; these are reasonable defaults
+
+**Most important: match the conventions of the project you're editing.** Read its
+`abaplint.jsonc` and a couple of existing classes first. If there is no house
+standard, the defaults below are safe.
+
+Note that **app classes are written in a light style** even in the official repos
+— e.g. the framework's own `z2ui5_cl_app_hello_world` and every sample app use no
+Hungarian prefixes on scalars and a single `client` reference. The heavy
+`mv_/mo_/mt_` prefixing documented for the framework is mainly its **internal
+engine** convention, not a requirement for your app classes.
+
+Sensible defaults for a new app class (used by the bundled templates):
+- `CLASS zcl_my_app DEFINITION PUBLIC FINAL CREATE PUBLIC.` (`FINAL` is a good
+  default; drop it only if you subclass). Some teams omit `FINAL`/`CREATE PUBLIC`
+  — both are fine.
+- All three sections present (`PUBLIC` / `PROTECTED` / `PRIVATE`), even if empty.
+- Light naming: no prefix on scalars; `t_`/`s_` for tables/structures; `ty_s_`/
+  `ty_t_` for local types. A single member `client TYPE REF TO z2ui5_if_client`.
+- Backtick string literals; `NEW #( )` not `CREATE OBJECT`; `xsdbool( )` not
+  `boolc( )`; `line_exists( )` not `READ TABLE`.
+
+If your project mandates full Hungarian notation, `FINAL`, etc., apply it — the
+templates are a starting point, not a constraint.
+
+> The **abap2UI5-samples** repo has its own stricter house style (lowercase class
+> names, no `FINAL`/`CREATE PUBLIC`). Follow that **only** when contributing demos
+> to that repo.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/examples-index.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/examples-index.md
@@ -1,0 +1,312 @@
+# Examples Index — "which example shows what"
+
+A lookup over the official **abap2UI5/samples** repo
+(<https://github.com/abap2UI5/abap2UI5-samples>), mined from its launchpad app
+`z2ui5_cl_demo_app_000`. When the user asks for a feature, find the nearest entry
+here and **read that demo class first** — each is a complete, lint-clean,
+working implementation to adapt. The classes live at
+`src/z2ui5_cl_demo_app_<NNN>.clas.abap` in that repo; fetch the file
+(raw.githubusercontent.com or a local clone) and adapt it to your own class name
+and data. Class names are case-insensitive at runtime.
+
+## General
+
+### Binding
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_001 | Binding I — Simple, send values to the backend |
+| z2ui5_cl_demo_app_166 | Binding II — Structure component level |
+| z2ui5_cl_demo_app_144 | Binding III — Table cell level |
+| z2ui5_cl_demo_app_071 | setSizeLimit |
+
+### Events
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_004 | Event I — Handle events & change the view |
+| z2ui5_cl_demo_app_024 | Event II — Call other apps & exchange data |
+| z2ui5_cl_demo_app_167 | Event III — Additional infos with t_args |
+| z2ui5_cl_demo_app_197 | Event IV — Facet filter, t_arg with objects |
+
+### Features
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_028 | Timer I — Wait n ms and call the server again |
+| z2ui5_cl_demo_app_064 | Timer II — Loading indicator while server request |
+| z2ui5_cl_demo_app_073 | New tab — open a URL in a new tab |
+| z2ui5_cl_demo_app_325 | Clipboard — copy & paste text |
+| z2ui5_cl_demo_app_133 | Focus I |
+| z2ui5_cl_demo_app_189 | Focus II |
+| z2ui5_cl_demo_app_362 | Scroll to position |
+| z2ui5_cl_demo_app_363 | Scroll into view |
+| z2ui5_cl_demo_app_139 | History |
+| z2ui5_cl_demo_app_279 | Data loss protection |
+| z2ui5_cl_demo_app_125 | Tab title |
+| z2ui5_cl_demo_app_s_02 | Session stickiness I — stateful mode |
+| z2ui5_cl_demo_app_s_01 | Session stickiness II — use locks |
+| z2ui5_cl_demo_app_327 | Local/session storage |
+| z2ui5_cl_demo_app_361 | System logout — SYSTEM_LOGOUT client event |
+
+### Messages
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_008 | Basic — toast, box & strip |
+| z2ui5_cl_demo_app_187 | Message box — sy, bapiret, cx_root |
+| z2ui5_cl_demo_app_154 | Popup — messages & exception |
+| z2ui5_cl_demo_app_038 | Message view — custom popup, popover & output |
+
+### File API
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_057 | Download CSV — export table as CSV |
+| z2ui5_cl_demo_app_074 | Upload CSV — import CSV as internal table |
+| z2ui5_cl_demo_app_075 | File uploader — upload files to the backend |
+| z2ui5_cl_demo_app_186 | File download — download files to the frontend |
+
+### S-RTTI — Dynamic Typing
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_061 | Dynamic types — send tables to the frontend |
+| z2ui5_cl_demo_app_131 | Dynamic objects I — render different subapps |
+| z2ui5_cl_demo_app_117 | Dynamic objects II — generic data refs in subapps |
+| z2ui5_cl_demo_app_185 | Dynamic objects III — generic data refs in subapps |
+
+### Device Capabilities
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_120 | Geolocation |
+| z2ui5_cl_demo_app_122 | Frontend infos |
+| z2ui5_cl_demo_app_306 | Camera |
+
+## Input & Output
+
+### Output
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_051 | Label |
+| z2ui5_cl_demo_app_022 | Progress indicator |
+| z2ui5_cl_demo_app_079 | PDF viewer — display PDFs via iframe |
+| z2ui5_cl_demo_app_015 | Formatted text — display HTML |
+| z2ui5_cl_demo_app_206 | Text — max lines |
+| z2ui5_cl_demo_app_209 | InfoLabel |
+| z2ui5_cl_demo_app_215 | Busy indicator |
+| z2ui5_cl_demo_app_272 | Object header — circle-shaped image |
+| z2ui5_cl_demo_app_303 | Object page header — with header container |
+| z2ui5_cl_demo_app_289 | Object marker in a table |
+| z2ui5_cl_demo_app_293 | Link |
+| z2ui5_cl_demo_app_300 | Object status |
+| z2ui5_cl_demo_app_302 | Object attribute inside table |
+| z2ui5_cl_demo_app_330 | ObjectPage — hidden section titles |
+
+### Input
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_041 | Step input |
+| z2ui5_cl_demo_app_005 | Range slider |
+| z2ui5_cl_demo_app_021 | Text area |
+| z2ui5_cl_demo_app_035 | Code editor |
+| z2ui5_cl_demo_app_106 | Rich text editor |
+| z2ui5_cl_demo_app_101 | Feed input |
+| z2ui5_cl_demo_app_207 | Radio button |
+| z2ui5_cl_demo_app_208 | Radio button group |
+| z2ui5_cl_demo_app_210 | Input — types |
+| z2ui5_cl_demo_app_213 | Input — password |
+| z2ui5_cl_demo_app_220 | Rating indicator |
+| z2ui5_cl_demo_app_229 | ComboBox — suggestions wrapping |
+| z2ui5_cl_demo_app_231 | Date range selection |
+| z2ui5_cl_demo_app_232 | Multi input — suggestions wrapping |
+| z2ui5_cl_demo_app_233 | Multi combo box — suggestions wrapping |
+| z2ui5_cl_demo_app_237 | Slider |
+| z2ui5_cl_demo_app_239 | Checkbox |
+| z2ui5_cl_demo_app_240 | Switch |
+| z2ui5_cl_demo_app_288 | Select |
+| z2ui5_cl_demo_app_297 | Select — with icons |
+| z2ui5_cl_demo_app_301 | Expandable text |
+
+### Interaction
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_053 | Search field I — filter with enter |
+| z2ui5_cl_demo_app_059 | Search field II — filter with live change event |
+| z2ui5_cl_demo_app_078 | Multi input — token & range handling |
+| z2ui5_cl_demo_app_270 | Color picker |
+| z2ui5_cl_demo_app_292 | Breadcrumbs |
+| z2ui5_cl_demo_app_316 | URL helper — email, telephone, SMS |
+
+### Formatting & Calculations
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_047 | Data types — integer, decimals, dates & time |
+| z2ui5_cl_demo_app_067 | Formatting — currencies |
+| z2ui5_cl_demo_app_110 | Mask input |
+| z2ui5_cl_demo_app_027 | Expression binding — calculations in views |
+
+### Tiles
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_228 | Tile — numeric content without margins |
+| z2ui5_cl_demo_app_277 | Tile — KPI tile |
+| z2ui5_cl_demo_app_262 | Tile — numeric content of different colors |
+| z2ui5_cl_demo_app_271 | Tile — image content |
+| z2ui5_cl_demo_app_281 | Tile — statuses |
+
+## Tables & Trees
+
+### Table
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_006 | Toolbar — add a container & toolbar |
+| z2ui5_cl_demo_app_019 | Selection modes — single & multi select |
+| z2ui5_cl_demo_app_011 | Editable — set columns editable |
+| z2ui5_cl_demo_app_072 | Visualization — object number, states & tab filter |
+| z2ui5_cl_demo_app_183 | Column menu |
+| z2ui5_cl_demo_app_305 | Cell coloring |
+| z2ui5_cl_demo_app_070 | ui.Table I — simple example |
+| z2ui5_cl_demo_app_160 | ui.Table II — events on cell level |
+| z2ui5_cl_demo_app_307 | Grid list — with drag & drop |
+
+### Lists
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_003 | List I — basic |
+| z2ui5_cl_demo_app_048 | List II — events & visualization |
+| z2ui5_cl_demo_app_216 | Action list item |
+| z2ui5_cl_demo_app_219 | Input list item |
+| z2ui5_cl_demo_app_290 | Object list item — markers aggregation |
+
+### Trees
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_068 | Tree table I — popup select entry |
+| z2ui5_cl_demo_app_364 | Tree table II — checkbox binding per node |
+
+## Popups & Popovers
+
+### Popups
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_012 | Flow logic — different ways of calling popups |
+| z2ui5_cl_demo_app_161 | Call popup in popup — backend popup stack handling |
+| z2ui5_cl_demo_app_009 | F4 value help — popup for value help |
+| z2ui5_cl_demo_app_273 | LightBox |
+
+### Popovers
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_026 | Popover — simple example |
+| z2ui5_cl_demo_app_052 | Popover item level — popover for a specific table entry |
+| z2ui5_cl_demo_app_081 | Popover with list |
+| z2ui5_cl_demo_app_109 | Popover with quick view |
+| z2ui5_cl_demo_app_163 | Popover with action sheet |
+
+### Built-in Popups (z2ui5_cl_pop_*)
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_151 | Popup to inform |
+| z2ui5_cl_demo_app_150 | Popup to confirm |
+| z2ui5_cl_demo_app_174 | Popup to select |
+| z2ui5_cl_demo_app_155 | Popup textedit |
+| z2ui5_cl_demo_app_156 | Popup input value |
+| z2ui5_cl_demo_app_157 | Popup file upload |
+| z2ui5_cl_demo_app_158 | Popup display PDF |
+| z2ui5_cl_demo_app_056 | Popup get range — select-options in multi inputs |
+| z2ui5_cl_demo_app_162 | Popup get range multi — select-options for structures & tables |
+| z2ui5_cl_demo_app_164 | Popup display table |
+| z2ui5_cl_demo_app_168 | Popup display download |
+| z2ui5_cl_demo_app_149 | Popup display HTML |
+| z2ui5_cl_demo_app_365 | Popup display CL_DEMO_OUTPUT |
+
+## More Controls
+
+### Visualization
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_080 | Planning calendar |
+| z2ui5_cl_demo_app_175 | Wizard control I |
+| z2ui5_cl_demo_app_202 | Wizard control II — next step & subsequent step |
+| z2ui5_cl_demo_app_181 | Cards |
+
+### Layouts
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_010 | Header, footer, grid — split view into areas |
+| z2ui5_cl_demo_app_030 | Dynamic page — display items |
+| z2ui5_cl_demo_app_069 | Flexible column layout — master/details with tree |
+| z2ui5_cl_demo_app_103 | Splitting container |
+| z2ui5_cl_demo_app_205 | Flex box — basic alignment |
+| z2ui5_cl_demo_app_247 | Splitter layout — 2 areas |
+| z2ui5_cl_demo_app_269 | Shell bar — title mega menu |
+
+### Nested Views
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_065 | Nested views I — basic example |
+| z2ui5_cl_demo_app_097 | Nested views II — head & item table |
+| z2ui5_cl_demo_app_098 | Nested views III — head & item table & detail |
+| z2ui5_cl_demo_app_104 | Nested views IV — sub-app |
+
+### Navigation Container
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_088 | Nav container I |
+| z2ui5_cl_demo_app_221 | Icon tab bar — icons only |
+| z2ui5_cl_demo_app_226 | Icon tab bar — sub tabs |
+| z2ui5_cl_demo_app_227 | Bar — page, toolbar & bar |
+
+### Templating
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_173 | Templating I — basic example |
+| z2ui5_cl_demo_app_176 | Templating II — nested views |
+
+## Custom Extensions
+
+### CSS
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_310 | Messages with styles I |
+| z2ui5_cl_demo_app_311 | Messages with styles II |
+| z2ui5_cl_demo_app_050 | Change CSS — send your own CSS to the frontend |
+
+### General
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_031 | Import view — copy & paste views from the UI5 docs |
+| z2ui5_cl_demo_app_s_05 | Websocket — consume APC messages |
+
+## Generic XML Builder (z2ui5_cl_util_xml, pkg 02)
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_355 | InputListItem sample |
+| z2ui5_cl_demo_app_357 | Controls overview |
+| z2ui5_cl_demo_app_358 | Table |
+| z2ui5_cl_demo_app_359 | Expression binding |
+| z2ui5_cl_demo_app_360 | Formatter |
+
+## Native JS / Extensions (pkg 03)
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_032 | extension — html css js |
+| z2ui5_cl_demo_app_036 | extension — canvas and svg |
+| z2ui5_cl_demo_app_037 | extension — custom control |
+| z2ui5_cl_demo_app_040 | extension — ext library |
+| z2ui5_cl_demo_app_093 | ext — call custom function |
+| z2ui5_cl_demo_app_309 | follow_up_action with JS |
+
+## Demos (full apps)
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_002 | Selection screen — explore input controls |
+| z2ui5_cl_demo_app_085 | Sample app — nested view, object page, navigation, tables, lists, images |
+
+## Charts & higher-release controls (UI5 only / version gated)
+| App class | Title |
+|---|---|
+| z2ui5_cl_demo_app_013 | Donut chart |
+| z2ui5_cl_demo_app_014 | Line chart |
+| z2ui5_cl_demo_app_016 | Bar chart |
+| z2ui5_cl_demo_app_312 | VizFrame charts |
+| z2ui5_cl_demo_app_182 | Network graph |
+| z2ui5_cl_demo_app_113 | Timeline |
+| z2ui5_cl_demo_app_017 | Object page with avatar (≥1.73) |
+| z2ui5_cl_demo_app_124 | Barcode scanner (≥1.102) |
+| z2ui5_cl_demo_app_108 | Side panel (≥1.107) |

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/recipes.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/recipes.md
@@ -1,0 +1,232 @@
+# Recipes — copy-pasteable patterns
+
+Distilled from the sample apps. Each recipe names the canonical sample — **read
+it in full** before adapting. Snippets are trimmed to the essentials.
+
+## 1. Editable / responsive table bound to an internal table
+
+`sap.m.Table` bound two-way on the table path; columns are headers, cells bind
+per field with `{FIELDNAME}`. Row selection via `selected="{SELKZ}"` +
+`mode="MultiSelect"`. Event handlers operate directly on the ABAP table, then
+`view_model_update( )`. **Canonical: `z2ui5_cl_demo_app_011`** (simpler table:
+`app_056`, cell-level binding: `app_144`).
+
+```abap
+DATA(tab) = page->table(
+        items = |\{path: '{ client->_bind_edit( val = t_tab path = abap_true ) }', templateShareable: false\}|
+        mode  = `MultiSelect` ).
+
+tab->columns(
+    )->column( )->text( `Title` )->get_parent(
+    )->column( )->text( `Checkbox` ).
+
+tab->items( )->column_list_item( selected = `{SELKZ}`
+    )->cells(
+        )->input(    value    = `{TITLE}`    enabled = `{EDITABLE}`
+        )->checkbox( selected = `{CHECKBOX}` enabled = `{EDITABLE}` ).
+```
+```abap
+ELSEIF client->check_on_event( `BUTTON_DELETE` ).
+  DELETE t_tab WHERE selkz = abap_true.
+  client->view_model_update( ).
+ELSEIF client->check_on_event( `BUTTON_ADD` ).
+  INSERT VALUE #( ) INTO TABLE t_tab.
+  client->view_model_update( ).
+```
+
+## 2. sap.ui.table grid table and tree table
+
+**Grid table** (`ui_table`) — bind `rows`, define `ui_columns`/`ui_column`, each
+column carries a `ui_template` leaf control. Supports `sortproperty`/
+`filterproperty`, `selectionmode`, `rowactioncount` + `ui_row_action_template`,
+and a `ui_extension` toolbar. **Canonical: `z2ui5_cl_demo_app_070`** (editable
+cells: `app_160`, variant mgmt: `app_100`).
+
+```abap
+DATA(tab) = page->ui_table( rows           = client->_bind( val = mt_table )
+                            selectionmode  = `None`
+                            rowactioncount = `2` ).
+DATA(cols) = tab->ui_columns( ).
+cols->ui_column( width = `11rem` sortproperty = `PRICE` filterproperty = `PRICE`
+    )->text( `Price` )->ui_template( )->currency( value = `{PRICE}` currency = `{WAERS}` ).
+```
+
+**Tree table** (`tree_table`) — `rows` is a JSON binding string declaring
+`arrayNames` (the nested child table) and `numberOfExpandedLevels`. The ABAP type
+nests a child `nodes` table. **Canonical: `z2ui5_cl_demo_app_364`** (tree in a
+popup: `app_068`).
+
+```abap
+TYPES: BEGIN OF ty_s_tree,
+         user  TYPE string,
+         nodes TYPE STANDARD TABLE OF ty_s_node WITH DEFAULT KEY,
+       END OF ty_s_tree.
+
+DATA(columns) = page->tree_table(
+        rows = `{path:'` && client->_bind_edit( val = t_tree path = abap_true )
+            && `', parameters: {arrayNames:['NODES'], numberOfExpandedLevels: 1}}`
+    )->tree_columns( ).
+columns->tree_column( `User` )->tree_template( )->text( `{USER}` ).
+```
+
+## 3. Built-in popups (`z2ui5_cl_pop_*`)
+
+Every built-in popup is itself an app: build via `...=>factory( )`, push with
+`client->nav_app_call( )`. Read the result in the navigated-back branch.
+
+| pop class | Purpose | Sample |
+|---|---|---|
+| `z2ui5_cl_pop_to_inform` | info message | app_151 |
+| `z2ui5_cl_pop_to_confirm` | yes/no, fires confirm/cancel events | app_150 |
+| `z2ui5_cl_pop_to_select` | pick row(s) from a table | app_174 |
+| `z2ui5_cl_pop_messages` / `_bal` / `_error` | bapiret / BAL / exception | app_154 |
+| `z2ui5_cl_pop_file_ul` / `_file_dl` | file upload / download | app_157 / app_168 |
+| `z2ui5_cl_pop_get_range` / `_get_range_m` | build select-options | app_056 / app_162 |
+| `z2ui5_cl_pop_input_val` / `_textedit` / `_pdf` / `_html` | value/text/PDF/HTML | app_156/155/158/149 |
+
+```abap
+" Confirm — fires named events back into THIS app (app_150)
+client->nav_app_call( z2ui5_cl_pop_to_confirm=>factory(
+    i_question_text = `this is a question`
+    i_event_confirm = `POPUP_TRUE`
+    i_event_cancel  = `POPUP_FALSE` ) ).
+" ... later:  ELSEIF client->check_on_event( `POPUP_TRUE` ). ...
+
+" Select — pass a table, read result on navigated-back (app_174)
+client->nav_app_call( z2ui5_cl_pop_to_select=>factory(
+    i_tab = mt_tab  i_multiselect = abap_true  i_title = `Multi select` ) ).
+" in on_navigation:
+DATA(ls_result) = CAST z2ui5_cl_pop_to_select(
+    client->get_app( client->get( )-s_draft-id_prev_app ) )->result( ).
+```
+
+## 4. Custom popup / popover built with a view
+
+`factory_popup( )` builds `dialog`/`popover`/`message_view` XML; show with
+`client->popup_display( xml )` (modal) or
+`client->popover_display( xml = ... by_id = <control id> )` (anchored). Close with
+`popup_destroy( )` / `popover_destroy( )`, or
+`_event_client( client->cs_event-popup_close )` (no roundtrip). **Canonical:
+`z2ui5_cl_demo_app_038`** (popover with placement: `app_026`).
+
+```abap
+DATA(popup) = z2ui5_cl_xml_view=>factory_popup( ).
+popup = popup->dialog( title      = `Messages`
+                       afterclose = client->_event_client( client->cs_event-popup_close ) ).
+popup->buttons( )->button( text  = `Continue`
+                           press = client->_event_client( client->cs_event-popup_close )
+                           type  = `Emphasized` ).
+client->popup_display( popup->stringify( ) ).
+```
+
+## 5. App-to-app navigation with parameters and result
+
+Push a sub-app with `nav_app_call( NEW sub( ) )`; pass parameters by setting
+**public attributes on the instance before the call**. On return,
+`check_on_navigated` is true; read results via `CAST sub( client->get_app_prev( ) )`.
+**Canonical: `z2ui5_cl_demo_app_024`** (caller) + `z2ui5_cl_demo_app_025` (sub-app).
+
+```abap
+" Caller: set instance attributes, then push
+WHEN `CALL_NEW_APP_READ`.
+  DATA(app_next) = NEW z2ui5_cl_demo_app_025( ).
+  app_next->input_previous_set = input.
+  client->nav_app_call( app_next ).
+
+" Caller's navigated-back branch: read the sub-app's result
+ELSEIF client->check_on_navigated( ).
+  DATA(app_025) = CAST z2ui5_cl_demo_app_025( client->get_app_prev( ) ).
+  client->message_box_display( |Input from sub app: { app_025->input }| ).
+```
+
+Dynamic launch by class name: `CREATE OBJECT li_app TYPE (lv_classname).
+client->nav_app_call( li_app ).` (see `z2ui5_cl_demo_app_000`).
+
+## 6. File upload and download (base64)
+
+Files cross the wire as base64 data URIs. Decode with
+`z2ui5_cl_util=>conv_decode_x_base64( )` -> `conv_get_string_by_xstring( )`.
+**Upload canonical: `z2ui5_cl_demo_app_075`**, **download: `z2ui5_cl_demo_app_186`**.
+
+```abap
+" Upload: strip the "data:mime;base64," prefix, then decode
+SPLIT mv_value AT `;` INTO DATA(lv_dummy) DATA(lv_data).
+SPLIT lv_data  AT `,` INTO lv_dummy lv_data.
+DATA(lv_x)  = z2ui5_cl_util=>conv_decode_x_base64( lv_data ).
+mv_file     = z2ui5_cl_util=>conv_get_string_by_xstring( lv_x ).
+
+" Download via client action
+client->action->gen(
+    val   = client->cs_event-download_b64_file
+    t_arg = VALUE #( ( file_content_64 ) ( file_name ) ) ).
+```
+
+Simpler: `z2ui5_cl_pop_file_ul=>factory( )` / `z2ui5_cl_pop_file_dl=>factory( file )`.
+
+## 7. Two-way binding patterns
+
+`_bind_edit( var )` = two-way (`{/XX/...}`), read back next roundtrip.
+`_bind( var )` = read-only (display, list/combo items). Works on scalars,
+structure components, and tables. Use `path = abap_true` when only the path is
+needed inside a JSON literal (`items`/`rows`). **Canonical: `z2ui5_cl_demo_app_002`**.
+
+```abap
+)->date_picker( client->_bind_edit( s_screen-date )
+)->combobox( selectedkey = client->_bind_edit( s_screen-combo_key )
+             items       = client->_bind( t_combo )
+    )->item( key = `{KEY}` text = `{TEXT}` ).
+
+" valueState / valueStateText for validation feedback (app_298)
+)->select( selectedkey    = client->_bind( key )
+           valuestate     = `Error`
+           valuestatetext = `error value state text`
+           items          = client->_bind( lt_products ) ).
+```
+
+## 8. Events with arguments
+
+`client->_event( val = 'NAME' t_arg = VALUE #( ( ... ) ) )` attaches args
+collected on the client at fire time; read them via `client->get( )-t_event_arg`
+(1-based). Arg expressions: literals, model values, source-control properties
+(`${$source>/text}`), event params (`${$parameters>/value}`). **Canonical:
+`z2ui5_cl_demo_app_167`** (per-cell args: `app_160`).
+
+```abap
+page->input( submit = client->_event( val   = `EVENT_PROPERTY_VALUE`
+                                      t_arg = VALUE #( ( `${$parameters>/value}` ) ) ) ).
+" read back
+CASE client->get( )-event.
+  WHEN `EVENT_PROPERTY_VALUE`.
+    client->message_box_display( `arg: ` && client->get( )-t_event_arg[ 1 ] ).
+ENDCASE.
+```
+
+## 9. Custom controls / HTML / CSS / JS
+
+```abap
+" Raw HTML (app_242)
+page->vertical_layout( )->content( `layout`
+    )->html( `<div class="content"><h4>Lorem ipsum</h4></div>` ).
+
+" Code editor (app_035)
+page->code_editor( type = client->_bind_edit( mv_type ) value = client->_bind( mv_editor ) ).
+
+" Custom-namespace control: _z2ui5( ) switches into the z2ui5.cc namespace (app_075)
+footer->_z2ui5( )->file_uploader( value  = client->_bind_edit( mv_value )
+                                  upload = client->_event( `UPLOAD` ) ).
+
+" Own CSS to the frontend (app_050) / JS loader popup (app_090)
+client->nav_app_call( z2ui5_cl_pop_js_loader=>factory( get_custom_js( ) ) ).
+```
+CSS classes apply via `class = 'sapUi...'` on any control (e.g.
+`sapUiContentPadding`, `sapUiTinyMargin`).
+
+## Cross-cutting notes
+- `factory( )` -> normal view (`view_display`); `factory_popup( )` -> popup/popover XML.
+- Hand a result back from a pushed app/popup with
+  `client->get_app( client->get( )-s_draft-id_prev_app )` (or `get_app_prev( )`) + `CAST`.
+- `path = abap_true` returns just the binding path (for JSON literals);
+  without it you get the full `{...}` expression.
+- The `)->x( ... )->get_parent(` idiom adds a child then walks back up so the
+  next sibling attaches at the right level — this is why `get_parent` is the most
+  frequent call in the whole sample set.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/setup.md
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/reference/setup.md
@@ -1,0 +1,58 @@
+# Setup — from nothing to a running app
+
+You only do this **once per system/project**. After the framework is installed
+and one HTTP entry point exists, every new app is just a new class implementing
+`z2ui5_if_app` — no extra wiring.
+
+## 1. Install the framework
+Pull abap2UI5 into the system with **abapGit**:
+- Repo: `https://github.com/abap2UI5/abap2UI5`
+- It is self-contained — no other dependencies, no JS build, no OData/RAP.
+- Works on NW 7.02+ (on-premise) and ABAP Cloud.
+
+Optionally also install the examples for reference:
+`https://github.com/abap2UI5/abap2UI5-samples`.
+
+## 2. Create the HTTP entry point
+abap2UI5 needs one HTTP handler that hands incoming requests to the framework.
+The handler is ~15 lines and the same for every app you ever build — the app
+that runs is chosen at runtime (e.g. via startup parameter / launchpad), not
+hard-coded here.
+
+### On-premise (ICF node)
+1. Create an ICF service node (transaction `SICF`, e.g. under
+   `/sap/bc/z2ui5`).
+2. Point it at a handler class whose `IF_HTTP_EXTENSION~HANDLE_REQUEST` delegates
+   to the framework:
+   ```abap
+   METHOD if_http_extension~handle_request.
+     DATA(app) = z2ui5_cl_http_handler=>factory( server ).
+     app->main( ).
+   ENDMETHOD.
+   ```
+   Use the reference handler `zcl_sicf` in the framework repo
+   (`node/srv/zcl_sicf.clas.abap`) as the template.
+3. Activate the service. The app is reachable at the service URL.
+
+### ABAP Cloud
+Use `z2ui5_cl_http_handler=>factory_cloud( )` from a class implementing
+`if_http_service_extension`, exposed via an **HTTP service** (IAM/“Service
+Binding”) in the ABAP Development Tools (Eclipse). The app class itself is
+identical to on-premise.
+
+> Exact, screenshot-level steps (SICF config, cloud service binding, launchpad
+> integration) are in the official docs — link the user there rather than
+> guessing system specifics: <https://abap2ui5.github.io/docs/>.
+
+## 3. Run an app
+- Open the ICF service URL in a browser; abap2UI5 serves the UI5 shell and starts
+  the configured startup app.
+- To launch a specific app, follow the project's startup mechanism (startup
+  parameter / a small menu app that calls `client->nav_app_call( NEW zcl_my_app( ) )`).
+- For local development without a backend, the framework repo ships a Node dev
+  server (`npm run express`, port 3000) used for its own frontend tests — that is
+  for framework development, not for running your ABAP apps.
+
+## 4. Iterate
+With the handler in place, building a new app is: write the class → activate →
+launch it. No handler or routing changes are needed per app.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/templates/app_canonical.clas.abap
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/templates/app_canonical.clas.abap
@@ -1,0 +1,100 @@
+"! Larger abap2UI5 app — main( ) is a dispatcher; logic in on_init / on_event.
+"! Add only the methods you actually need. Rename ZCL_MY_APP to your own class,
+"! and adjust the style (FINAL, prefixes) to match your project's ABAP standards.
+CLASS zcl_my_app DEFINITION PUBLIC FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    TYPES:
+      BEGIN OF ty_s_row,
+        id   TYPE string,
+        text TYPE string,
+      END OF ty_s_row.
+    DATA t_rows TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS on_init.
+    METHODS on_event.
+    METHODS view_display.
+    METHODS data_read.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS zcl_my_app IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+    IF client->check_on_init( ).
+      on_init( ).
+    ELSEIF client->check_on_event( ).
+      on_event( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD on_init.
+
+    data_read( ).
+    view_display( ).
+
+  ENDMETHOD.
+
+
+  METHOD on_event.
+
+    CASE client->get( )-event.
+      WHEN `SAVE`.
+        client->message_toast_display( `Saved` ).
+      WHEN `BACK`.
+        client->nav_app_leave( ).
+    ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD data_read.
+
+    t_rows = VALUE #(
+        ( id = `1` text = `First` )
+        ( id = `2` text = `Second` ) ).
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(page) = view->shell(
+        )->page(
+            title          = `My abap2UI5 App`
+            navbuttonpress = client->_event_nav_app_leave( )
+            shownavbutton  = client->check_app_prev_stack( ) ).
+
+    DATA(tab) = page->table( client->_bind( t_rows ) ).
+    tab->columns(
+        )->column( )->text( `Id` )->get_parent(
+        )->column( )->text( `Text` ).
+    tab->items( )->column_list_item(
+        )->cells(
+            )->text( `{ID}`
+            )->text( `{TEXT}` ).
+
+    page->footer( )->overflow_toolbar(
+        )->toolbar_spacer(
+        )->button(
+            text  = `Save`
+            press = client->_event( `SAVE` )
+            type  = `Emphasized` ).
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/abap2ui5-claude-plugin/skills/abap2ui5-app/templates/app_simple.clas.abap
+++ b/abap2ui5-claude-plugin/skills/abap2ui5-app/templates/app_simple.clas.abap
@@ -1,0 +1,51 @@
+"! Minimal abap2UI5 app — everything in main( ).
+"! Rename ZCL_MY_APP to your own class, in your own namespace, and adjust the
+"! style (FINAL, prefixes) to match your project's ABAP standards.
+CLASS zcl_my_app DEFINITION PUBLIC FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    DATA product  TYPE string.
+    DATA quantity TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS zcl_my_app IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    IF client->check_on_init( ).
+
+      product  = `Product`.
+      quantity = `500`.
+
+      DATA(view) = z2ui5_cl_xml_view=>factory( ).
+      view->shell(
+          )->page(
+              title          = `My abap2UI5 App`
+              navbuttonpress = client->_event_nav_app_leave( )
+              shownavbutton  = client->check_app_prev_stack( )
+              )->simple_form(
+                  title    = `Form`
+                  editable = abap_true
+                  )->content( `form`
+                  )->label( `Quantity`
+                  )->input( client->_bind_edit( quantity )
+                  )->label( `Product`
+                  )->input( value = product
+                  )->button(
+                      text  = `Post`
+                      press = client->_event( `POST` ) ).
+      client->view_display( view->stringify( ) ).
+
+    ELSEIF client->check_on_event( `POST` ).
+      client->message_toast_display( |{ product } { quantity } - sent to the server| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.


### PR DESCRIPTION
## Summary
Introduces a complete Claude Code plugin for building abap2UI5 applications in pure ABAP. The plugin ships a single skill (`abap2ui5-app`) with comprehensive reference documentation, code templates, and a mined recipe/control catalog derived from the ~360 official sample apps.

## Key Changes

- **Plugin manifest** (`.claude-plugin/plugin.json`, `marketplace.json`): Registers the plugin and skill for Claude Code discovery and installation.

- **Skill definition** (`SKILL.md`): Documents the complete workflow for building an abap2UI5 app:
  - Prerequisites and framework setup
  - App clarification (class name, package, target platform)
  - Example discovery and adaptation
  - Structure selection (small vs. large apps)
  - Implementation guidance
  - Wiring and validation

- **Reference documentation**:
  - `setup.md`: One-time framework installation, HTTP/ICF entry point wiring (on-premise and ABAP Cloud), and app launch
  - `examples-index.md`: Lookup table mapping ~360 official demo classes to features (binding, events, tables, popups, file I/O, charts, layouts, etc.)
  - `controls.md`: Ranked catalog of fluent `z2ui5_cl_xml_view` builder methods and `client` API methods by real usage frequency
  - `recipes.md`: Copy-pasteable patterns for common tasks (editable tables, grid/tree tables, built-in popups, custom popups, app-to-app navigation, file up/download, binding, events, custom controls)
  - `conventions.md`: abap2UI5 essentials (lifecycle checks, binding direction, view building, navigation) and two ABAP style flavors for matching project standards

- **Code templates**:
  - `app_simple.clas.abap`: Minimal app with everything in `main( )`
  - `app_canonical.clas.abap`: Larger app with dispatcher pattern and separate `on_init`, `on_event`, `view_display`, `data_read` methods

- **README.md**: Plugin overview, installation instructions, and directory structure

## Implementation Details

- All reference docs are mined from the official abap2UI5 samples repo (~360 demo classes) to ensure accuracy and real-world applicability.
- The examples index and recipes are organized by feature area (General, Input & Output, Tables & Trees, Popups, Controls, Extensions, Charts) for easy discovery.
- Templates follow established ABAP conventions and are intentionally light on prefixes to match the style of the framework's own sample apps.
- The skill guides users through a structured build process: clarify intent → find worked example → choose structure → write class → wire entry point → validate.

https://claude.ai/code/session_01XiE31SH5SYPsJ2SGbDqeZR