### PR TITLE
Fix frontend state leakage during app navigation

### DIFF
--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -211,12 +211,16 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     " when navigating between apps ( both nav_app_call and nav_app_leave ),
     " start the next app with a clean frontend state - messages and follow-up
     " actions queued by the previous app must not leak into the next one.
-    " ( popups / popovers are deliberately left untouched: an app may open a
-    "   popup app via nav_app_call and relies on the popup close / destroy
-    "   lifecycle being carried across the app stack )
     CLEAR result->ms_next-s_set-s_msg_box.
     CLEAR result->ms_next-s_set-s_msg_toast.
     CLEAR result->ms_next-s_set-s_follow_up_action.
+
+    " always destroy an open popup on navigation, so an app never has to close
+    " a popup explicitly before nav_app_call / nav_app_leave. If the app that
+    " is navigated to renders a popup itself, its popup_display( ) overwrites
+    " this destroy request again ( the frontend processes CHECK_DESTROY before
+    " the new popup XML ). Destroying when no popup is open is a no-op.
+    result->ms_next-s_set-s_popup = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -122,16 +122,6 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     result = prepare_app_stack( ms_next-o_app_call ).
     result->mo_app->ms_draft-id_prev_app_stack = mo_app->ms_draft-id.
 
-    " when navigating forward into a new app, start with a clean frontend
-    " state - messages and follow-up actions queued by the calling app must
-    " not leak into the newly called app.
-    " ( popups / popovers are deliberately left untouched: an app may open a
-    "   popup app via nav_app_call and relies on the popup close / destroy
-    "   lifecycle being carried across the app stack )
-    CLEAR result->ms_next-s_set-s_msg_box.
-    CLEAR result->ms_next-s_set-s_msg_toast.
-    CLEAR result->ms_next-s_set-s_follow_up_action.
-
   ENDMETHOD.
 
   METHOD factory_stack_leave.
@@ -218,8 +208,15 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     ENDIF.
     result->ms_actual-r_data = ms_next-r_data.
 
+    " when navigating between apps ( both nav_app_call and nav_app_leave ),
+    " start the next app with a clean frontend state - messages and follow-up
+    " actions queued by the previous app must not leak into the next one.
+    " ( popups / popovers are deliberately left untouched: an app may open a
+    "   popup app via nav_app_call and relies on the popup close / destroy
+    "   lifecycle being carried across the app stack )
     CLEAR result->ms_next-s_set-s_msg_box.
     CLEAR result->ms_next-s_set-s_msg_toast.
+    CLEAR result->ms_next-s_set-s_follow_up_action.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -122,6 +122,16 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     result = prepare_app_stack( ms_next-o_app_call ).
     result->mo_app->ms_draft-id_prev_app_stack = mo_app->ms_draft-id.
 
+    " when navigating forward into a new app, start with a clean frontend
+    " state - messages and follow-up actions queued by the calling app must
+    " not leak into the newly called app.
+    " ( popups / popovers are deliberately left untouched: an app may open a
+    "   popup app via nav_app_call and relies on the popup close / destroy
+    "   lifecycle being carried across the app stack )
+    CLEAR result->ms_next-s_set-s_msg_box.
+    CLEAR result->ms_next-s_set-s_msg_toast.
+    CLEAR result->ms_next-s_set-s_follow_up_action.
+
   ENDMETHOD.
 
   METHOD factory_stack_leave.

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -22,6 +22,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_factory_by_frontend FOR TESTING RAISING cx_static_check.
     METHODS test_reset_view_flags   FOR TESTING RAISING cx_static_check.
     METHODS test_stack_call         FOR TESTING RAISING cx_static_check.
+    METHODS test_stack_leave        FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS z2ui5_cl_core_action DEFINITION LOCAL FRIENDS ltcl_test.
@@ -254,6 +255,54 @@ CLASS ltcl_test IMPLEMENTATION.
                                         act = lo_result->mo_app->ms_draft-id_prev_app_stack ).
 
     " messages and follow-up actions are reset for the called app
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_box ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_toast ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_follow_up_action ).
+    " popups / popovers survive the navigation ( popup close lifecycle )
+    cl_abap_unit_assert=>assert_equals( exp = `<popup/>`
+                                        act = lo_result->ms_next-s_set-s_popup-xml ).
+    cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
+                                        act = lo_result->ms_next-s_set-s_popover-xml ).
+
+  ENDMETHOD.
+
+  METHOD test_stack_leave.
+    DATA lo_http TYPE REF TO z2ui5_cl_core_handler.
+    DATA lo_action TYPE REF TO z2ui5_cl_core_action.
+    DATA lo_prev_app TYPE REF TO ltcl_test_app.
+    DATA lo_result TYPE REF TO z2ui5_cl_core_action.
+
+    IF sy-sysid = `ABC`.
+      RETURN.
+    ENDIF.
+
+
+    lo_http = NEW #( val = `` ).
+
+    lo_action = NEW #( val = lo_http ).
+    lo_action->mo_app->mo_app = NEW ltcl_test_app( ).
+    lo_action->mo_app->ms_draft-id = `CURRENT_DRAFT`.
+
+
+    lo_prev_app = NEW #( ).
+    lo_action->ms_next-o_app_leave = lo_prev_app.
+
+    " frontend actions queued by the leaving app - messages and follow-up
+    " actions must not leak into the app that is navigated back to...
+    lo_action->ms_next-s_set-s_msg_box-text   = `box`.
+    lo_action->ms_next-s_set-s_msg_toast-text = `toast`.
+    INSERT `some_js` INTO TABLE lo_action->ms_next-s_set-s_follow_up_action-custom_js.
+    " ...while popups / popovers are deliberately carried across the app stack
+    " ( e.g. a popup_destroy( ) issued right before nav_app_leave( ) )
+    lo_action->ms_next-s_set-s_popup-xml   = `<popup/>`.
+    lo_action->ms_next-s_set-s_popover-xml = `<popover/>`.
+
+
+    lo_result = lo_action->factory_stack_leave( ).
+
+    cl_abap_unit_assert=>assert_bound( lo_result ).
+
+    " leave behaves like call: messages and follow-up actions are reset
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_box ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_toast ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_follow_up_action ).

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -237,12 +237,31 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_new_app = NEW #( ).
     lo_action->ms_next-o_app_call = lo_new_app.
 
+    " frontend actions queued by the calling app - messages and follow-up
+    " actions must not leak into the newly called app...
+    lo_action->ms_next-s_set-s_msg_box-text   = `box`.
+    lo_action->ms_next-s_set-s_msg_toast-text = `toast`.
+    INSERT `some_js` INTO TABLE lo_action->ms_next-s_set-s_follow_up_action-custom_js.
+    " ...while popups / popovers are deliberately carried across the app stack
+    lo_action->ms_next-s_set-s_popup-xml   = `<popup/>`.
+    lo_action->ms_next-s_set-s_popover-xml = `<popover/>`.
+
 
     lo_result = lo_action->factory_stack_call( ).
 
     cl_abap_unit_assert=>assert_bound( lo_result ).
     cl_abap_unit_assert=>assert_equals( exp = `CURRENT_DRAFT`
                                         act = lo_result->mo_app->ms_draft-id_prev_app_stack ).
+
+    " messages and follow-up actions are reset for the called app
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_box ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_toast ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_follow_up_action ).
+    " popups / popovers survive the navigation ( popup close lifecycle )
+    cl_abap_unit_assert=>assert_equals( exp = `<popup/>`
+                                        act = lo_result->ms_next-s_set-s_popup-xml ).
+    cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
+                                        act = lo_result->ms_next-s_set-s_popover-xml ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -243,9 +243,8 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_action->ms_next-s_set-s_msg_box-text   = `box`.
     lo_action->ms_next-s_set-s_msg_toast-text = `toast`.
     INSERT `some_js` INTO TABLE lo_action->ms_next-s_set-s_follow_up_action-custom_js.
-    " ...while popups / popovers are deliberately carried across the app stack
-    lo_action->ms_next-s_set-s_popup-xml   = `<popup/>`.
-    lo_action->ms_next-s_set-s_popover-xml = `<popover/>`.
+    lo_action->ms_next-s_set-s_popup-xml    = `<popup/>`.
+    lo_action->ms_next-s_set-s_popover-xml  = `<popover/>`.
 
 
     lo_result = lo_action->factory_stack_call( ).
@@ -258,9 +257,12 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_box ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_toast ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_follow_up_action ).
-    " popups / popovers survive the navigation ( popup close lifecycle )
-    cl_abap_unit_assert=>assert_equals( exp = `<popup/>`
-                                        act = lo_result->ms_next-s_set-s_popup-xml ).
+    " a popup is always destroyed on navigation ( a called app that renders
+    " its own popup overwrites this destroy request again )
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_result->ms_next-s_set-s_popup-check_destroy ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popup-xml ).
+    " popovers are carried across the app stack
     cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
                                         act = lo_result->ms_next-s_set-s_popover-xml ).
 
@@ -292,10 +294,8 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_action->ms_next-s_set-s_msg_box-text   = `box`.
     lo_action->ms_next-s_set-s_msg_toast-text = `toast`.
     INSERT `some_js` INTO TABLE lo_action->ms_next-s_set-s_follow_up_action-custom_js.
-    " ...while popups / popovers are deliberately carried across the app stack
-    " ( e.g. a popup_destroy( ) issued right before nav_app_leave( ) )
-    lo_action->ms_next-s_set-s_popup-xml   = `<popup/>`.
-    lo_action->ms_next-s_set-s_popover-xml = `<popover/>`.
+    lo_action->ms_next-s_set-s_popup-xml    = `<popup/>`.
+    lo_action->ms_next-s_set-s_popover-xml  = `<popover/>`.
 
 
     lo_result = lo_action->factory_stack_leave( ).
@@ -306,9 +306,11 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_box ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_msg_toast ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_follow_up_action ).
-    " popups / popovers survive the navigation ( popup close lifecycle )
-    cl_abap_unit_assert=>assert_equals( exp = `<popup/>`
-                                        act = lo_result->ms_next-s_set-s_popup-xml ).
+    " a popup is always destroyed on navigation, also on leave
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_result->ms_next-s_set-s_popup-check_destroy ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popup-xml ).
+    " popovers are carried across the app stack
     cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
                                         act = lo_result->ms_next-s_set-s_popover-xml ).
 


### PR DESCRIPTION
# Description

This PR fixes a bug where frontend UI state (messages, follow-up actions, and popups) queued by one app would leak into the next app when navigating via `nav_app_call` or `nav_app_leave`.

## Changes

**src/01/02/z2ui5_cl_core_action.clas.abap:**
- Enhanced the `factory_stack_call` method to clear additional frontend state when navigating between apps:
  - `s_follow_up_action` (custom JavaScript actions)
  - `s_popup` (set destroy flag and clear XML to ensure popups don't persist across navigation)
- Popovers (`s_popover`) are intentionally preserved across app navigation
- Added detailed comments explaining the navigation behavior

**src/01/02/z2ui5_cl_core_action.clas.testclasses.abap:**
- Extended `test_stack_call` to verify that messages, follow-up actions, and popups are properly cleared when calling a new app, while popovers are preserved
- Added new `test_stack_leave` test method to verify the same cleanup behavior applies when leaving an app (navigating back in the stack)

## How to test

The added and extended unit tests (`test_stack_call` and `test_stack_leave`) verify that:
1. Message boxes and toasts are cleared on app navigation
2. Follow-up actions (custom JS) are cleared on app navigation
3. Popups are destroyed on app navigation
4. Popovers are preserved across app navigation

Run the unit tests in `z2ui5_cl_core_action.clas.testclasses.abap` to verify the fix.

## Checklist

- [x] Unit tests added/updated where it makes sense (`.testclasses.abap`)
- [x] Changes made via abapGit: yes

https://claude.ai/code/session_012Frc8TTGXYaXHd9ZfYdWb9