### PR TITLE
Enhance itab_filter_by_val with field selection and case-insensitive search

### DIFF
--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -492,6 +492,14 @@ CLASS z2ui5_cl_util DEFINITION
       CHANGING
         !tab TYPE STANDARD TABLE.
 
+    CLASS-METHODS itab_filter_by_search_string
+      IMPORTING
+        val         TYPE clike
+        fields      TYPE string_table OPTIONAL
+        ignore_case TYPE abap_bool DEFAULT abap_false
+      CHANGING
+        !tab        TYPE STANDARD TABLE.
+
     CLASS-METHODS itab_get_by_struc
       IMPORTING
         val           TYPE any
@@ -521,6 +529,12 @@ CLASS z2ui5_cl_util DEFINITION
         !from         TYPE any
       RETURNING
         VALUE(result) TYPE REF TO data.
+
+    CLASS-METHODS conv_get_xstring_by_data_uri
+      IMPORTING
+        val           TYPE clike
+      RETURNING
+        VALUE(result) TYPE xstring.
 
     CLASS-METHODS source_get_file_types
       RETURNING
@@ -917,6 +931,17 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD conv_get_xstring_by_data_uri.
+
+    DATA lv_metadata TYPE string ##NEEDED.
+    DATA lv_base64   TYPE string.
+
+    SPLIT val AT `,` INTO lv_metadata lv_base64.
+    result = conv_decode_x_base64( lv_base64 ).
+
+  ENDMETHOD.
+
+
   METHOD c_trim.
 
     result = shift_left( shift_right( CONV string( val ) ) ).
@@ -1127,6 +1152,58 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
       IF lv_row NS val.
         DELETE tab.
       ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD itab_filter_by_search_string.
+
+    FIELD-SYMBOLS <row>   TYPE any.
+    FIELD-SYMBOLS <field> TYPE any.
+
+    DATA(lv_search) = COND string( WHEN ignore_case = abap_true
+                                   THEN to_upper( val )
+                                   ELSE val ).
+
+    LOOP AT tab ASSIGNING <row>.
+
+      DATA(lv_check_found) = abap_false.
+      DATA(lv_index) = 1.
+      DO.
+        IF fields IS INITIAL.
+          ASSIGN COMPONENT lv_index OF STRUCTURE <row> TO <field>.
+          IF sy-subrc <> 0.
+            EXIT.
+          ENDIF.
+        ELSE.
+          IF lv_index > lines( fields ).
+            EXIT.
+          ENDIF.
+          DATA(lv_name) = fields[ lv_index ].
+          ASSIGN COMPONENT lv_name OF STRUCTURE <row> TO <field>.
+          IF sy-subrc <> 0.
+            lv_index = lv_index + 1.
+            CONTINUE.
+          ENDIF.
+        ENDIF.
+
+        DATA(lv_value) = |{ <field> }|.
+        IF ignore_case = abap_true.
+          lv_value = to_upper( lv_value ).
+        ENDIF.
+        IF lv_value CS lv_search.
+          lv_check_found = abap_true.
+          EXIT.
+        ENDIF.
+
+        lv_index = lv_index + 1.
+      ENDDO.
+
+      IF lv_check_found = abap_false.
+        DELETE tab.
+      ENDIF.
+
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -488,12 +488,6 @@ CLASS z2ui5_cl_util DEFINITION
 
     CLASS-METHODS itab_filter_by_val
       IMPORTING
-        val  TYPE clike
-      CHANGING
-        !tab TYPE STANDARD TABLE.
-
-    CLASS-METHODS itab_filter_by_search_string
-      IMPORTING
         val         TYPE clike
         fields      TYPE string_table OPTIONAL
         ignore_case TYPE abap_bool DEFAULT abap_false
@@ -1134,30 +1128,6 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
 
   METHOD itab_filter_by_val.
-
-    FIELD-SYMBOLS <row> TYPE any.
-
-    LOOP AT tab ASSIGNING <row>.
-      DATA(lv_row) = ``.
-      DATA(lv_index) = 1.
-      DO.
-        ASSIGN COMPONENT lv_index OF STRUCTURE <row> TO FIELD-SYMBOL(<field>).
-        IF sy-subrc <> 0.
-          EXIT.
-        ENDIF.
-        lv_row = lv_row && <field>.
-        lv_index = lv_index + 1.
-      ENDDO.
-
-      IF lv_row NS val.
-        DELETE tab.
-      ENDIF.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD itab_filter_by_search_string.
 
     FIELD-SYMBOLS <row>   TYPE any.
     FIELD-SYMBOLS <field> TYPE any.

--- a/src/00/03/z2ui5_cl_util.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_util.clas.testclasses.abap
@@ -1173,8 +1173,8 @@ CLASS ltcl_unit_test_filter DEFINITION FINAL
     METHODS test_sql_string_no_fields   FOR TESTING RAISING cx_static_check.
 
     METHODS test_filter_itab            FOR TESTING RAISING cx_static_check.
-    METHODS test_itab_by_search_string  FOR TESTING RAISING cx_static_check.
-    METHODS test_itab_by_search_fields  FOR TESTING RAISING cx_static_check.
+    METHODS test_itab_filter_by_val_ci  FOR TESTING RAISING cx_static_check.
+    METHODS test_itab_filter_by_val_fld FOR TESTING RAISING cx_static_check.
     METHODS test_update_tokens          FOR TESTING RAISING cx_static_check.
     METHODS test_update_tokens_remove   FOR TESTING RAISING cx_static_check.
 
@@ -1698,7 +1698,7 @@ CLASS ltcl_unit_test_filter IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD test_itab_by_search_string.
+  METHOD test_itab_filter_by_val_ci.
 
     TYPES:
       BEGIN OF ty_row,
@@ -1712,8 +1712,8 @@ CLASS ltcl_unit_test_filter IMPLEMENTATION.
     INSERT VALUE #( name = `beta`  value = `mid` ) INTO TABLE lt_data.
     INSERT VALUE #( name = `gamma` value = `top` ) INTO TABLE lt_data.
 
-    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val = `mid`
-                                                 CHANGING  tab = lt_data ).
+    z2ui5_cl_util=>itab_filter_by_val( EXPORTING val = `mid`
+                                       CHANGING  tab = lt_data ).
 
     cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_data ) ).
     cl_abap_unit_assert=>assert_equals( exp = `beta` act = lt_data[ 1 ]-name ).
@@ -1721,16 +1721,16 @@ CLASS ltcl_unit_test_filter IMPLEMENTATION.
     lt_data = VALUE #( ( name = `alpha` value = `low` )
                        ( name = `beta`  value = `MID` ) ).
 
-    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val         = `mid`
-                                                           ignore_case = abap_true
-                                                 CHANGING  tab         = lt_data ).
+    z2ui5_cl_util=>itab_filter_by_val( EXPORTING val         = `mid`
+                                                 ignore_case = abap_true
+                                       CHANGING  tab         = lt_data ).
 
     cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_data ) ).
     cl_abap_unit_assert=>assert_equals( exp = `beta` act = lt_data[ 1 ]-name ).
 
   ENDMETHOD.
 
-  METHOD test_itab_by_search_fields.
+  METHOD test_itab_filter_by_val_fld.
 
     TYPES:
       BEGIN OF ty_row,
@@ -1744,7 +1744,7 @@ CLASS ltcl_unit_test_filter IMPLEMENTATION.
     INSERT VALUE #( name = `beta`  value = `mid` ) INTO TABLE lt_data.
     INSERT VALUE #( name = `low`   value = `top` ) INTO TABLE lt_data.
 
-    z2ui5_cl_util=>itab_filter_by_search_string(
+    z2ui5_cl_util=>itab_filter_by_val(
       EXPORTING
         val    = `low`
         fields = VALUE #( ( `NAME` ) )

--- a/src/00/03/z2ui5_cl_util.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_util.clas.testclasses.abap
@@ -1173,6 +1173,8 @@ CLASS ltcl_unit_test_filter DEFINITION FINAL
     METHODS test_sql_string_no_fields   FOR TESTING RAISING cx_static_check.
 
     METHODS test_filter_itab            FOR TESTING RAISING cx_static_check.
+    METHODS test_itab_by_search_string  FOR TESTING RAISING cx_static_check.
+    METHODS test_itab_by_search_fields  FOR TESTING RAISING cx_static_check.
     METHODS test_update_tokens          FOR TESTING RAISING cx_static_check.
     METHODS test_update_tokens_remove   FOR TESTING RAISING cx_static_check.
 
@@ -1693,6 +1695,64 @@ CLASS ltcl_unit_test_filter IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = 2 act = lines( lt_data ) ).
     cl_abap_unit_assert=>assert_equals( exp = `beta` act = lt_data[ 1 ]-name ).
     cl_abap_unit_assert=>assert_equals( exp = `gamma` act = lt_data[ 2 ]-name ).
+
+  ENDMETHOD.
+
+  METHOD test_itab_by_search_string.
+
+    TYPES:
+      BEGIN OF ty_row,
+        name  TYPE string,
+        value TYPE string,
+      END OF ty_row.
+
+    DATA lt_data TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY.
+
+    INSERT VALUE #( name = `alpha` value = `low` ) INTO TABLE lt_data.
+    INSERT VALUE #( name = `beta`  value = `mid` ) INTO TABLE lt_data.
+    INSERT VALUE #( name = `gamma` value = `top` ) INTO TABLE lt_data.
+
+    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val = `mid`
+                                                 CHANGING  tab = lt_data ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_data ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `beta` act = lt_data[ 1 ]-name ).
+
+    lt_data = VALUE #( ( name = `alpha` value = `low` )
+                       ( name = `beta`  value = `MID` ) ).
+
+    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val         = `mid`
+                                                           ignore_case = abap_true
+                                                 CHANGING  tab         = lt_data ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_data ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `beta` act = lt_data[ 1 ]-name ).
+
+  ENDMETHOD.
+
+  METHOD test_itab_by_search_fields.
+
+    TYPES:
+      BEGIN OF ty_row,
+        name  TYPE string,
+        value TYPE string,
+      END OF ty_row.
+
+    DATA lt_data TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY.
+
+    INSERT VALUE #( name = `alpha` value = `low` ) INTO TABLE lt_data.
+    INSERT VALUE #( name = `beta`  value = `mid` ) INTO TABLE lt_data.
+    INSERT VALUE #( name = `low`   value = `top` ) INTO TABLE lt_data.
+
+    z2ui5_cl_util=>itab_filter_by_search_string(
+      EXPORTING
+        val    = `low`
+        fields = VALUE #( ( `NAME` ) )
+      CHANGING
+        tab    = lt_data ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 1 act = lines( lt_data ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `top` act = lt_data[ 1 ]-value ).
 
   ENDMETHOD.
 

--- a/src/02/01/z2ui5_cl_pop_file_ul.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_file_ul.clas.abap
@@ -98,11 +98,8 @@ CLASS z2ui5_cl_pop_file_ul IMPLEMENTATION.
 
       WHEN `UPLOAD`.
 
-        SPLIT mv_value AT `;` INTO DATA(lv_dummy) DATA(lv_data).
-        SPLIT lv_data AT `,` INTO lv_dummy lv_data.
-
-        DATA(lv_data2) = z2ui5_cl_util=>conv_decode_x_base64( lv_data ).
-        ms_result-value = z2ui5_cl_util=>conv_get_string_by_xstring( lv_data2 ).
+        DATA(lv_data) = z2ui5_cl_util=>conv_get_xstring_by_data_uri( mv_value ).
+        ms_result-value = z2ui5_cl_util=>conv_get_string_by_xstring( lv_data ).
         check_confirm_enabled = abap_true.
 
         CLEAR mv_value.

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -290,9 +290,9 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
     <tab_out> = <tab_out_backup>.
 
-    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val         = client->get_event_arg( 1 )
-                                                           ignore_case = abap_true
-                                                 CHANGING  tab         = <tab_out> ).
+    z2ui5_cl_util=>itab_filter_by_val( EXPORTING val         = client->get_event_arg( 1 )
+                                                 ignore_case = abap_true
+                                       CHANGING  tab         = <tab_out> ).
     client->popup_model_update( ).
 
   ENDMETHOD.

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -284,34 +284,15 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
 
     FIELD-SYMBOLS <tab_out>        TYPE STANDARD TABLE.
     FIELD-SYMBOLS <tab_out_backup> TYPE STANDARD TABLE.
-    FIELD-SYMBOLS <row2>           TYPE any.
-    FIELD-SYMBOLS <field2>         TYPE any.
-
-    DATA(ls_arg) = client->get_event_arg( 1 ).
-    DATA(lv_arg_upper) = to_upper( ls_arg ).
 
     ASSIGN mr_tab_popup->* TO <tab_out>.
     ASSIGN mr_tab_popup_backup->* TO <tab_out_backup>.
 
     <tab_out> = <tab_out_backup>.
 
-    DATA(lt_comp) = z2ui5_cl_util=>rtti_get_t_attri_by_any( <tab_out> ).
-    LOOP AT <tab_out> ASSIGNING <row2>.
-      DATA(lv_check_continue) = abap_false.
-      LOOP AT lt_comp INTO DATA(ls_comp).
-        DATA(lv_assign) = |<ROW2>-{ ls_comp-name }|.
-        ASSIGN (lv_assign) TO <field2>.
-        ASSERT sy-subrc = 0.
-        IF to_upper( <field2> ) CS lv_arg_upper.
-          lv_check_continue = abap_true.
-          EXIT.
-        ENDIF.
-      ENDLOOP.
-      IF lv_check_continue = abap_true.
-        CONTINUE.
-      ENDIF.
-      DELETE <tab_out>.
-    ENDLOOP.
+    z2ui5_cl_util=>itab_filter_by_search_string( EXPORTING val         = client->get_event_arg( 1 )
+                                                           ignore_case = abap_true
+                                                 CHANGING  tab         = <tab_out> ).
     client->popup_model_update( ).
 
   ENDMETHOD.


### PR DESCRIPTION
## Summary
Enhanced the `itab_filter_by_val` utility method to support filtering by specific fields and case-insensitive search, while also extracting data URI parsing logic into a dedicated method.

## Key Changes

- **Enhanced `itab_filter_by_val` method**:
  - Added optional `fields` parameter to filter only specific table fields instead of all fields
  - Added optional `ignore_case` parameter for case-insensitive value matching
  - Refactored filtering logic to use substring search (`CS` operator) instead of concatenating all field values
  - Improved performance by exiting early when a match is found

- **New utility method `conv_get_xstring_by_data_uri`**:
  - Extracts data URI parsing logic (splitting metadata and base64 content)
  - Decodes base64 content to xstring
  - Simplifies data URI handling across the codebase

- **Refactored `z2ui5_cl_pop_to_select` class**:
  - Replaced manual field iteration logic with call to enhanced `itab_filter_by_val`
  - Leverages new `ignore_case` parameter for case-insensitive search
  - Reduces code complexity and improves maintainability

- **Refactored `z2ui5_cl_pop_file_ul` class**:
  - Simplified data URI parsing by using new `conv_get_xstring_by_data_uri` method
  - Reduces manual string splitting logic

- **Added comprehensive unit tests**:
  - `test_itab_filter_by_val_ci`: Tests case-insensitive filtering
  - `test_itab_filter_by_val_fld`: Tests field-specific filtering

## Implementation Details

The filtering logic now checks each field value individually and exits early when a match is found, improving performance compared to the previous approach of concatenating all field values. The case-insensitive comparison is applied consistently to both the search value and field values when enabled.

https://claude.ai/code/session_01QPSE7jazyDMaQKojXzodTs