### PR TITLE
fix: keep app id stable in nav_app_set_id, remove dead branches in prepare_app_stack

### DIFF
--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -166,12 +166,11 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
 
     mo_app->db_save( ).
 
+    " val is always the ms_next-o_app_leave / ms_next-o_app_call reference
+    " itself (see factory_stack_leave / factory_stack_call), so an already
+    " assigned draft id is kept as is
     IF val->id_draft IS INITIAL.
       val->id_draft = z2ui5_cl_util=>uuid_get_c32( ).
-    ELSEIF ms_next-o_app_leave IS BOUND.
-      val->id_draft = ms_next-o_app_leave->id_draft.
-    ELSE.
-      val->id_draft = ms_next-o_app_call->id_draft.
     ENDIF.
 
     result = NEW #( mo_http_post ).

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -220,7 +220,9 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
           val = `NAV_APP_LEAVE_TO_INITIAL_APP_ERROR`.
     ENDIF.
 
-    app->id_app = COND #( WHEN app->id_app IS INITIAL THEN z2ui5_cl_util=>uuid_get_c32( ) ).
+    IF app->id_app IS INITIAL.
+      app->id_app = z2ui5_cl_util=>uuid_get_c32( ).
+    ENDIF.
     result = app->id_app.
 
   ENDMETHOD.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -46,6 +46,7 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_check_on_event_empty FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_navigated   FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_call         FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_app_call_id_stable FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_leave_event  FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_leave_r_data FOR TESTING RAISING cx_static_check.
     METHODS test_check_app_prev_stack FOR TESTING RAISING cx_static_check.
@@ -483,6 +484,26 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_not_initial( lv_id ).
     cl_abap_unit_assert=>assert_bound( mo_action->ms_next-o_app_call ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_app_call_id_stable.
+
+    DATA lo_new_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lv_id_first TYPE string.
+    DATA lv_id_second TYPE string.
+    lo_new_app = NEW #( ).
+    li_client ?= mo_client.
+
+    lv_id_first  = li_client->nav_app_call( lo_new_app ).
+    lv_id_second = li_client->nav_app_call( lo_new_app ).
+
+    cl_abap_unit_assert=>assert_not_initial( lv_id_second ).
+    cl_abap_unit_assert=>assert_equals( exp = lv_id_first
+                                        act = lv_id_second ).
+    cl_abap_unit_assert=>assert_equals( exp = lv_id_first
+                                        act = lo_new_app->z2ui5_if_app~id_app ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Two behavior-relevant follow-ups that were deliberately excluded from the pure-cleanup PR #2345 because they change observable behavior. Both are small, but please review them functionally.

## 1. `nav_app_set_id` cleared an already assigned `id_app` (`z2ui5_cl_core_client`)

```abap
app->id_app = COND #( WHEN app->id_app IS INITIAL THEN z2ui5_cl_util=>uuid_get_c32( ) ).
```

A `COND` without `ELSE` returns the initial value when the condition is false. So whenever `id_app` was **already set**, it was overwritten with an empty string and the empty id was returned to the caller of `nav_app_call` / `nav_app_leave`. Navigating to the same app instance repeatedly cleared and re-rolled its id on every second navigation.

The framework itself never reads `id_app` (it is written only here), so this was latent internally — but `id_app` is a public attribute of `z2ui5_if_app` and the id is the return value of two public client methods, so apps holding on to it got an unstable value.

New behavior: an existing id is kept and returned unchanged; a fresh UUID is only assigned when `id_app` is still initial. Covered by a new unit test (`test_nav_app_call_id_stable`) asserting that two `nav_app_call` calls with the same instance return the same non-initial id.

## 2. Dead `ELSEIF`/`ELSE` branches in `prepare_app_stack` (`z2ui5_cl_core_action`)

```abap
IF val->id_draft IS INITIAL.
  val->id_draft = z2ui5_cl_util=>uuid_get_c32( ).
ELSEIF ms_next-o_app_leave IS BOUND.
  val->id_draft = ms_next-o_app_leave->id_draft.
ELSE.
  val->id_draft = ms_next-o_app_call->id_draft.
ENDIF.
```

`prepare_app_stack` is only called from `factory_stack_leave` / `factory_stack_call`, which pass `ms_next-o_app_leave` / `ms_next-o_app_call` **themselves** as `val`. On the leave path the `ELSEIF` therefore assigned `val->id_draft = val->id_draft`; on the call path (where the handler guarantees `o_app_leave` is unbound) the `ELSE` did the same. Both branches were self-assignments on every reachable call path and are removed; a comment documents the invariant.

Note this also removes a hypothetical edge case: if `factory_stack_call` were ever invoked while `o_app_leave` is also bound, the old code would have overwritten the call app's `id_draft` with the leave app's `id_draft` — almost certainly never intended.

## Validation

- `npx abaplint` clean (the only reported issue is the dependency clone blocked by this environment's network policy, present on `main` as well)
- unit test added for fix 1; existing `test_nav_app_call` and `factory_stack_call` tests unaffected
- transpile/unit/browser test workflows run in CI (not runnable locally in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC3Zqsep6iGZGdEFs4f4uV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC3Zqsep6iGZGdEFs4f4uV)_