### PR TITLE
Add conv_exit method for SAP conversion exit function calls

### DIFF
--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -532,6 +532,13 @@ CLASS z2ui5_cl_util DEFINITION
       RETURNING
         VALUE(result) TYPE string.
 
+    CLASS-METHODS conv_exit
+      IMPORTING
+        convexit TYPE clike
+        output   TYPE abap_bool DEFAULT abap_false
+      CHANGING
+        value    TYPE data.
+
     CLASS-METHODS rtti_check_clike
       IMPORTING
         val           TYPE any
@@ -1471,6 +1478,41 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
         ENDCASE.
       CATCH cx_root INTO DATA(x).
         DATA(lv_error) = x->get_text( ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD conv_exit.
+
+    DATA(conex) = COND string( WHEN output = abap_true
+                               THEN |CONVERSION_EXIT_{ convexit }_OUTPUT|
+                               ELSE |CONVERSION_EXIT_{ convexit }_INPUT| ).
+
+    TRY.
+        IF convexit = `CUNIT`.
+
+          CALL FUNCTION conex
+            EXPORTING
+              input    = value
+              language = sy-langu
+            IMPORTING
+              output   = value
+            EXCEPTIONS
+              OTHERS   = 99.
+
+        ELSE.
+
+          CALL FUNCTION conex
+            EXPORTING
+              input  = value
+            IMPORTING
+              output = value
+            EXCEPTIONS
+              OTHERS = 99.
+
+        ENDIF.
+
+      CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 
   ENDMETHOD.


### PR DESCRIPTION
## Summary
Added a new `conv_exit` class method to the utility class that provides a wrapper for calling SAP conversion exit functions (CONVERSION_EXIT_*_INPUT/OUTPUT). This method handles the dynamic invocation of conversion functions with proper exception handling.

## Key Changes
- Added `conv_exit` method to `z2ui5_cl_util` class that:
  - Accepts a conversion exit name and a flag to determine INPUT vs OUTPUT mode
  - Dynamically constructs the conversion function name based on the `convexit` parameter
  - Handles special case for `CUNIT` conversion exit which requires a `language` parameter
  - Calls the appropriate conversion function with proper exception handling
  - Modifies the value parameter in-place with the conversion result

## Implementation Details
- The method uses conditional logic to build the function name: `CONVERSION_EXIT_{convexit}_OUTPUT` or `CONVERSION_EXIT_{convexit}_INPUT`
- Special handling for CUNIT conversion exit includes the `sy-langu` (system language) parameter
- All other conversion exits use the standard INPUT/OUTPUT parameter interface
- Exceptions are caught and suppressed to allow graceful handling of missing or invalid conversion functions

https://claude.ai/code/session_01T3f6uWKeqTiwjiBvp7miiH