### PR TITLE
Refactor: Extract variables and remove dead code

### DIFF
--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -193,7 +193,6 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
   METHOD main_cell.
 
     ms_config = config.
-    mv_type   = type.
 
     DATA(lo_bind) = NEW z2ui5_cl_core_srv_bind( mo_app ).
     result = lo_bind->main( val    = config-tab

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -232,6 +232,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
                       name        = lr_pre->name ) INTO TABLE lt_child_idx.
     ENDLOOP.
 
+    DATA(lr_child_idx) = REF #( lt_child_idx ).
     LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri)   "#EC CI_SORTSEQ
          WHERE name_ref IS NOT INITIAL.
       CASE lr_attri->type_kind.
@@ -239,7 +240,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
           main_attri_db_load_table( lr_attri ).
         WHEN cl_abap_datadescr=>typekind_dref.
           main_attri_db_load_dref( ir_attri     = lr_attri
-                                   ir_child_idx = REF #( lt_child_idx ) ).
+                                   ir_child_idx = lr_child_idx ).
       ENDCASE.
     ENDLOOP.
 
@@ -536,14 +537,15 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     DATA(lr_ref) = z2ui5_cl_util=>unassign_object( lr_val ).
     DATA(lt_attri) = z2ui5_cl_util=>rtti_get_t_attri_by_oref( lr_ref ).
 
+    DATA(lv_prefix) = COND string( WHEN ir_attri->name IS NOT INITIAL THEN |{ ir_attri->name }->| ).
+
     LOOP AT lt_attri REFERENCE INTO DATA(lr_attri)
          WHERE visibility   = cl_abap_objectdescr=>public
                AND is_interface = abap_false
                AND is_class     = abap_false
                AND is_constant  = abap_false.
       TRY.
-          DATA(lv_name) = COND #( WHEN ir_attri->name IS NOT INITIAL THEN |{ ir_attri->name }->| ) && lr_attri->name.
-          DATA(ls_new) = attri_create_new( lv_name ).
+          DATA(ls_new) = attri_create_new( lv_prefix && lr_attri->name ).
           ls_new-name_parent = ir_attri->name.
           INSERT ls_new INTO TABLE result.
 

--- a/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_get_range_m.clas.abap
@@ -138,8 +138,8 @@ CLASS z2ui5_cl_pop_get_range_m IMPLEMENTATION.
 
       WHEN `LIST_OPEN`.
         mv_popup_name = client->get_event_arg( 1 ).
-        DATA(ls_sql) = ms_result-t_filter[ name = mv_popup_name ].
-        client->nav_app_call( z2ui5_cl_pop_get_range=>factory( ls_sql-t_range ) ).
+        client->nav_app_call( z2ui5_cl_pop_get_range=>factory(
+            ms_result-t_filter[ name = mv_popup_name ]-t_range ) ).
 
       WHEN `BUTTON_CONFIRM`.
         ms_result-check_confirmed = abap_true.

--- a/src/02/01/z2ui5_cl_pop_to_select.clas.abap
+++ b/src/02/01/z2ui5_cl_pop_to_select.clas.abap
@@ -266,8 +266,6 @@ CLASS z2ui5_cl_pop_to_select IMPLEMENTATION.
       INSERT <row_result> INTO TABLE <table_result>.
       IF multiselect = abap_false.
         EXIT.
-      ELSE.
-        CLEAR <row_result>.
       ENDIF.
 
     ENDLOOP.

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -193,11 +193,10 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
                href    = client->_bind( ms_home-url )
                enabled = |\{= ${ client->_bind( val = ms_home-class_editable ) } === false \}| ).
 
-    DATA(lv_url_samples) = get_app_url( `z2ui5_cl_demo_app_000` ).
-
     simple_form->toolbar( )->title( `What's next?` ).
 
     IF z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_demo_app_000` ).
+      DATA(lv_url_samples) = get_app_url( `z2ui5_cl_demo_app_000` ).
       simple_form->label( `Start Developing` ).
       simple_form->button( text  = `Explore Code Samples`
                            press = client->_event_client( val   = client->cs_event-open_new_tab


### PR DESCRIPTION
## Summary
This pull request contains several code quality improvements focused on extracting intermediate variables, removing unnecessary code paths, and optimizing variable scope.

## Key Changes

- **z2ui5_cl_core_srv_model.clas.abap**
  - Extract `lr_child_idx` reference variable to avoid creating the same reference twice in the loop
  - Extract `lv_prefix` variable to reduce redundant conditional expression evaluation in the loop

- **z2ui5_cl_pop_get_range_m.clas.abap**
  - Inline temporary variable `ls_sql` directly into the method call to reduce intermediate variable creation

- **z2ui5_cl_app_startup.clas.abap**
  - Move `lv_url_samples` variable declaration inside the conditional block where it's actually used, improving variable scope

- **z2ui5_cl_pop_to_select.clas.abap**
  - Remove unnecessary `ELSE` branch with `CLEAR` statement that had no effect

- **z2ui5_cl_core_srv_bind.clas.abap**
  - Remove unused assignment `mv_type = type` in the `main_cell` method

## Implementation Details
These changes maintain functional equivalence while improving code clarity and reducing unnecessary variable allocations. The refactoring follows best practices for variable scope management and eliminates dead code paths.

https://claude.ai/code/session_01TE6LXpLoRkqV1kNEZZgHTZ