### PR TITLE
Add ui5lint disable comments for deprecated API usage

### DIFF
--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -141,6 +141,7 @@ sap.ui.define(
         let el = dom;
         while (el && el.getAttribute) {
           if (el.hasAttribute("data-sap-ui")) {
+            // ui5lint-disable-next-line no-globals, no-deprecated-api -- only resolution path on UI5 < 1.106
             return sap.ui.getCore().byId(el.id) || null;
           }
           el = el.parentElement;

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -161,6 +161,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        let el = dom;` && |\n| &&
              `        while (el && el.getAttribute) {` && |\n| &&
              `          if (el.hasAttribute("data-sap-ui")) {` && |\n| &&
+             `            // ui5lint-disable-next-line no-globals, no-deprecated-api -- only resolution path on UI5 < 1.106` && |\n| &&
              `            return sap.ui.getCore().byId(el.id) || null;` && |\n| &&
              `          }` && |\n| &&
              `          el = el.parentElement;` && |\n| &&
@@ -416,9 +417,9 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          } catch (e) {` && |\n| &&
              `            this.responseError(``Invalid JSON response: ${e.message}``);` && |\n| &&
              `            return;` && |\n| &&
-             `          }` && |\n| &&
-             `          if (!responseData || !responseData.S_FRONT) {` && |\n|.
+             `          }` && |\n|.
     result = result &&
+             `          if (!responseData || !responseData.S_FRONT) {` && |\n| &&
              `            this.responseError("Invalid response: missing S_FRONT");` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&


### PR DESCRIPTION
# Description

This PR adds `ui5lint-disable-next-line` comments to suppress linting warnings for deprecated SAP UI5 APIs that are necessary for compatibility with UI5 versions < 1.106.

Specifically:
- Added a lint disable comment for `sap.ui.getCore().byId()` usage in the DOM element resolution logic, which is the only available resolution path for older UI5 versions
- Minor code formatting adjustment in the response validation logic (line break repositioning with no functional change)

## How to test

- Verify that `npx abaplint` passes without errors
- Confirm that the generated JavaScript in `app/webapp/core/Server.js` matches the ABAP class generation
- No functional changes to test; this is purely a linting/code quality improvement

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01AEXfCCg4gT3332cZMDihH4