### PR TITLE
Fix dangling hash in URL after app start

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -8,6 +8,7 @@ sap.ui.define(
     "z2ui5/core/Lib",
     "z2ui5/core/AppState",
     "z2ui5/Util",
+    "sap/ui/core/routing/HashChanger",
   ],
   (
     UIComponent,
@@ -18,6 +19,7 @@ sap.ui.define(
     Lib,
     AppState,
     DateUtil,
+    HashChanger,
   ) => {
     "use strict";
 
@@ -55,6 +57,17 @@ sap.ui.define(
         this._installUnloadListener();
         this._installDebugToolShortcut();
         this._installScrollListener();
+
+        // The stopped router removed with the manifest routing section used
+        // to initialize the HashChanger (and its underlying hasher
+        // singleton) as a side effect. Without that init hasher never
+        // learns the URL's current hash, so the app-state cleanup after
+        // every roundtrip (View1._updateBrowserHistory calling
+        // replaceHash("")) is treated as a change and rewrites the URL to
+        // "...#" - every app start ended with a dangling "#". Initialize it
+        // explicitly; inside the FLP the shell has already done this and
+        // init() is a guarded no-op.
+        HashChanger.getInstance().init();
       },
 
       // ------------------------------------------------------------------

--- a/node/tests/e2e/roundtrip.spec.js
+++ b/node/tests/e2e/roundtrip.spec.js
@@ -84,3 +84,29 @@ test("boots the UI5 shell in the browser and issues the initial roundtrip", asyn
   expect(body.S_FRONT.APP).toBe(HELLO_WORLD);
   expect(body.S_FRONT.ID).toMatch(/^[0-9A-F]{32}$/);
 });
+
+test("does not append a dangling '#' to the URL after app start", async ({
+  page,
+}) => {
+  // Regression: with the manifest routing gone, nothing initialized the
+  // HashChanger's hasher singleton anymore, so the app-state cleanup in
+  // View1._updateBrowserHistory (replaceHash("")) rewrote every started
+  // app's URL to ".../path#". Component.init now initializes the
+  // HashChanger explicitly.
+  const responsePromise = page.waitForResponse(
+    (r) => r.request().method() === "POST",
+  );
+  await page.goto("/?app_start=z2ui5_cl_app_hello_world");
+  await responsePromise;
+
+  // _updateBrowserHistory runs inside _processAfterRendering, which flags
+  // the response as processed right before the history update phase - wait
+  // for the flag plus a settle tick so the (synchronous) hash rewrite, if
+  // any, has happened before asserting.
+  await page.waitForFunction(
+    () => window.z2ui5?.oResponse?._processed === true,
+  );
+  await page.waitForTimeout(100);
+
+  expect(page.url()).not.toContain("#");
+});

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -28,6 +28,7 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `    "z2ui5/core/Lib",` && |\n| &&
              `    "z2ui5/core/AppState",` && |\n| &&
              `    "z2ui5/Util",` && |\n| &&
+             `    "sap/ui/core/routing/HashChanger",` && |\n| &&
              `  ],` && |\n| &&
              `  (` && |\n| &&
              `    UIComponent,` && |\n| &&
@@ -38,6 +39,7 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `    Lib,` && |\n| &&
              `    AppState,` && |\n| &&
              `    DateUtil,` && |\n| &&
+             `    HashChanger,` && |\n| &&
              `  ) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
@@ -75,6 +77,17 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        this._installUnloadListener();` && |\n| &&
              `        this._installDebugToolShortcut();` && |\n| &&
              `        this._installScrollListener();` && |\n| &&
+             `` && |\n| &&
+             `        // The stopped router removed with the manifest routing section used` && |\n| &&
+             `        // to initialize the HashChanger (and its underlying hasher` && |\n| &&
+             `        // singleton) as a side effect. Without that init hasher never` && |\n| &&
+             `        // learns the URL's current hash, so the app-state cleanup after` && |\n| &&
+             `        // every roundtrip (View1._updateBrowserHistory calling` && |\n| &&
+             `        // replaceHash("")) is treated as a change and rewrites the URL to` && |\n| &&
+             `        // "...#" - every app start ended with a dangling "#". Initialize it` && |\n| &&
+             `        // explicitly; inside the FLP the shell has already done this and` && |\n| &&
+             `        // init() is a guarded no-op.` && |\n| &&
+             `        HashChanger.getInstance().init();` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&


### PR DESCRIPTION
# Description

Fixes a regression where app URLs would end with a dangling `#` character after startup. This occurred because the removal of manifest routing eliminated the initialization of the `HashChanger` singleton, which is responsible for tracking the current URL hash state.

Without explicit initialization, the `HashChanger` doesn't learn the current hash value. When `View1._updateBrowserHistory` calls `replaceHash("")` to clean up app state after each roundtrip, the uninitialised hasher treats this as a change and rewrites the URL to include `#`.

The fix explicitly initializes `HashChanger` in `Component.init()`. This is safe because:
- Inside the Fiori Launchpad, the shell has already initialized it, making `init()` a guarded no-op
- In standalone mode, this ensures proper hash tracking from the start

## How to test

The new e2e test `does not append a dangling '#' to the URL after app start` verifies the fix by:
1. Starting an app with `app_start` parameter
2. Waiting for the response to be processed
3. Asserting that the final URL does not contain `#`

Run: `npm test -- roundtrip.spec.js`

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (e2e test added)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_018XSzrcjseUkW1Bv3pb29cB