### PR TITLE
Fix ShellUIService initialization to use component service

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -119,7 +119,14 @@ sap.ui.define(
           }
         };
 
-        Container.getServiceAsync("ShellUIService")
+        // ShellUIService is a UI5 service (factory
+        // sap.ushell.ui5service.ShellUIService, declared in manifest.json),
+        // not a Container service. Requesting it via Container.getServiceAsync
+        // resolves to sap/ushell/services/ShellUIService.js, which does not
+        // exist in the (ABAP) launchpad and fails with a 404. The component's
+        // getService() honors the manifest declaration and returns the
+        // correctly scoped instance.
+        this.getService("ShellUIService")
           .then((s) => setIfAlive("ShellUIService", s))
           .catch((e) =>
             Lib.logError("Component: ShellUIService init failed", e),

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -139,7 +139,14 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `          }` && |\n| &&
              `        };` && |\n| &&
              `` && |\n| &&
-             `        Container.getServiceAsync("ShellUIService")` && |\n| &&
+             `        // ShellUIService is a UI5 service (factory` && |\n| &&
+             `        // sap.ushell.ui5service.ShellUIService, declared in manifest.json),` && |\n| &&
+             `        // not a Container service. Requesting it via Container.getServiceAsync` && |\n| &&
+             `        // resolves to sap/ushell/services/ShellUIService.js, which does not` && |\n| &&
+             `        // exist in the (ABAP) launchpad and fails with a 404. The component's` && |\n| &&
+             `        // getService() honors the manifest declaration and returns the` && |\n| &&
+             `        // correctly scoped instance.` && |\n| &&
+             `        this.getService("ShellUIService")` && |\n| &&
              `          .then((s) => setIfAlive("ShellUIService", s))` && |\n| &&
              `          .catch((e) =>` && |\n| &&
              `            Lib.logError("Component: ShellUIService init failed", e),` && |\n| &&


### PR DESCRIPTION
## Summary
Changed ShellUIService initialization to use the component's `getService()` method instead of `Container.getServiceAsync()` to properly resolve the UI5 service declared in the manifest.

## Changes
- Replaced `Container.getServiceAsync("ShellUIService")` with `this.getService("ShellUIService")` in the component initialization
- Added detailed comments explaining why this change is necessary:
  - ShellUIService is a UI5 service (factory `sap.ushell.ui5service.ShellUIService`) declared in manifest.json, not a Container service
  - Using `Container.getServiceAsync()` incorrectly resolves to `sap/ushell/services/ShellUIService.js`, which doesn't exist in the ABAP launchpad and causes 404 errors
  - The component's `getService()` method properly honors the manifest declaration and returns the correctly scoped instance

## Implementation Details
- Updated both the JavaScript source file and the ABAP class that generates it
- The change maintains the same promise-based API (`.then()` and `.catch()` handlers remain unchanged)
- This fix ensures proper service resolution in ABAP launchpad environments

https://claude.ai/code/session_01N7MFc3BmQpxAkVYj2qdwzi