### PR TITLE
Add trigger_local workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 <br>
 [![create_app2abap](https://github.com/abap2UI5/abap2UI5/actions/workflows/create_app2abap.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/create_app2abap.yaml)
 [![create_frontend](https://github.com/abap2UI5/abap2UI5/actions/workflows/create_frontend.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/create_frontend.yaml)
+[![trigger_local](https://github.com/abap2UI5/abap2UI5/actions/workflows/trigger_local.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/trigger_local.yaml)
 <br>
 [![mirror_ajson](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_ajson.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_ajson.yaml)
 [![mirror_srtti](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_srtti.yaml/badge.svg)](https://github.com/abap2UI5/abap2UI5/actions/workflows/mirror_srtti.yaml)


### PR DESCRIPTION
# Description

Added a badge for the `trigger_local` GitHub Actions workflow to the README.md file. This badge displays the status of the local trigger workflow alongside other existing workflow badges.

## How to test

N/A - This is a documentation-only change that adds a status badge link.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: no

https://claude.ai/code/session_01M5xYa9dHUXzHywXdHiVYh6