### PR TITLE
Add trigger_local workflow to sync abap2UI5-local

### DIFF
--- a/.github/workflows/trigger_local.yaml
+++ b/.github/workflows/trigger_local.yaml
@@ -1,0 +1,31 @@
+name: trigger_local
+
+# Keeps abap2UI5/abap2UI5-local in sync with this repository, analogous to
+# create_frontend for abap2UI5/frontend: every push to main dispatches the
+# update_input workflow over there, which copies the current src/ into its
+# input/ folder and then rebuilds the 702/standard/cloud artifact branches
+# (via its own workflow_run chain). The monthly cron in abap2UI5-local
+# remains as a safety net in case a dispatch is lost.
+#
+# Requires the secret ACTION_TOKEN_LOCAL: a fine-grained PAT (or GitHub App
+# token) scoped to abap2UI5/abap2UI5-local with "Actions: read and write"
+# permission — deploy keys cannot call the workflow-dispatch API.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trigger_local:
+    if: github.repository == 'abap2UI5/abap2UI5'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: dispatch update_input in abap2UI5-local
+      env:
+        GH_TOKEN: ${{ secrets.ACTION_TOKEN_LOCAL }}
+      run: gh workflow run update_input.yaml --repo abap2UI5/abap2UI5-local --ref main

--- a/.github/workflows/trigger_local.yaml
+++ b/.github/workflows/trigger_local.yaml
@@ -1,15 +1,15 @@
 name: trigger_local
 
 # Keeps abap2UI5/abap2UI5-local in sync with this repository, analogous to
-# create_frontend for abap2UI5/frontend: every push to main dispatches the
-# update_input workflow over there, which copies the current src/ into its
-# input/ folder and then rebuilds the 702/standard/cloud artifact branches
-# (via its own workflow_run chain). The monthly cron in abap2UI5-local
-# remains as a safety net in case a dispatch is lost.
+# create_frontend for abap2UI5/frontend: every push to main refreshes the
+# input/ copy in abap2UI5-local and pushes it to its main branch via a
+# deploy key. That push then triggers the generate_702/standard/cloud
+# workflows over there, which rebuild the artifact branches. The monthly
+# update_input cron in abap2UI5-local remains as a safety net.
 #
-# Requires the secret ACTION_TOKEN_LOCAL: a fine-grained PAT (or GitHub App
-# token) scoped to abap2UI5/abap2UI5-local with "Actions: read and write"
-# permission — deploy keys cannot call the workflow-dispatch API.
+# Requires the secret ACTION_KEY_LOCAL: the private half of a deploy key
+# registered on abap2UI5/abap2UI5-local with write access (same pattern as
+# ACTION_KEY_FRONTEND for the frontend repository).
 
 on:
   push:
@@ -19,13 +19,54 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: trigger_local
+  cancel-in-progress: false
+
 jobs:
   trigger_local:
     if: github.repository == 'abap2UI5/abap2UI5'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
-    - name: dispatch update_input in abap2UI5-local
-      env:
-        GH_TOKEN: ${{ secrets.ACTION_TOKEN_LOCAL }}
-      run: gh workflow run update_input.yaml --repo abap2UI5/abap2UI5-local --ref main
+    - name: Checkout abap2UI5 (this repo)
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        path: upstream
+
+    - name: Checkout abap2UI5-local via deploy key
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: abap2UI5/abap2UI5-local
+        ref: main
+        ssh-key: ${{ secrets.ACTION_KEY_LOCAL }}
+        path: local
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: '20'
+
+    # Same steps as update_input in abap2UI5-local, only running here so the
+    # refresh happens on every upstream push instead of once a month.
+    - name: Overwrite input with current sources
+      run: |
+        rm -rf local/input
+        cp -r upstream/src local/input
+
+    - name: abaplint input
+      working-directory: local
+      run: npx --yes @abaplint/cli@latest
+
+    - name: Commit and push to abap2UI5-local main
+      working-directory: local
+      run: |
+        version=$(grep -oP "VALUE \`\K[0-9.]+" input/02/z2ui5_if_app.intf.abap)
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add -A input
+        if git diff --cached --quiet; then
+          echo "input: no changes"
+        else
+          git commit -m "update input to abap2UI5 v${version}"
+          git push origin main
+        fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ src/
 | `node/setup/` | `abap_transpile.json` (transpiler config), `setup.mjs` (SQLite bootstrap for Node unit tests) |
 | `node/tests/` | Playwright tests — browser tests in `e2e/` (`example.spec.js` shell smoke test, `roundtrip.spec.js` POST/draft wire contract, `lib-sanitizer.spec.js` XSS regression tests for `Lib.sanitizeMessageDetails`, `error-view.spec.js` fatal-error overlay accessibility/focus/Retry tests; run via `node/playwright.config.js` against the dev server), plus unit specs (`buildDeltaFromPaths.spec.js`, `utilHelpers.spec.js`, `appState.spec.js`, `viewSlots.spec.js`, `uiTableExt.spec.js`, `messages.spec.js`, `util.spec.js`, `serverTimeout.spec.js`, `serverClosestElement.spec.js`) that load the **real** `app/webapp` modules via `loadModule.js` (stubbed `sap.ui.define`, stubbable dependencies); run them without a browser via `npx playwright test -c node/playwright-unit.config.js` (the unit config ignores `e2e/`) |
 | `node/tests-examples/` | Playwright example specs and performance benchmarks (reference material, not run in CI) — `modelUpdate.bench.spec.js` measures the model-update strategies and documents its own setup; run via `node/playwright-bench.config.js` |
-| `.github/workflows/` | 15 CI/CD workflows (see below) |
+| `.github/workflows/` | 16 CI/CD workflows (see below) |
 | `.github/scripts/` | `ui5lint-gate.mjs` — baseline gate for the UI5 linter (fails CI only when new errors are introduced; lower its `MAX_ERRORS` when findings are fixed) |
 | `.github/abaplint/` | Target-specific abaplint configs: `abap_702.jsonc`, `abap_standard.jsonc`, `abap_cloud.jsonc`, `auto_abaplint_fix.jsonc`, `rename_test.jsonc` |
 | `.github/app2abap/` | `trans2abap.js` — converts `app/webapp/*` files into embedded ABAP string constants in `src/01/03/` |
@@ -196,6 +196,7 @@ Grouped by purpose:
 | **Automation** | `auto_downport.yaml`, `auto_abaplint_fix.yaml`, `auto_abaplint_fix_pr.yaml` | Scheduled downporting and auto-formatting (open PRs) |
 | **Generation** | `create_app2abap.yaml`, `create_frontend.yaml` | Regenerate `src/01/03/` from `app/webapp/` |
 | **Mirroring** | `mirror_ajson.yaml`, `mirror_srtti.yaml` | Sync `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI) from upstream repos |
+| **Downstream sync** | `trigger_local.yaml` | On every push to `main`, dispatch the `update_input` workflow in [abap2UI5-local](https://github.com/abap2UI5/abap2UI5-local) so its `input/` copy and artifact branches follow this repo (needs secret `ACTION_TOKEN_LOCAL`); `create_frontend.yaml` covers [frontend](https://github.com/abap2UI5/frontend) the same way |
 
 ## Language & Code Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ Grouped by purpose:
 | **Automation** | `auto_downport.yaml`, `auto_abaplint_fix.yaml`, `auto_abaplint_fix_pr.yaml` | Scheduled downporting and auto-formatting (open PRs) |
 | **Generation** | `create_app2abap.yaml`, `create_frontend.yaml` | Regenerate `src/01/03/` from `app/webapp/` |
 | **Mirroring** | `mirror_ajson.yaml`, `mirror_srtti.yaml` | Sync `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI) from upstream repos |
-| **Downstream sync** | `trigger_local.yaml` | On every push to `main`, dispatch the `update_input` workflow in [abap2UI5-local](https://github.com/abap2UI5/abap2UI5-local) so its `input/` copy and artifact branches follow this repo (needs secret `ACTION_TOKEN_LOCAL`); `create_frontend.yaml` covers [frontend](https://github.com/abap2UI5/frontend) the same way |
+| **Downstream sync** | `trigger_local.yaml` | On every push to `main`, refresh the `input/` copy in [abap2UI5-local](https://github.com/abap2UI5/abap2UI5-local) and push it to its `main` via deploy key (secret `ACTION_KEY_LOCAL`), which rebuilds its artifact branches; `create_frontend.yaml` covers [frontend](https://github.com/abap2UI5/frontend) the same way |
 
 ## Language & Code Rules
 


### PR DESCRIPTION
# Description

Adds a new GitHub Actions workflow `trigger_local.yaml` that automatically keeps the `abap2UI5/abap2UI5-local` repository in sync with this repository. On every push to main (or manual trigger), the workflow:

1. Checks out the current repository and the `abap2UI5-local` repository
2. Overwrites the `input/` directory in `abap2UI5-local` with the current `src/` sources
3. Runs abaplint validation on the input
4. Commits and pushes changes to `abap2UI5-local` main if there are any differences

This push then triggers the existing `generate_702/standard/cloud` workflows in `abap2UI5-local`, which rebuild the artifact branches. The workflow uses a deploy key (`ACTION_KEY_LOCAL`) for authentication, following the same pattern as the existing `create_frontend` workflow.

Updates AGENTS.md to reflect the new workflow count (15 → 16).

## How to test

The workflow is guarded by `if: github.repository == 'abap2UI5/abap2UI5'` and requires the `ACTION_KEY_LOCAL` secret to be configured on the main repository. It can be tested via:
- Manual trigger using the GitHub Actions UI (`workflow_dispatch`)
- Automatic trigger on next push to main

## Checklist

- [x] No abaplint changes (workflow file only)
- [x] No unit tests needed (CI/CD infrastructure change)
- [x] No changes to `src/00/` or `src/01/03/`
- [x] No public API changes
- [x] Changes made via direct file addition (not abapGit)

https://claude.ai/code/session_01Lq9fV8TJML7VEf5jc2LzQo