### PR TITLE
Rename sample class reference from z2ui5_cl_sample_000 to z2ui5_cl_sample_app_000

### DIFF
--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -196,7 +196,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     simple_form->toolbar( )->title( `What's next?` ).
 
     DATA(lv_class_samples) = COND string(
-      WHEN z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_sample_000` )   THEN `z2ui5_cl_sample_000`
+      WHEN z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_sample_app_000` ) THEN `z2ui5_cl_sample_app_000`
       WHEN z2ui5_cl_util=>rtti_check_class_exists( `z2ui5_cl_demo_app_000` ) THEN `z2ui5_cl_demo_app_000` ).
 
     IF lv_class_samples IS NOT INITIAL.


### PR DESCRIPTION
# Description

Updates the class name reference in the startup app's "What's next?" section from `z2ui5_cl_sample_000` to `z2ui5_cl_sample_app_000` to match the actual sample application class naming convention.

## How to test

Navigate to the startup app and verify that the "What's next?" section correctly detects and displays the sample application when `z2ui5_cl_sample_app_000` is available in the system.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01LrT22ghP1az6CmxKPoTHTn