### PR TITLE
Add Logali Group reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ abap2UI5 is a **single-page app**. The browser loads a UI5 shell once, then talk
 You never touch JSON, HTTP, or JavaScript yourself. You implement `z2ui5_if_app~main`, build views with an ABAP XML view builder, and bind ABAP variables to UI5 controls — the framework handles serialization, sessions, and rendering.
 
 #### References
-* Magic on the Local Server: Fiori-type Apps built 100% with ABAP [(Logali Group)](https://logaligroup.com/magia-en-el-servidor-local-apps-tipo-fiori-creadas-100-con-codigo-abap/)
+* Magic on the Local Server: Fiori-type Apps built 100% with ABAP [(Logali Group - 23.04.2026)](https://logaligroup.com/magia-en-el-servidor-local-apps-tipo-fiori-creadas-100-con-codigo-abap/)
 * Webinar on Launchpad Integration [(YouTube - 30.07.2025)](https://www.youtube.com/watch?v=t5g3F3PHsbw&list=PLLpkZ_86h4quGSfsjohDHt9CrpjXdeA1P)
 * Featured on SAP Developer News [(YouTube - 21.03.2025)](https://www.youtube.com/watch?v=vKrpkDe2mkU&list=PL6RpkC85SLQAVBSQXN9522_1jNvPavBgg&t=90s)
 * Webinar on Creating UI5 UIs from ABAP with abap2UI5 [(YouTube - 12.12.2024)](https://www.youtube.com/watch?v=N2OAdxf7Lng)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ abap2UI5 is a **single-page app**. The browser loads a UI5 shell once, then talk
 You never touch JSON, HTTP, or JavaScript yourself. You implement `z2ui5_if_app~main`, build views with an ABAP XML view builder, and bind ABAP variables to UI5 controls — the framework handles serialization, sessions, and rendering.
 
 #### References
+* Magic on the Local Server: Fiori-type Apps built 100% with ABAP [(Logali Group)](https://logaligroup.com/magia-en-el-servidor-local-apps-tipo-fiori-creadas-100-con-codigo-abap/)
 * Webinar on Launchpad Integration [(YouTube - 30.07.2025)](https://www.youtube.com/watch?v=t5g3F3PHsbw&list=PLLpkZ_86h4quGSfsjohDHt9CrpjXdeA1P)
 * Featured on SAP Developer News [(YouTube - 21.03.2025)](https://www.youtube.com/watch?v=vKrpkDe2mkU&list=PL6RpkC85SLQAVBSQXN9522_1jNvPavBgg&t=90s)
 * Webinar on Creating UI5 UIs from ABAP with abap2UI5 [(YouTube - 12.12.2024)](https://www.youtube.com/watch?v=N2OAdxf7Lng)


### PR DESCRIPTION
# Description

Added a new reference to the README.md file linking to a Logali Group article about building Fiori-type applications with ABAP using abap2UI5. This reference is placed at the top of the References section and includes the publication date (23.04.2026).

## How to test

N/A - Documentation-only change. Verify that the link is correctly formatted and the reference appears in the References section of the README.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01XhuXkaATjJiCTS2pojMNMW