### PR TITLE
Upgrade development dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,13 +10,13 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@sap/ui5-builder-webide-extension": "^1.1.10",
-        "@sap/ux-ui5-tooling": "^1.25.0",
-        "@ui5/cli": "^4.0.55",
-        "@ui5/linter": "^1.21.2",
-        "eslint": "^10.4.1",
-        "globals": "^17.6.0",
+        "@sap/ux-ui5-tooling": "^1.27.0",
+        "@ui5/cli": "^4.0.57",
+        "@ui5/linter": "^1.23.1",
+        "eslint": "^10.6.0",
+        "globals": "^17.7.0",
         "mbt": "^1.2.49",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.4",
         "rimraf": "^6.1.3"
       }
     },
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/@sap/ux-ui5-tooling": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@sap/ux-ui5-tooling/-/ux-ui5-tooling-1.25.0.tgz",
-      "integrity": "sha512-D0nRtni7jZtJMM4j8DgETbPIqyf5utyKSlKvDPSEsAhwdHnT+I55auj6dp5QdUnp1qERaBiHu/L4rErmkyPAaQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@sap/ux-ui5-tooling/-/ux-ui5-tooling-1.27.0.tgz",
+      "integrity": "sha512-nQXBBiYViIz7TypaapfwV69NKpsbu1lRNtqSVojdTIhAk4wezI65FqmP7qgIrNF4bYiEoeemMAHCA2b3tizqXQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
@@ -836,27 +836,27 @@
       }
     },
     "node_modules/@ui5/cli": {
-      "version": "4.0.55",
-      "resolved": "https://registry.npmjs.org/@ui5/cli/-/cli-4.0.55.tgz",
-      "integrity": "sha512-q1LZLGYgT4LP9G9VIVM2nkkANo1IaACqtsOYK9c6/tF9/yfzxeTyh2tRZ0lOByHMvrVdkYh6Ictg2QhPKkTXsA==",
+      "version": "4.0.57",
+      "resolved": "https://registry.npmjs.org/@ui5/cli/-/cli-4.0.57.tgz",
+      "integrity": "sha512-UJA+nI4IBG5p+08F28Htkj5o+a+0kh2RhE4IQ0t1TJQ2lMYaqCXBKYHoWeTWG6FOv/ahN4jCynhObVSttaElgw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ui5/builder": "^4.1.6",
+        "@ui5/builder": "^4.2.0",
         "@ui5/fs": "^4.0.6",
         "@ui5/logger": "^4.0.2",
-        "@ui5/project": "^4.0.16",
+        "@ui5/project": "^4.0.17",
         "@ui5/server": "^4.0.15",
         "chalk": "^5.6.2",
         "data-with-position": "^0.5.0",
         "import-local": "^3.2.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "open": "^11.0.0",
         "pretty-hrtime": "^1.0.3",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "update-notifier": "^7.3.1",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.3"
       },
       "bin": {
         "ui5": "bin/ui5.cjs"
@@ -1299,9 +1299,9 @@
       "license": "ISC"
     },
     "node_modules/@ui5/cli/node_modules/@pnpm/npm-conf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1496,14 +1496,14 @@
       "license": "MIT"
     },
     "node_modules/@ui5/cli/node_modules/@ui5/builder": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-4.1.6.tgz",
-      "integrity": "sha512-e0SdT7f8HP4Fz1yZUofs4f6BJZCxh/KtxSyFIOuuidzoIK0f9Lpd4Rr135fzates+YZSrteb4BoECu3kevvFPg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-4.2.0.tgz",
+      "integrity": "sha512-fwVzgEyW6Ji4LZuManLbyyLWgDAgyLoUfPIAztjgHsLtBbAR51UvELodH00HxO4Me2MZfZdHmwIApoMTxjSTqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5",
-        "@ui5/fs": "^4.0.5",
+        "@ui5/fs": "^4.0.6",
         "@ui5/logger": "^4.0.2",
         "cheerio": "1.0.0",
         "escape-unicode": "^0.3.0",
@@ -1513,9 +1513,9 @@
         "jsdoc": "^4.0.5",
         "less-openui5": "^0.11.6",
         "pretty-data": "^0.40.0",
-        "semver": "^7.7.4",
-        "terser": "^5.46.1",
-        "workerpool": "^9.3.4",
+        "semver": "^7.8.4",
+        "terser": "^5.48.0",
+        "workerpool": "^10.0.2",
         "xml2js": "^0.6.2"
       },
       "engines": {
@@ -1561,14 +1561,14 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/@ui5/project": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.16.tgz",
-      "integrity": "sha512-zSNY24itJqgnfg2MT5UPmzJ7805nPEFgrDvVC+EnrlafGvgWPknEQelH4+GfY3adNnUxst36MD52U76nd7nQCA==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.17.tgz",
+      "integrity": "sha512-W/RoE179OTfloubSfgfnnbTf+DSZZxVnTYuhftaezdreZzvbxcqlLdPMZvwGPcaq9qwu5A3x4eEHtTNlC3Lopw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/config": "^9.0.0",
-        "@ui5/fs": "^4.0.5",
+        "@ui5/fs": "^4.0.6",
         "@ui5/logger": "^4.0.2",
         "ajv": "^8.20.0",
         "ajv-errors": "^3.0.0",
@@ -1576,7 +1576,7 @@
         "escape-string-regexp": "^5.0.0",
         "globby": "^14.1.0",
         "graceful-fs": "^4.2.11",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "lockfile": "^1.0.4",
         "make-fetch-happen": "^14.0.3",
         "node-stream-zip": "^1.15.0",
@@ -1585,7 +1585,7 @@
         "read-package-up": "^11.0.0",
         "read-pkg": "^9.0.1",
         "resolve": "^1.22.12",
-        "semver": "^7.8.0",
+        "semver": "^7.8.4",
         "xml2js": "^0.6.2",
         "yesno": "^0.4.0"
       },
@@ -1594,7 +1594,7 @@
         "npm": ">= 8"
       },
       "peerDependencies": {
-        "@ui5/builder": "^4.1.6"
+        "@ui5/builder": "^4.2.0"
       },
       "peerDependenciesMeta": {
         "@ui5/builder": {
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1874,21 +1874,21 @@
       "license": "MIT"
     },
     "node_modules/@ui5/cli/node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2425,13 +2425,17 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@ui5/cli/node_modules/cookie": {
@@ -3161,6 +3165,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/@ui5/cli/node_modules/express/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@ui5/cli/node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3693,9 +3707,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4253,10 +4267,20 @@
       "license": "MIT"
     },
     "node_modules/@ui5/cli/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6335,9 +6359,9 @@
       "license": "MIT"
     },
     "node_modules/@ui5/cli/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6436,15 +6460,15 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6901,9 +6925,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6947,9 +6971,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7020,20 +7044,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@ui5/cli/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@ui5/cli/node_modules/type-is/node_modules/mime-types": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
@@ -7066,9 +7076,9 @@
       "license": "MIT"
     },
     "node_modules/@ui5/cli/node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7291,9 +7301,9 @@
       }
     },
     "node_modules/@ui5/cli/node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.2.tgz",
+      "integrity": "sha512-8PCeZlCwu0+8hXruze1ahYNsY+M0LOCmbmySZ9BWWqWIXP9TAXa6FZCxACTDL/0j47pFcC4xW98Gr8nAC5oymg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -7497,9 +7507,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ui5/cli/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7558,33 +7568,33 @@
       }
     },
     "node_modules/@ui5/linter": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@ui5/linter/-/linter-1.21.2.tgz",
-      "integrity": "sha512-BNDeIin2o3OoFDk0DbLOcFsTLTc+/oecwe1waSBOqJ3kHsB5favBWrf9gy8l5ErhXjWA0A+6Dwfu99mFxHTTkQ==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@ui5/linter/-/linter-1.23.1.tgz",
+      "integrity": "sha512-WZtxyzlJIIkX78GUlFmghPj+GmLl8icrnbNFVNo/Xm6fIbMxQeytcf6wZISIVB+paTbrpbPELjfa3sOJccMqqw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@jridgewell/trace-mapping": "^0.3.31",
-        "@sapui5/types": "1.136.16",
+        "@sapui5/types": "1.136.19",
         "@ui5/fs": "^4.0.6",
         "@ui5/logger": "^4.0.2",
-        "@ui5/project": "^4.0.16",
+        "@ui5/project": "^4.0.17",
         "chalk": "^5.6.2",
         "data-with-position": "^0.5.0",
-        "fast-xml-parser": "^5.8.0",
+        "fast-xml-parser": "^5.9.3",
         "figures": "^6.1.0",
-        "globals": "^17.6.0",
+        "globals": "^17.7.0",
         "he": "^1.2.0",
         "json-source-map": "^0.6.1",
         "magic-string": "^0.30.21",
         "minimatch": "^10.2.5",
         "sax-wasm": "^3.1.4",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "typescript": "^5.9.3",
         "update-notifier": "^7.3.1",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.3"
       },
       "bin": {
         "ui5lint": "bin/ui5lint.js"
@@ -7679,9 +7689,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "dev": true,
       "funding": [
         {
@@ -7933,9 +7943,9 @@
       "license": "ISC"
     },
     "node_modules/@ui5/linter/node_modules/@pnpm/npm-conf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7948,9 +7958,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/@sapui5/types": {
-      "version": "1.136.16",
-      "resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.136.16.tgz",
-      "integrity": "sha512-5xEuMPF3gPQtDbgieBVPDkiy2pNZvsAyga1VvIF2vgIGbU1wzrLL4eGtboODtnDQ1ZaeQIjTvmMcL7VPecfs/w==",
+      "version": "1.136.19",
+      "resolved": "https://registry.npmjs.org/@sapui5/types/-/types-1.136.19.tgz",
+      "integrity": "sha512-dVfHO8ucVLlo59tlPycJBlkJlxo3Eo+7cIfETChC3mseQfW2B0fz9sNLZM4vnr03eH+CDIMUD6i8PRWTpL0xIA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -8193,14 +8203,14 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/@ui5/project": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.16.tgz",
-      "integrity": "sha512-zSNY24itJqgnfg2MT5UPmzJ7805nPEFgrDvVC+EnrlafGvgWPknEQelH4+GfY3adNnUxst36MD52U76nd7nQCA==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.17.tgz",
+      "integrity": "sha512-W/RoE179OTfloubSfgfnnbTf+DSZZxVnTYuhftaezdreZzvbxcqlLdPMZvwGPcaq9qwu5A3x4eEHtTNlC3Lopw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/config": "^9.0.0",
-        "@ui5/fs": "^4.0.5",
+        "@ui5/fs": "^4.0.6",
         "@ui5/logger": "^4.0.2",
         "ajv": "^8.20.0",
         "ajv-errors": "^3.0.0",
@@ -8208,7 +8218,7 @@
         "escape-string-regexp": "^5.0.0",
         "globby": "^14.1.0",
         "graceful-fs": "^4.2.11",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "lockfile": "^1.0.4",
         "make-fetch-happen": "^14.0.3",
         "node-stream-zip": "^1.15.0",
@@ -8217,7 +8227,7 @@
         "read-package-up": "^11.0.0",
         "read-pkg": "^9.0.1",
         "resolve": "^1.22.12",
-        "semver": "^7.8.0",
+        "semver": "^7.8.4",
         "xml2js": "^0.6.2",
         "yesno": "^0.4.0"
       },
@@ -8226,7 +8236,7 @@
         "npm": ">= 8"
       },
       "peerDependencies": {
-        "@ui5/builder": "^4.1.6"
+        "@ui5/builder": "^4.2.0"
       },
       "peerDependenciesMeta": {
         "@ui5/builder": {
@@ -8286,10 +8296,20 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/@ui5/project/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8448,6 +8468,19 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/@ui5/linter/node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@ui5/linter/node_modules/atomically": {
       "version": "2.1.1",
@@ -9049,9 +9082,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
       "dev": true,
       "funding": [
         {
@@ -9061,10 +9094,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
+        "@nodable/entities": "^2.2.0",
         "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
+        "strnum": "^2.4.1",
         "xml-naming": "^0.1.0"
       },
       "bin": {
@@ -9260,9 +9294,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9637,6 +9671,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ui5/linter/node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@ui5/linter/node_modules/isexe": {
       "version": "3.1.5",
@@ -10547,9 +10594,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "dev": true,
       "funding": [
         {
@@ -11000,9 +11047,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11271,9 +11318,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "dev": true,
       "funding": [
         {
@@ -11281,7 +11328,10 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/@ui5/linter/node_modules/stubborn-fs": {
       "version": "2.0.0",
@@ -11314,9 +11364,9 @@
       }
     },
     "node_modules/@ui5/linter/node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11776,9 +11826,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ui5/linter/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12426,11 +12476,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -12974,9 +13027,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13691,9 +13744,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,13 +12,13 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@sap/ui5-builder-webide-extension": "^1.1.10",
-    "@sap/ux-ui5-tooling": "^1.25.0",
-    "@ui5/cli": "^4.0.55",
-    "@ui5/linter": "^1.21.2",
-    "eslint": "^10.4.1",
-    "globals": "^17.6.0",
+    "@sap/ux-ui5-tooling": "^1.27.0",
+    "@ui5/cli": "^4.0.57",
+    "@ui5/linter": "^1.23.1",
+    "eslint": "^10.6.0",
+    "globals": "^17.7.0",
     "mbt": "^1.2.49",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.4",
     "rimraf": "^6.1.3"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.142.0",
       "license": "MIT",
       "devDependencies": {
-        "@abaplint/cli": "^2.119.24",
+        "@abaplint/cli": "^2.119.49",
         "@abaplint/database-sqlite": "^2.11.78",
-        "@abaplint/runtime": "^2.13.28",
-        "@abaplint/transpiler-cli": "^2.13.28",
-        "@playwright/test": "^1.60.0",
+        "@abaplint/runtime": "^2.13.31",
+        "@abaplint/transpiler-cli": "^2.13.31",
+        "@playwright/test": "^1.61.1",
         "express": "^5.2.1"
       },
       "engines": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.119.24",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.24.tgz",
-      "integrity": "sha512-9ppE7p9Kk4JJpTijwLG4g3aCFKMa1dLPNYldIZma394e/X7M0vzi+jW9rNXHcambiVeUGhLspUuYSgY/aKpJPw==",
+      "version": "2.119.49",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.49.tgz",
+      "integrity": "sha512-iihNhZqUGNp4ywVoYJhR0nAUyHetMVh9UeuIcwXTvpL8YawxDzhmMSlMcTTKfoQgKAZHpVGBjIVVMg4i+BAKoA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.28",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.28.tgz",
-      "integrity": "sha512-2YmYU/qVSEzVnhn7jL/iTgDxVrUdrvb6kudChyn6arZkA8qEqUlj5xHWceemrGdzvt8GLyP4aWklIQN/DrKR/w==",
+      "version": "2.13.31",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.31.tgz",
+      "integrity": "sha512-X5dHHgzDXn/dzcC2Qy41byNGD12d1UmzglktsY2SatmnCXBRncaYLkkDD8j8zNWgkQrHmLCjn9DYkcmc3rq4Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.13.28",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.28.tgz",
-      "integrity": "sha512-bYR7rNKaID8upJLjDvwyU/aZPFPozL1XDG5uWykYO7/TG+THiA3rf6tS/3kDzz9wG9zddyBNdvhYT0f8kDB4+A==",
+      "version": "2.13.31",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.31.tgz",
+      "integrity": "sha512-iS/VHwQT+slHgTJ7XHkNjh4sy/ex+EzugCquugMbntEnbLm6Gy8SUi8M4BzHHmr4SupwomC0UNwN7e2gZwG0Eg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -73,13 +73,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -708,13 +708,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abaplint/cli": "^2.119.24",
+    "@abaplint/cli": "^2.119.49",
     "@abaplint/database-sqlite": "^2.11.78",
-    "@abaplint/runtime": "^2.13.28",
-    "@abaplint/transpiler-cli": "^2.13.28",
-    "@playwright/test": "^1.60.0",
+    "@abaplint/runtime": "^2.13.31",
+    "@abaplint/transpiler-cli": "^2.13.31",
+    "@playwright/test": "^1.61.1",
     "express": "^5.2.1"
   }
 }


### PR DESCRIPTION
## Summary
Updated development dependencies across the project to their latest compatible versions to improve tooling capabilities and security.

## Changes
- **app/package.json**: Updated UI5 and linting toolchain
  - `@sap/ux-ui5-tooling`: ^1.25.0 → ^1.27.0
  - `@ui5/cli`: ^4.0.55 → ^4.0.57
  - `@ui5/linter`: ^1.21.2 → ^1.23.1
  - `eslint`: ^10.4.1 → ^10.6.0
  - `globals`: ^17.6.0 → ^17.7.0
  - `prettier`: ^3.8.3 → ^3.9.4

- **package.json**: Updated ABAP tooling and testing dependencies
  - `@abaplint/cli`: ^2.119.24 → ^2.119.49
  - `@abaplint/runtime`: ^2.13.28 → ^2.13.31
  - `@abaplint/transpiler-cli`: ^2.13.28 → ^2.13.31
  - `@playwright/test`: ^1.60.0 → ^1.61.1

## Notes
- All updates are within compatible semver ranges (caret dependencies)
- Lockfiles have been regenerated to reflect transitive dependency changes

https://claude.ai/code/session_015UP4mBNJeSRN7YphSd5fZM