### PR TITLE
Add Fixed and Interactive row modes, expand Auto mode parameters

### DIFF
--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -6454,6 +6454,7 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
         numberstate         TYPE clike OPTIONAL
         numbertextdirection TYPE clike OPTIONAL
         numberunit          TYPE clike OPTIONAL
+        unit                TYPE clike OPTIONAL
         title               TYPE clike OPTIONAL
         titletextdirection  TYPE clike OPTIONAL
         press               TYPE clike OPTIONAL
@@ -12720,6 +12721,7 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
                           ( n = `numberState`         v = numberstate )
                           ( n = `numberTextDirection` v = numbertextdirection )
                           ( n = `numberUnit`          v = numberunit )
+                          ( n = `unit`                v = unit )
                           ( n = `title`               v = title )
                           ( n = `titleTextDirection`  v = titletextdirection )
                           ( n = `iconDensityAware`    v = z2ui5_cl_util=>boolean_abap_2_json( icondensityaware ) )

--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -477,14 +477,64 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
     "!
     "! See https://ui5.sap.com/#/api/sap.ui.table.rowmodes.Auto. Used inside `rowMode` of sap.ui.table.Table / AnalyticalTable.
     "!
-    "! @parameter ns               | (string) XML namespace prefix (typically `t`).
-    "! @parameter rowcontentheight | (int) Row content height in pixels. 0 = theme-based default. Default: 0.
+    "! @parameter ns                  | (string) XML namespace prefix (typically `t`).
+    "! @parameter rowcontentheight    | (int) Row content height in pixels. 0 = theme-based default. Default: 0.
+    "! @parameter minrowcount         | (int) Minimum number of displayed rows. Default: 5.
+    "! @parameter maxrowcount         | (int) Maximum number of displayed rows (-1 = no limit). Default: -1.
+    "! @parameter fixedtoprowcount    | (int) Number of fixed rows at the top. Default: 0.
+    "! @parameter fixedbottomrowcount | (int) Number of fixed rows at the bottom. Default: 0.
     METHODS auto
       IMPORTING
-        ns               TYPE clike OPTIONAL
-        rowcontentheight TYPE clike OPTIONAL
+        ns                  TYPE clike OPTIONAL
+        rowcontentheight    TYPE clike OPTIONAL
+        minrowcount         TYPE clike OPTIONAL
+        maxrowcount         TYPE clike OPTIONAL
+        fixedtoprowcount    TYPE clike OPTIONAL
+        fixedbottomrowcount TYPE clike OPTIONAL
       RETURNING
-        VALUE(result)    TYPE REF TO z2ui5_cl_xml_view.
+        VALUE(result)       TYPE REF TO z2ui5_cl_xml_view.
+
+    "! <p class="shorttext synchronized" lang="en">sap.ui.table.rowmodes.Fixed</p>
+    "!
+    "! See https://ui5.sap.com/#/api/sap.ui.table.rowmodes.Fixed. Used inside `rowMode` of sap.ui.table.Table / AnalyticalTable.
+    "!
+    "! @parameter ns                  | (string) XML namespace prefix (typically `t`).
+    "! @parameter rowcount            | (int) Number of displayed rows. Default: 10.
+    "! @parameter rowcontentheight    | (int) Row content height in pixels. 0 = theme-based default. Default: 0.
+    "! @parameter fixedtoprowcount    | (int) Number of fixed rows at the top. Default: 0.
+    "! @parameter fixedbottomrowcount | (int) Number of fixed rows at the bottom. Default: 0.
+    METHODS fixed
+      IMPORTING
+        ns                  TYPE clike OPTIONAL
+        rowcount            TYPE clike OPTIONAL
+        rowcontentheight    TYPE clike OPTIONAL
+        fixedtoprowcount    TYPE clike OPTIONAL
+        fixedbottomrowcount TYPE clike OPTIONAL
+      RETURNING
+        VALUE(result)       TYPE REF TO z2ui5_cl_xml_view.
+
+    "! <p class="shorttext synchronized" lang="en">sap.ui.table.rowmodes.Interactive</p>
+    "!
+    "! See https://ui5.sap.com/#/api/sap.ui.table.rowmodes.Interactive. Used inside `rowMode` of sap.ui.table.Table / AnalyticalTable.
+    "!
+    "! @parameter ns                  | (string) XML namespace prefix (typically `t`).
+    "! @parameter rowcount            | (int) Initial number of displayed rows. Default: 10.
+    "! @parameter minrowcount         | (int) Minimum number of displayed rows. Default: 5.
+    "! @parameter maxrowcount         | (int) Maximum number of displayed rows (-1 = no limit). Default: -1.
+    "! @parameter rowcontentheight    | (int) Row content height in pixels. 0 = theme-based default. Default: 0.
+    "! @parameter fixedtoprowcount    | (int) Number of fixed rows at the top. Default: 0.
+    "! @parameter fixedbottomrowcount | (int) Number of fixed rows at the bottom. Default: 0.
+    METHODS interactive
+      IMPORTING
+        ns                  TYPE clike OPTIONAL
+        rowcount            TYPE clike OPTIONAL
+        minrowcount         TYPE clike OPTIONAL
+        maxrowcount         TYPE clike OPTIONAL
+        rowcontentheight    TYPE clike OPTIONAL
+        fixedtoprowcount    TYPE clike OPTIONAL
+        fixedbottomrowcount TYPE clike OPTIONAL
+      RETURNING
+        VALUE(result)       TYPE REF TO z2ui5_cl_xml_view.
 
     "! <p class="shorttext synchronized" lang="en">sap.m.MessageStrip</p>
     "!
@@ -15251,7 +15301,31 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
   METHOD auto.
     result = _generic( ns     = ns
                        name   = `Auto`
-                       t_prop = VALUE #( ( n = `rowContentHeight`           v = rowcontentheight ) ) ).
+                       t_prop = VALUE #( ( n = `rowContentHeight`    v = rowcontentheight )
+                                         ( n = `minRowCount`         v = minrowcount )
+                                         ( n = `maxRowCount`         v = maxrowcount )
+                                         ( n = `fixedTopRowCount`    v = fixedtoprowcount )
+                                         ( n = `fixedBottomRowCount` v = fixedbottomrowcount ) ) ).
+  ENDMETHOD.
+
+  METHOD fixed.
+    result = _generic( ns     = ns
+                       name   = `Fixed`
+                       t_prop = VALUE #( ( n = `rowCount`            v = rowcount )
+                                         ( n = `rowContentHeight`    v = rowcontentheight )
+                                         ( n = `fixedTopRowCount`    v = fixedtoprowcount )
+                                         ( n = `fixedBottomRowCount` v = fixedbottomrowcount ) ) ).
+  ENDMETHOD.
+
+  METHOD interactive.
+    result = _generic( ns     = ns
+                       name   = `Interactive`
+                       t_prop = VALUE #( ( n = `rowCount`            v = rowcount )
+                                         ( n = `minRowCount`         v = minrowcount )
+                                         ( n = `maxRowCount`         v = maxrowcount )
+                                         ( n = `rowContentHeight`    v = rowcontentheight )
+                                         ( n = `fixedTopRowCount`    v = fixedtoprowcount )
+                                         ( n = `fixedBottomRowCount` v = fixedbottomrowcount ) ) ).
   ENDMETHOD.
 
   METHOD rowmode.


### PR DESCRIPTION
# Description

This PR extends the table row mode support in the XML view builder by:

1. **Expanding the `auto()` method** with additional parameters:
   - `minrowcount`: Minimum number of displayed rows
   - `maxrowcount`: Maximum number of displayed rows
   - `fixedtoprowcount`: Number of fixed rows at the top
   - `fixedbottomrowcount`: Number of fixed rows at the bottom

2. **Adding new `fixed()` method** for `sap.ui.table.rowmodes.Fixed` with parameters:
   - `rowcount`: Number of displayed rows
   - `rowcontentheight`: Row content height in pixels
   - `fixedtoprowcount`: Number of fixed rows at the top
   - `fixedbottomrowcount`: Number of fixed rows at the bottom

3. **Adding new `interactive()` method** for `sap.ui.table.rowmodes.Interactive` with parameters:
   - `rowcount`: Initial number of displayed rows
   - `minrowcount`: Minimum number of displayed rows
   - `maxrowcount`: Maximum number of displayed rows
   - `rowcontentheight`: Row content height in pixels
   - `fixedtoprowcount`: Number of fixed rows at the top
   - `fixedbottomrowcount`: Number of fixed rows at the bottom

4. **Adding `unit` parameter** to the `objectnumber()` method for additional flexibility in number formatting.

These changes provide more comprehensive control over table row display modes and align with the SAP UI5 API capabilities.

## How to test

- Verify that the new `fixed()` and `interactive()` methods generate correct XML output for their respective row modes
- Confirm that the expanded `auto()` method properly includes all new parameters in the generated XML
- Test that the `unit` parameter in `objectnumber()` is correctly rendered in the output

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01TNp2F8z54owgZAjqctbEcT