### PR TITLE
Update frontend deployment to use main branch

### DIFF
--- a/.github/workflows/create_frontend.yaml
+++ b/.github/workflows/create_frontend.yaml
@@ -19,13 +19,16 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: send to bsp repository
+    # main is the single source branch of abap2UI5/frontend; its build_<branch>
+    # workflows regenerate the cloud/cloud_v2/standard/standard_v2 branches
+    # from main on every push.
+    - name: send to frontend repository
       uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         external_repository: abap2UI5/frontend
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        publish_branch: cloud
+        publish_branch: main
         publish_dir: ./app/webapp
         deploy_key: ${{ secrets.ACTION_KEY_FRONTEND }}
         destination_dir: ./app/webapp


### PR DESCRIPTION
# Description

Updates the GitHub Actions workflow for frontend deployment to publish to the `main` branch instead of the `cloud` branch. This aligns with the documented workflow where `main` is the single source branch for abap2UI5/frontend, and separate `build_<branch>` workflows regenerate the cloud/cloud_v2/standard/standard_v2 branches from main on every push.

Also clarifies the workflow step name from "send to bsp repository" to "send to frontend repository" for better accuracy.

## How to test

N/A - Configuration change to GitHub Actions workflow. The change will be validated when the workflow runs on the next push to this repository.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01DCm6NoaB5dH7Zcsvc8JYVA