### PR TITLE
Refactor: Inline variable declarations in loop statements

### DIFF
--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -51,10 +51,8 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
 
   METHOD get_t_arg.
 
-    DATA temp1 LIKE LINE OF val.
-    DATA lr_arg LIKE REF TO temp1.
     DATA lv_new TYPE string.
-    LOOP AT val REFERENCE INTO lr_arg.
+    LOOP AT val REFERENCE INTO DATA(lr_arg).
 
       lv_new = lr_arg->*.
       IF lv_new IS INITIAL.

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -187,10 +187,11 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
                            reason = ms_res-status_reason ).
 
     " transform cookie to header based contextid handling
+    DATA lv_contextid TYPE string.
     IF ms_res-s_stateful-switched = abap_true.
       mo_server->set_session_stateful( ms_res-s_stateful-active ).
       IF mo_server->get_header_field( `sap-contextid-accept` ) = `header`.
-        DATA(lv_contextid) = mo_server->get_response_cookie( `sap-contextid` ).
+        lv_contextid = mo_server->get_response_cookie( `sap-contextid` ).
         IF lv_contextid IS NOT INITIAL.
           mo_server->delete_response_cookie( `sap-contextid` ).
           mo_server->set_header_field( n = `sap-contextid`


### PR DESCRIPTION
## Summary
Modernize variable declaration patterns by using inline `DATA()` declarations in loop statements, reducing unnecessary intermediate variable declarations and improving code readability.

## Key Changes
- **z2ui5_cl_core_srv_event.clas.abap**: Removed separate `DATA` declarations for `temp1` and `lr_arg`, replacing them with inline `DATA(lr_arg)` declaration in the `LOOP AT` statement
- **z2ui5_cl_http_handler.clas.abap**: Moved `lv_contextid` declaration outside the conditional block to module level, and changed inline `DATA(lv_contextid)` assignment to use the pre-declared variable

## Implementation Details
These changes follow modern ABAP conventions by:
- Eliminating unnecessary intermediate type definitions
- Using inline variable declarations where appropriate to reduce boilerplate
- Maintaining proper variable scope and initialization patterns

https://claude.ai/code/session_01KqhAYdxc3hKT2Ymc133nK1