### PR TITLE
Support z2ui5_cl_sample_000 as fallback for code samples

### DIFF
--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -195,8 +195,12 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
 
     simple_form->toolbar( )->title( `What's next?` ).
 
-    IF z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_demo_app_000` ).
-      DATA(lv_url_samples) = get_app_url( `z2ui5_cl_demo_app_000` ).
+    DATA(lv_class_samples) = COND string(
+      WHEN z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_sample_000` )   THEN `z2ui5_cl_sample_000`
+      WHEN z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_demo_app_000` ) THEN `z2ui5_cl_demo_app_000` ).
+
+    IF lv_class_samples IS NOT INITIAL.
+      DATA(lv_url_samples) = get_app_url( lv_class_samples ).
       simple_form->label( `Start Developing` ).
       simple_form->button( text  = `Explore Code Samples`
                            press = client->_event_client( val   = client->cs_event-open_new_tab


### PR DESCRIPTION
# Description

Updated the startup app to check for `z2ui5_cl_sample_000` as the primary class for code samples, with `z2ui5_cl_demo_app_000` as a fallback. This improves flexibility in sample app naming conventions.

The change refactors the conditional logic to use a `COND` expression that checks for class existence in priority order, then uses the resolved class name to generate the URL. This is more maintainable than nested IF statements and allows for easier addition of future fallback options.

## How to test

1. Verify the startup app loads successfully
2. If `z2ui5_cl_sample_000` exists, confirm the "Explore Code Samples" button appears and links to it
3. If only `z2ui5_cl_demo_app_000` exists, confirm the button still appears and links to the demo app
4. If neither class exists, confirm the button does not appear

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_013qt2Naz7GW9B1N8XwBdLVR