### PR TITLE
fix: correct toast option name, FLP logout guard, download anchor

### DIFF
--- a/app/webapp/cc/Info.js
+++ b/app/webapp/cc/Info.js
@@ -71,14 +71,7 @@ sap.ui.define(
           const ui5Version = ui5Info?.VERSION || "";
 
           // Single system-type label, same derivation as Server._getDeviceInfo.
-          let systemType = "desktop";
-          if (system.phone) {
-            systemType = "phone";
-          } else if (system.tablet) {
-            systemType = "tablet";
-          } else if (system.combi) {
-            systemType = "combi";
-          }
+          const systemType = Lib.deriveSystemType(system);
 
           const props = [
             ["ui5_version", ui5Version],

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -126,7 +126,12 @@ sap.ui.define(
           annotationURI: args[3] || "",
         });
         const oView = ViewSlots.getView("MAIN");
-        if (oView) oView.setModel(oModel, args[2] || undefined);
+        if (oView) {
+          oView.setModel(oModel, args[2] || undefined);
+        } else {
+          // No view to attach to - release the model instead of leaking it.
+          oModel.destroy();
+        }
       } catch (e) {
         Lib.logError(`SET_ODATA_MODEL: failed for '${args[1]}'`, e);
       }

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -83,7 +83,11 @@ sap.ui.define(
       const a = document.createElement("a");
       a.href = args[1];
       a.download = args[2];
+      // Firefox only triggers a programmatic download click when the anchor
+      // is part of the document, so attach it briefly and remove it again.
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
     }
 
     function evCrossAppNavToPrevApp() {
@@ -177,7 +181,10 @@ sap.ui.define(
       const logoutUrl = args[1] || "/sap/public/bc/icf/logoff";
       try {
         const container = z2ui5.oLaunchpad?.Container;
-        if (container?.logout && args.length == 0) {
+        // No explicit logout URL was passed (args is just the event name):
+        // inside the launchpad, prefer its own logout over the BSP/ICF
+        // redirect below.
+        if (container?.logout && args.length <= 1) {
           container.logout();
           return;
         }
@@ -523,15 +530,21 @@ sap.ui.define(
     function execute(oController, args) {
       Lib.runCallbacks(z2ui5.onBeforeEventFrontend, args);
 
-      // NavContainer navigation is dispatched via lookup table.
-      const navLookup = navContainerLookups[args[0]];
-      if (navLookup) {
-        navigateContainer(navLookup, args);
-        return;
-      }
+      try {
+        // NavContainer navigation is dispatched via lookup table.
+        const navLookup = navContainerLookups[args[0]];
+        if (navLookup) {
+          navigateContainer(navLookup, args);
+          return;
+        }
 
-      const handler = handlers[args[0]];
-      if (handler) handler(oController, args);
+        const handler = handlers[args[0]];
+        if (handler) handler(oController, args);
+      } catch (e) {
+        // Backstop: individual handlers already guard themselves, but a
+        // malformed payload must never let an error escape into the caller.
+        Lib.logError(`FrontendAction: handler '${args[0]}' failed`, e);
+      }
     }
 
     return { execute };

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -162,6 +162,18 @@ sap.ui.define([], () => {
     return val == null ? "" : String(val);
   }
 
+  // Collapse a UI5 Device `system` flag object into a single label. The
+  // order matters - phone/tablet/combi are mutually exclusive with the
+  // desktop fallback. Shared by Server._getDeviceInfo (request payload) and
+  // the Info control so both report the same value.
+  function deriveSystemType(system) {
+    if (!system) return "desktop";
+    if (system.phone) return "phone";
+    if (system.tablet) return "tablet";
+    if (system.combi) return "combi";
+    return "desktop";
+  }
+
   // Returns true only if the URL is on the same origin and uses http/https.
   function isValidRedirectURL(url) {
     if (!url) return false;
@@ -298,6 +310,7 @@ sap.ui.define([], () => {
     whenRendered,
     copyToClipboard,
     toText,
+    deriveSystemType,
     isValidRedirectURL,
     isSafeRedirectProtocol,
     isSafeDownloadURL,

--- a/app/webapp/core/Messages.js
+++ b/app/webapp/core/Messages.js
@@ -21,7 +21,7 @@ sap.ui.define(
         autoClose: !!msg.AUTOCLOSE,
         animationTimingFunction: msg.ANIMATIONTIMINGFUNCTION || "ease",
         animationDuration: parseMs(msg.ANIMATIONDURATION, 1000),
-        closeonBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,
+        closeOnBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,
       });
       if (msg.CLASS) {
         const classes = msg.CLASS.trim().split(/\s+/).filter(Boolean);

--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -105,17 +105,8 @@ sap.ui.define(
         // session, so resolve them once and reuse the cached block; only
         // ORIENTATION and RESIZE are read fresh on every roundtrip.
         if (!this._deviceStatic) {
-          const sys = d.system;
-          let system = "desktop";
-          if (sys.phone) {
-            system = "phone";
-          } else if (sys.tablet) {
-            system = "tablet";
-          } else if (sys.combi) {
-            system = "combi";
-          }
           this._deviceStatic = {
-            SYSTEM: system,
+            SYSTEM: Lib.deriveSystemType(d.system),
             BROWSER: {
               NAME: d.browser.name || "",
               VERSION: String(d.browser.version || ""),
@@ -141,6 +132,15 @@ sap.ui.define(
         };
       },
 
+      // Strip the owning view's "<viewId>--" prefix from a control id so the
+      // backend gets the id as the app declared it. Returns the id unchanged
+      // when it does not belong to that view.
+      _stripViewPrefix(fullId, view) {
+        if (!view) return fullId;
+        const prefix = `${view.getId()}--`;
+        return fullId.startsWith(prefix) ? fullId.slice(prefix.length) : fullId;
+      },
+
       _getFocusInfo() {
         try {
           const active = document.activeElement;
@@ -150,15 +150,14 @@ sap.ui.define(
           const ui5El = Element.closestTo?.(active) ?? null;
           if (!ui5El) return {};
           const fullId = ui5El.getId();
-          const views = ViewSlots.slots.map((slot) =>
-            ViewSlots.getView(slot.key),
-          );
           let id = fullId;
-          for (const v of views) {
-            if (!v) continue;
-            const prefix = v.getId() + "--";
-            if (fullId.startsWith(prefix)) {
-              id = fullId.slice(prefix.length);
+          for (const slot of ViewSlots.slots) {
+            const local = this._stripViewPrefix(
+              fullId,
+              ViewSlots.getView(slot.key),
+            );
+            if (local !== fullId) {
+              id = local;
               break;
             }
           }
@@ -223,10 +222,10 @@ sap.ui.define(
             continue;
           }
 
-          let id = entry.control.getId();
-          const view = ViewSlots.getView(slot.key);
-          const prefix = view ? `${view.getId()}--` : "";
-          if (prefix && id.startsWith(prefix)) id = id.slice(prefix.length);
+          const id = this._stripViewPrefix(
+            entry.control.getId(),
+            ViewSlots.getView(slot.key),
+          );
           out[slot.key] = {
             ID: id,
             X: entry.dom.scrollLeft || 0,

--- a/node/tests/utilHelpers.spec.js
+++ b/node/tests/utilHelpers.spec.js
@@ -128,6 +128,22 @@ test.describe("toText", () => {
   });
 });
 
+test.describe("deriveSystemType", () => {
+  const { Lib } = loadLib();
+
+  test("maps each device flag to its label, phone winning first", () => {
+    expect(Lib.deriveSystemType({ phone: true, tablet: true })).toBe("phone");
+    expect(Lib.deriveSystemType({ tablet: true })).toBe("tablet");
+    expect(Lib.deriveSystemType({ combi: true })).toBe("combi");
+  });
+
+  test("falls back to desktop for no flags or a missing object", () => {
+    expect(Lib.deriveSystemType({ desktop: true })).toBe("desktop");
+    expect(Lib.deriveSystemType({})).toBe("desktop");
+    expect(Lib.deriveSystemType(undefined)).toBe("desktop");
+  });
+});
+
 test.describe("runCallbacks", () => {
   test("calls every callback with the given arguments", () => {
     const { Lib } = loadLib();

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -103,7 +103,11 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const a = document.createElement("a");` && |\n| &&
              `      a.href = args[1];` && |\n| &&
              `      a.download = args[2];` && |\n| &&
+             `      // Firefox only triggers a programmatic download click when the anchor` && |\n| &&
+             `      // is part of the document, so attach it briefly and remove it again.` && |\n| &&
+             `      document.body.appendChild(a);` && |\n| &&
              `      a.click();` && |\n| &&
+             `      document.body.removeChild(a);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evCrossAppNavToPrevApp() {` && |\n| &&
@@ -197,7 +201,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const logoutUrl = args[1] || "/sap/public/bc/icf/logoff";` && |\n| &&
              `      try {` && |\n| &&
              `        const container = z2ui5.oLaunchpad?.Container;` && |\n| &&
-             `        if (container?.logout && args.length == 0) {` && |\n| &&
+             `        // No explicit logout URL was passed (args is just the event name):` && |\n| &&
+             `        // inside the launchpad, prefer its own logout over the BSP/ICF` && |\n| &&
+             `        // redirect below.` && |\n| &&
+             `        if (container?.logout && args.length <= 1) {` && |\n| &&
              `          container.logout();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
@@ -411,6 +418,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          } else if (oElement.scrollTo) {` && |\n| &&
              `            // sap.m.Page.scrollTo(y, time) - vertical only` && |\n| &&
              `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n| &&
+             |\n|.
+    result = result &&
              `            handled = true;` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&
@@ -418,8 +427,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        Lib.logError(``SCROLL_TO: failed for '${args[1]}'``, e);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
-             |\n|.
-    result = result &&
              `` && |\n| &&
              `    function evScrollIntoView(oController, args) {` && |\n| &&
              `      // args[1] = control id` && |\n| &&
@@ -545,15 +552,21 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    function execute(oController, args) {` && |\n| &&
              `      Lib.runCallbacks(z2ui5.onBeforeEventFrontend, args);` && |\n| &&
              `` && |\n| &&
-             `      // NavContainer navigation is dispatched via lookup table.` && |\n| &&
-             `      const navLookup = navContainerLookups[args[0]];` && |\n| &&
-             `      if (navLookup) {` && |\n| &&
-             `        navigateContainer(navLookup, args);` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
+             `      try {` && |\n| &&
+             `        // NavContainer navigation is dispatched via lookup table.` && |\n| &&
+             `        const navLookup = navContainerLookups[args[0]];` && |\n| &&
+             `        if (navLookup) {` && |\n| &&
+             `          navigateContainer(navLookup, args);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
              `` && |\n| &&
-             `      const handler = handlers[args[0]];` && |\n| &&
-             `      if (handler) handler(oController, args);` && |\n| &&
+             `        const handler = handlers[args[0]];` && |\n| &&
+             `        if (handler) handler(oController, args);` && |\n| &&
+             `      } catch (e) {` && |\n| &&
+             `        // Backstop: individual handlers already guard themselves, but a` && |\n| &&
+             `        // malformed payload must never let an error escape into the caller.` && |\n| &&
+             `        Lib.logError(``FrontendAction: handler '${args[0]}' failed``, e);` && |\n| &&
+             `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    return { execute };` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -146,7 +146,12 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          annotationURI: args[3] || "",` && |\n| &&
              `        });` && |\n| &&
              `        const oView = ViewSlots.getView("MAIN");` && |\n| &&
-             `        if (oView) oView.setModel(oModel, args[2] || undefined);` && |\n| &&
+             `        if (oView) {` && |\n| &&
+             `          oView.setModel(oModel, args[2] || undefined);` && |\n| &&
+             `        } else {` && |\n| &&
+             `          // No view to attach to - release the model instead of leaking it.` && |\n| &&
+             `          oModel.destroy();` && |\n| &&
+             `        }` && |\n| &&
              `      } catch (e) {` && |\n| &&
              `        Lib.logError(``SET_ODATA_MODEL: failed for '${args[1]}'``, e);` && |\n| &&
              `      }` && |\n| &&
@@ -413,13 +418,13 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            handled = true;` && |\n| &&
              `          } else if (dom) {` && |\n| &&
              `            dom.scrollTop = y;` && |\n| &&
+             |\n|.
+    result = result &&
              `            dom.scrollLeft = x;` && |\n| &&
              `            handled = true;` && |\n| &&
              `          } else if (oElement.scrollTo) {` && |\n| &&
              `            // sap.m.Page.scrollTo(y, time) - vertical only` && |\n| &&
              `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n| &&
-             |\n|.
-    result = result &&
              `            handled = true;` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_info_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_info_js.clas.abap
@@ -91,14 +91,7 @@ CLASS z2ui5_cl_app_info_js IMPLEMENTATION.
              `          const ui5Version = ui5Info?.VERSION || "";` && |\n| &&
              `` && |\n| &&
              `          // Single system-type label, same derivation as Server._getDeviceInfo.` && |\n| &&
-             `          let systemType = "desktop";` && |\n| &&
-             `          if (system.phone) {` && |\n| &&
-             `            systemType = "phone";` && |\n| &&
-             `          } else if (system.tablet) {` && |\n| &&
-             `            systemType = "tablet";` && |\n| &&
-             `          } else if (system.combi) {` && |\n| &&
-             `            systemType = "combi";` && |\n| &&
-             `          }` && |\n| &&
+             `          const systemType = Lib.deriveSystemType(system);` && |\n| &&
              `` && |\n| &&
              `          const props = [` && |\n| &&
              `            ["ui5_version", ui5Version],` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -182,6 +182,18 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `    return val == null ? "" : String(val);` && |\n| &&
              `  }` && |\n| &&
              `` && |\n| &&
+             `  // Collapse a UI5 Device ``system`` flag object into a single label. The` && |\n| &&
+             `  // order matters - phone/tablet/combi are mutually exclusive with the` && |\n| &&
+             `  // desktop fallback. Shared by Server._getDeviceInfo (request payload) and` && |\n| &&
+             `  // the Info control so both report the same value.` && |\n| &&
+             `  function deriveSystemType(system) {` && |\n| &&
+             `    if (!system) return "desktop";` && |\n| &&
+             `    if (system.phone) return "phone";` && |\n| &&
+             `    if (system.tablet) return "tablet";` && |\n| &&
+             `    if (system.combi) return "combi";` && |\n| &&
+             `    return "desktop";` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
              `  // Returns true only if the URL is on the same origin and uses http/https.` && |\n| &&
              `  function isValidRedirectURL(url) {` && |\n| &&
              `    if (!url) return false;` && |\n| &&
@@ -318,6 +330,7 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `    whenRendered,` && |\n| &&
              `    copyToClipboard,` && |\n| &&
              `    toText,` && |\n| &&
+             `    deriveSystemType,` && |\n| &&
              `    isValidRedirectURL,` && |\n| &&
              `    isSafeRedirectProtocol,` && |\n| &&
              `    isSafeDownloadURL,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_messages_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messages_js.clas.abap
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_app_messages_js IMPLEMENTATION.
              `        autoClose: !!msg.AUTOCLOSE,` && |\n| &&
              `        animationTimingFunction: msg.ANIMATIONTIMINGFUNCTION || "ease",` && |\n| &&
              `        animationDuration: parseMs(msg.ANIMATIONDURATION, 1000),` && |\n| &&
-             `        closeonBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,` && |\n| &&
+             `        closeOnBrowserNavigation: !!msg.CLOSEONBROWSERNAVIGATION,` && |\n| &&
              `      });` && |\n| &&
              `      if (msg.CLASS) {` && |\n| &&
              `        const classes = msg.CLASS.trim().split(/\s+/).filter(Boolean);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -125,17 +125,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        // session, so resolve them once and reuse the cached block; only` && |\n| &&
              `        // ORIENTATION and RESIZE are read fresh on every roundtrip.` && |\n| &&
              `        if (!this._deviceStatic) {` && |\n| &&
-             `          const sys = d.system;` && |\n| &&
-             `          let system = "desktop";` && |\n| &&
-             `          if (sys.phone) {` && |\n| &&
-             `            system = "phone";` && |\n| &&
-             `          } else if (sys.tablet) {` && |\n| &&
-             `            system = "tablet";` && |\n| &&
-             `          } else if (sys.combi) {` && |\n| &&
-             `            system = "combi";` && |\n| &&
-             `          }` && |\n| &&
              `          this._deviceStatic = {` && |\n| &&
-             `            SYSTEM: system,` && |\n| &&
+             `            SYSTEM: Lib.deriveSystemType(d.system),` && |\n| &&
              `            BROWSER: {` && |\n| &&
              `              NAME: d.browser.name || "",` && |\n| &&
              `              VERSION: String(d.browser.version || ""),` && |\n| &&
@@ -161,6 +152,15 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        };` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
+             `      // Strip the owning view's "<viewId>--" prefix from a control id so the` && |\n| &&
+             `      // backend gets the id as the app declared it. Returns the id unchanged` && |\n| &&
+             `      // when it does not belong to that view.` && |\n| &&
+             `      _stripViewPrefix(fullId, view) {` && |\n| &&
+             `        if (!view) return fullId;` && |\n| &&
+             `        const prefix = ``${view.getId()}--``;` && |\n| &&
+             `        return fullId.startsWith(prefix) ? fullId.slice(prefix.length) : fullId;` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
              `      _getFocusInfo() {` && |\n| &&
              `        try {` && |\n| &&
              `          const active = document.activeElement;` && |\n| &&
@@ -170,15 +170,14 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          const ui5El = Element.closestTo?.(active) ?? null;` && |\n| &&
              `          if (!ui5El) return {};` && |\n| &&
              `          const fullId = ui5El.getId();` && |\n| &&
-             `          const views = ViewSlots.slots.map((slot) =>` && |\n| &&
-             `            ViewSlots.getView(slot.key),` && |\n| &&
-             `          );` && |\n| &&
              `          let id = fullId;` && |\n| &&
-             `          for (const v of views) {` && |\n| &&
-             `            if (!v) continue;` && |\n| &&
-             `            const prefix = v.getId() + "--";` && |\n| &&
-             `            if (fullId.startsWith(prefix)) {` && |\n| &&
-             `              id = fullId.slice(prefix.length);` && |\n| &&
+             `          for (const slot of ViewSlots.slots) {` && |\n| &&
+             `            const local = this._stripViewPrefix(` && |\n| &&
+             `              fullId,` && |\n| &&
+             `              ViewSlots.getView(slot.key),` && |\n| &&
+             `            );` && |\n| &&
+             `            if (local !== fullId) {` && |\n| &&
+             `              id = local;` && |\n| &&
              `              break;` && |\n| &&
              `            }` && |\n| &&
              `          }` && |\n| &&
@@ -243,10 +242,10 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `            continue;` && |\n| &&
              `          }` && |\n| &&
              `` && |\n| &&
-             `          let id = entry.control.getId();` && |\n| &&
-             `          const view = ViewSlots.getView(slot.key);` && |\n| &&
-             `          const prefix = view ? ``${view.getId()}--`` : "";` && |\n| &&
-             `          if (prefix && id.startsWith(prefix)) id = id.slice(prefix.length);` && |\n| &&
+             `          const id = this._stripViewPrefix(` && |\n| &&
+             `            entry.control.getId(),` && |\n| &&
+             `            ViewSlots.getView(slot.key),` && |\n| &&
+             `          );` && |\n| &&
              `          out[slot.key] = {` && |\n| &&
              `            ID: id,` && |\n| &&
              `            X: entry.dom.scrollLeft || 0,` && |\n| &&
@@ -418,9 +417,9 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          }` && |\n| &&
              `` && |\n| &&
              `          // Partial response: refresh whichever existing views the backend` && |\n| &&
+             `          // sent updates for.` && |\n| &&
              |\n|.
     result = result &&
-             `          // sent updates for.` && |\n| &&
              `          for (const slot of ViewSlots.slots) {` && |\n| &&
              `            oController.updateModelIfRequired(slot.key);` && |\n| &&
              `          }` && |\n| &&


### PR DESCRIPTION
- Messages.js: rename "closeonBrowserNavigation" to the correct UI5
  MessageToast option "closeOnBrowserNavigation" (the typo silently
  ignored the CLOSEONBROWSERNAVIGATION setting sent by the backend).
- FrontendAction.js evSystemLogout: the launchpad logout branch was
  dead code - `args.length == 0` is never true since args always holds
  the event name. Use `args.length <= 1` so the FLP logout runs when no
  explicit logout URL was passed, as documented (also fixes the eqeqeq
  lint error).
- FrontendAction.js evDownloadB64File: attach the temporary anchor to
  the document before click(); Firefox ignores programmatic download
  clicks on detached anchors.
- FrontendAction.js execute(): wrap the handler dispatch in a try/catch
  backstop so a malformed payload cannot let an error escape the caller.

Regenerated src/01/03 embedded constants via npm run app2abap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019SQuCyP6dmn3eriCpWR2jZ