### PR TITLE
Fix mirror-input.js script path in CAP workflow

### DIFF
--- a/.github/workflows/trigger_cap.yaml
+++ b/.github/workflows/trigger_cap.yaml
@@ -51,7 +51,7 @@ jobs:
     # pushed input/ state always matches the commit that triggered this run.
     - name: Mirror current sources into input/abap2UI5
       working-directory: cap
-      run: MIRROR_SOURCE="${{ github.workspace }}/upstream" node scripts/mirror-input.js abap2UI5
+      run: MIRROR_SOURCE="${{ github.workspace }}/upstream" node tools/scripts/mirror-input.js abap2UI5
 
     - name: Commit and push to cap2UI5 main
       working-directory: cap


### PR DESCRIPTION
# Description

Updates the path to the `mirror-input.js` script in the CAP trigger workflow from `scripts/mirror-input.js` to `tools/scripts/mirror-input.js` to reflect the correct location of the script in the repository structure.

## How to test

The CAP workflow will execute successfully when triggered, properly locating and running the mirror-input script from its new path location.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01ApKt1SK2NSZRXHBQUG7ijZ