### PR TITLE
refactor: small backend improvements (avoid redundant work, fix style)

### DIFF
--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -156,10 +156,10 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
   METHOD reset_view_update_flags.
 
     ms_next-s_set-s_view-check_update_model       = abap_false.
-    ms_next-s_set-s_view_nest-check_update_model   = abap_false.
-    ms_next-s_set-s_view_nest2-check_update_model  = abap_false.
-    ms_next-s_set-s_popup-check_update_model       = abap_false.
-    ms_next-s_set-s_popover-check_update_model     = abap_false.
+    ms_next-s_set-s_view_nest-check_update_model  = abap_false.
+    ms_next-s_set-s_view_nest2-check_update_model = abap_false.
+    ms_next-s_set-s_popup-check_update_model      = abap_false.
+    ms_next-s_set-s_popover-check_update_model    = abap_false.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -244,7 +244,6 @@ CLASS Z2UI5_CL_CORE_CLIENT IMPLEMENTATION.
     mo_action->ms_next-next_event  = event.
 
     IF r_data IS NOT INITIAL.
-      CREATE DATA mo_action->ms_next-r_data LIKE r_data.
       mo_action->ms_next-r_data = z2ui5_cl_util=>conv_copy_ref_data( r_data ).
     ENDIF.
 
@@ -406,7 +405,6 @@ CLASS Z2UI5_CL_CORE_CLIENT IMPLEMENTATION.
                                 s_cnt     = s_ctrl ).
 
     IF r_data IS NOT INITIAL.
-      CREATE DATA mo_action->ms_next-r_data LIKE r_data.
       mo_action->ms_next-r_data = z2ui5_cl_util=>conv_copy_ref_data( r_data ).
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -70,9 +70,9 @@ CLASS Z2UI5_CL_CORE_CLIENT IMPLEMENTATION.
   METHOD z2ui5_if_client~check_on_event.
 
     IF val IS NOT INITIAL.
-      result = xsdbool( z2ui5_if_client~get( )-event = val ).
+      result = xsdbool( mo_action->ms_actual-event = val ).
     ELSE.
-      result = xsdbool( z2ui5_if_client~get( )-event <> `` ).
+      result = xsdbool( mo_action->ms_actual-event <> `` ).
     ENDIF.
 
   ENDMETHOD.
@@ -237,7 +237,7 @@ CLASS Z2UI5_CL_CORE_CLIENT IMPLEMENTATION.
   METHOD z2ui5_if_client~nav_app_leave.
 
     IF app IS NOT SUPPLIED.
-      app = z2ui5_if_client~get_app( z2ui5_if_client~get( )-s_draft-id_prev_app_stack ).
+      app = z2ui5_if_client~get_app( mo_action->mo_app->ms_draft-id_prev_app_stack ).
     ENDIF.
 
     mo_action->ms_next-o_app_leave = app.

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -778,10 +778,11 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
         IF sy-subrc <> 0.
           CONTINUE.
         ENDIF.
-        IF lo_row_d->get_node_type( |/{ lv_fld }| ) = z2ui5_if_ajson_types=>node_type-boolean.
-          <comp> = lo_row_d->get_boolean( |/{ lv_fld }| ).
+        DATA(lv_fld_path) = |/{ lv_fld }|.
+        IF lo_row_d->get_node_type( lv_fld_path ) = z2ui5_if_ajson_types=>node_type-boolean.
+          <comp> = lo_row_d->get_boolean( lv_fld_path ).
         ELSE.
-          <comp> = lo_row_d->get_string( |/{ lv_fld }| ).
+          <comp> = lo_row_d->get_string( lv_fld_path ).
         ENDIF.
       ENDLOOP.
     ENDLOOP.

--- a/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
@@ -116,9 +116,10 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
     IF client->get( )-check_on_navigated = abap_true.
 
       DATA(lo_popup) = CAST z2ui5_cl_pop_get_range( client->get_app( client->get( )-s_draft-id_prev_app ) ).
-      IF lo_popup->result( )-check_confirmed = abap_true.
+      DATA(ls_popup_result) = lo_popup->result( ).
+      IF ls_popup_result-check_confirmed = abap_true.
         ASSIGN ms_result-t_filter[ name = mv_popup_name ] TO FIELD-SYMBOL(<tab>).
-        <tab>-t_range = lo_popup->result( )-t_range.
+        <tab>-t_range = ls_popup_result-t_range.
         <tab>-t_token = z2ui5_cl_util=>filter_get_token_t_by_range_t( <tab>-t_range ).
       ENDIF.
       popup_display( ).

--- a/src/02/01/z2ui5_cl_pop_table.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_table.clas.abap
@@ -74,7 +74,7 @@ CLASS z2ui5_cl_pop_table IMPLEMENTATION.
         lv_ddic_field_label = z2ui5_cl_util=>rtti_get_data_element_text_l( lv_name ).
 
         IF lv_ddic_field_label IS NOT INITIAL.
-          columns->column( '8rem' )->header( `` )->text( lv_ddic_field_label ).
+          columns->column( `8rem` )->header( `` )->text( lv_ddic_field_label ).
           CONTINUE.
         ENDIF.
       ENDIF.

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -288,6 +288,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
     FIELD-SYMBOLS <field2>         TYPE any.
 
     DATA(ls_arg) = client->get_event_arg( 1 ).
+    DATA(lv_arg_upper) = to_upper( ls_arg ).
 
     ASSIGN mr_tab_popup->* TO <tab_out>.
     ASSIGN mr_tab_popup_backup->* TO <tab_out_backup>.
@@ -301,7 +302,7 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
         DATA(lv_assign) = |<ROW2>-{ ls_comp-name }|.
         ASSIGN (lv_assign) TO <field2>.
         ASSERT sy-subrc = 0.
-        IF to_upper( <field2> ) CS to_upper( ls_arg ).
+        IF to_upper( <field2> ) CS lv_arg_upper.
           lv_check_continue = abap_true.
           EXIT.
         ENDIF.

--- a/src/02/z2ui5_cl_exit.clas.abap
+++ b/src/02/z2ui5_cl_exit.clas.abap
@@ -119,8 +119,7 @@ CLASS z2ui5_cl_exit IMPLEMENTATION.
                                           CHANGING  cs_config  = cs_config ).
     ENDIF.
 
-    IF cs_config-draft_exp_time_in_hours IS INITIAL
-        OR cs_config-draft_exp_time_in_hours <= 0.
+    IF cs_config-draft_exp_time_in_hours <= 0.
       cs_config-draft_exp_time_in_hours = 4.
     ENDIF.
 

--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -14983,7 +14983,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
 
     result = me.
     _generic( name   = `ZZPLAIN`
-                ns   = 'html'
+              ns     = `html`
               t_prop = VALUE #( ( n = `VALUE` v = val ) ) ).
 
   ENDMETHOD.


### PR DESCRIPTION
- core_client: read event/draft fields directly instead of rebuilding the
  full get() response structure in check_on_event and nav_app_leave
- core_srv_model: hoist repeated JSON path string in delta_apply_to_table
- pop_to_select: compute to_upper of search term once instead of per cell
- exit: drop redundant IS INITIAL check (covered by <= 0) for integer
- pop_table / xml_view: use backtick string literals per project convention

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nw48DKUDEvG3Vp9HfcaX3h