### PR TITLE
Downgrade abaplint dependencies to stable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.142.0",
       "license": "MIT",
       "devDependencies": {
-        "@abaplint/cli": "^2.119.49",
+        "@abaplint/cli": "^2.119.24",
         "@abaplint/database-sqlite": "^2.11.78",
-        "@abaplint/runtime": "^2.13.31",
-        "@abaplint/transpiler-cli": "^2.13.31",
+        "@abaplint/runtime": "^2.13.28",
+        "@abaplint/transpiler-cli": "^2.13.28",
         "@playwright/test": "^1.61.1",
         "express": "^5.2.1"
       },
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.119.49",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.49.tgz",
-      "integrity": "sha512-iihNhZqUGNp4ywVoYJhR0nAUyHetMVh9UeuIcwXTvpL8YawxDzhmMSlMcTTKfoQgKAZHpVGBjIVVMg4i+BAKoA==",
+      "version": "2.119.24",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.24.tgz",
+      "integrity": "sha512-9ppE7p9Kk4JJpTijwLG4g3aCFKMa1dLPNYldIZma394e/X7M0vzi+jW9rNXHcambiVeUGhLspUuYSgY/aKpJPw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.31",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.31.tgz",
-      "integrity": "sha512-X5dHHgzDXn/dzcC2Qy41byNGD12d1UmzglktsY2SatmnCXBRncaYLkkDD8j8zNWgkQrHmLCjn9DYkcmc3rq4Hw==",
+      "version": "2.13.28",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.28.tgz",
+      "integrity": "sha512-2YmYU/qVSEzVnhn7jL/iTgDxVrUdrvb6kudChyn6arZkA8qEqUlj5xHWceemrGdzvt8GLyP4aWklIQN/DrKR/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.13.31",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.31.tgz",
-      "integrity": "sha512-iS/VHwQT+slHgTJ7XHkNjh4sy/ex+EzugCquugMbntEnbLm6Gy8SUi8M4BzHHmr4SupwomC0UNwN7e2gZwG0Eg==",
+      "version": "2.13.28",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.28.tgz",
+      "integrity": "sha512-bYR7rNKaID8upJLjDvwyU/aZPFPozL1XDG5uWykYO7/TG+THiA3rf6tS/3kDzz9wG9zddyBNdvhYT0f8kDB4+A==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abaplint/cli": "^2.119.49",
+    "@abaplint/cli": "^2.119.24",
     "@abaplint/database-sqlite": "^2.11.78",
-    "@abaplint/runtime": "^2.13.31",
-    "@abaplint/transpiler-cli": "^2.13.31",
+    "@abaplint/runtime": "^2.13.28",
+    "@abaplint/transpiler-cli": "^2.13.28",
     "@playwright/test": "^1.61.1",
     "express": "^5.2.1"
   }


### PR DESCRIPTION
## Summary
This PR downgrades several abaplint-related dependencies to earlier stable versions to ensure compatibility and stability.

## Changes
- `@abaplint/cli`: `^2.119.49` → `^2.119.24`
- `@abaplint/runtime`: `^2.13.31` → `^2.13.28`
- `@abaplint/transpiler-cli`: `^2.13.31` → `^2.13.28`

## Notes
These version reductions target specific patch versions within the same minor version ranges, suggesting a rollback to previously tested and stable releases.

https://claude.ai/code/session_01AESboBMe6xunkRZ5ce2imy