### PR TITLE
Expose sap.m.Menu wrapper and complete Since annotations (GenericTag, ShellBar, DateRangeSelection)

### DIFF
--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -2841,6 +2841,23 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
       RETURNING
         VALUE(result) TYPE REF TO z2ui5_cl_xml_view.
 
+    "! <p class="shorttext synchronized" lang="en">sap.m.Menu</p>
+    "!
+    "! See https://ui5.sap.com/#/api/sap.m.Menu. Since 1.38. Hierarchical menu; the items are `sap.m.MenuItem`. Opened as a popover via `client->popover_display( by_id = ... )`.
+    "!
+    "! @parameter id           | (string) Stable control id.
+    "! @parameter title        | (string) Menu title.
+    "! @parameter itemselected | (event) Fired when a `MenuItem` is selected.
+    "! @parameter closed       | (event) Fired when the menu is closed.
+    METHODS menu
+      IMPORTING
+        id            TYPE clike OPTIONAL
+        title         TYPE clike OPTIONAL
+        itemselected  TYPE clike OPTIONAL
+        closed        TYPE clike OPTIONAL
+      RETURNING
+        VALUE(result) TYPE REF TO z2ui5_cl_xml_view.
+
     "! <p class="shorttext synchronized" lang="en">sap.m.MenuItem</p>
     "!
     "! See https://ui5.sap.com/#/api/sap.m.MenuItem.
@@ -12355,6 +12372,14 @@ CLASS z2ui5_cl_xml_view IMPLEMENTATION.
                                          ( n = `enabled`       v = z2ui5_cl_util=>boolean_abap_2_json( enabled ) )
                                          ( n = `activeIcon`    v = activeicon )
                                          ( n = `type`          v = type ) ) ).
+  ENDMETHOD.
+
+  METHOD menu.
+    result = _generic( name   = `Menu`
+                       t_prop = VALUE #( ( n = `id`           v = id )
+                                         ( n = `title`        v = title )
+                                         ( n = `itemSelected` v = itemselected )
+                                         ( n = `closed`       v = closed ) ) ).
   ENDMETHOD.
 
   METHOD menu_item.

--- a/src/02/z2ui5_cl_xml_view.clas.abap
+++ b/src/02/z2ui5_cl_xml_view.clas.abap
@@ -1346,7 +1346,7 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
 
     "! <p class="shorttext synchronized" lang="en">sap.f.ShellBar</p>
     "!
-    "! Top-level shell/navigation bar. See https://ui5.sap.com/#/api/sap.f.ShellBar.
+    "! Top-level shell/navigation bar. See https://ui5.sap.com/#/api/sap.f.ShellBar. Since 1.63.
     "!
     "! @parameter homeicon               | (sap.ui.core.URI) Home icon (company/product logo).
     "! @parameter homeicontooltip        | (string) Custom tooltip for the home icon.
@@ -3730,7 +3730,7 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
 
     "! <p class="shorttext synchronized" lang="en">sap.m.GenericTag</p>
     "!
-    "! Badge-style status tag. See https://ui5.sap.com/#/api/sap.m.GenericTag.
+    "! Badge-style status tag. See https://ui5.sap.com/#/api/sap.m.GenericTag. Since 1.62.
     "!
     "! @parameter arialabelledby | (sap.ui.core.ID[]) Ids of labelling controls (ARIA).
     "! @parameter text           | (string) Tag text.
@@ -7399,7 +7399,7 @@ CLASS z2ui5_cl_xml_view DEFINITION PUBLIC.
     "! @parameter required                | (boolean) Required field marker. Default: false.
     "! @parameter visible                 | (boolean) Whether visible. Default: true.
     "! @parameter width                   | (sap.ui.core.CSSSize) Width.
-    "! @parameter showcurrentdatebutton   | (boolean) Show "Today" button. Default: false.
+    "! @parameter showcurrentdatebutton   | (boolean) Show "Today" button. Default: false. Since 1.95.
     "! @parameter showfooter              | (boolean) Show calendar footer. Default: false.
     "! @parameter hideinput               | (boolean) Hide the input field. Default: false.
     "! @parameter placeholder             | (string) Placeholder text.


### PR DESCRIPTION
# Description

Additive `z2ui5_cl_xml_view` follow-up to the samples categorisation work (continues the already-merged #2391), all following the strict 1:1 UI5 SDK rule (#2390):

- **New control wrapper** — `sap.m.Menu` (`menu`), the successor of the deprecated `sap.m.ActionSheet`. Hierarchical menu whose items are `sap.m.MenuItem`; opened as a popover via `client->popover_display( by_id = ... )`. Property/event names verified 1:1 against the UI5 SDK. Since 1.38.
- **Completed `Since` annotations** — fill the remaining release-version gaps found while auditing the samples for the UI5 1.71 baseline:
  - `sap.m.GenericTag` → Since 1.62
  - `sap.f.ShellBar` → Since 1.63
  - `sap.m.DateRangeSelection` `showCurrentDateButton` property → Since 1.95 (matches the Calendar variant)

`sap.tnt.InfoLabel` `renderMode` was verified as 1.54 and deliberately left unmarked, in line with the "annotate only post-1.71" convention.

## How to test

- `npx abaplint` passes with 0 issues.
- New wrapper, e.g.: `view->menu( )->menu_item( text = ... )`, opened via `client->popover_display( by_id = ... )`.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNp2F8z54owgZAjqctbEcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNp2F8z54owgZAjqctbEcT)_