### PR TITLE
fix: shorten char-utilities constants to ABAP 30-char identifier limit

### DIFF
--- a/src/00/03/01/z2ui5_cl_util_ext.clas.abap
+++ b/src/00/03/01/z2ui5_cl_util_ext.clas.abap
@@ -1112,10 +1112,10 @@ CLASS z2ui5_cl_util_ext IMPLEMENTATION.
         rv_tabkey = lv_tabkey.
         RETURN.
       ELSE.
-        lv_field_len = cl_abap_typedescr=>describe_by_data( <value> )->length / z2ui5_cl_util=>cv_char_utilities_charsize.
+        lv_field_len = cl_abap_typedescr=>describe_by_data( <value> )->length / z2ui5_cl_util=>cv_char_util_charsize.
       ENDIF.
 
-      lv_field_len = cl_abap_typedescr=>describe_by_data( <value> )->length / z2ui5_cl_util=>cv_char_utilities_charsize.
+      lv_field_len = cl_abap_typedescr=>describe_by_data( <value> )->length / z2ui5_cl_util=>cv_char_util_charsize.
       lv_tabkey+lv_tabkey_len(lv_field_len) = <value>.
       lv_tabkey_len = lv_tabkey_len + lv_field_len.
 

--- a/src/00/03/z2ui5_cl_util.clas.abap
+++ b/src/00/03/z2ui5_cl_util.clas.abap
@@ -24,10 +24,10 @@ CLASS z2ui5_cl_util DEFINITION
     " cl_abap_format directly, so the dependency on those SAP standard classes
     " lives in exactly one place (this class' class_constructor) and can be
     " ported once for non-ABAP runtimes (e.g. transpiled JS).
-    CLASS-DATA cv_char_utilities_newline        TYPE c LENGTH 1 READ-ONLY.
-    CLASS-DATA cv_char_utilities_cr_lf          TYPE c LENGTH 2 READ-ONLY.
-    CLASS-DATA cv_char_utilities_horizontal_tab TYPE c LENGTH 1 READ-ONLY.
-    CLASS-DATA cv_char_utilities_charsize       TYPE i          READ-ONLY.
+    CLASS-DATA cv_char_util_newline        TYPE c LENGTH 1 READ-ONLY.
+    CLASS-DATA cv_char_util_cr_lf          TYPE c LENGTH 2 READ-ONLY.
+    CLASS-DATA cv_char_util_horizontal_tab TYPE c LENGTH 1 READ-ONLY.
+    CLASS-DATA cv_char_util_charsize       TYPE i          READ-ONLY.
     CLASS-DATA cv_format_e_xml_attr             TYPE i          READ-ONLY.
 
     " RTTI type-kind / kind / visibility constants, so callers can branch on
@@ -1328,10 +1328,10 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
   METHOD class_constructor.
 
-    cv_char_utilities_newline        = cl_abap_char_utilities=>newline.
-    cv_char_utilities_cr_lf          = cl_abap_char_utilities=>cr_lf.
-    cv_char_utilities_horizontal_tab = cl_abap_char_utilities=>horizontal_tab.
-    cv_char_utilities_charsize       = cl_abap_char_utilities=>charsize.
+    cv_char_util_newline        = cl_abap_char_utilities=>newline.
+    cv_char_util_cr_lf          = cl_abap_char_utilities=>cr_lf.
+    cv_char_util_horizontal_tab = cl_abap_char_utilities=>horizontal_tab.
+    cv_char_util_charsize       = cl_abap_char_utilities=>charsize.
     cv_format_e_xml_attr             = cl_abap_format=>e_xml_attr.
 
     cv_typedescr_typekind_table      = cl_abap_typedescr=>typekind_table.
@@ -1479,9 +1479,9 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
     result = shift_left( shift_right( CONV string( val ) ) ).
     result = shift_right( val = result
-                          sub = cv_char_utilities_horizontal_tab ).
+                          sub = cv_char_util_horizontal_tab ).
     result = shift_left( val = result
-                         sub = cv_char_utilities_horizontal_tab ).
+                         sub = cv_char_util_horizontal_tab ).
     result = shift_left( shift_right( result ) ).
 
   ENDMETHOD.
@@ -1754,7 +1754,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
       INSERT lv_line INTO TABLE lt_lines.
     ENDLOOP.
 
-    result = concat_lines_of( table = lt_lines sep = cv_char_utilities_cr_lf ).
+    result = concat_lines_of( table = lt_lines sep = cv_char_util_cr_lf ).
 
   ENDMETHOD.
 
@@ -1767,7 +1767,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
     FIELD-SYMBOLS <tab> TYPE STANDARD TABLE.
     DATA lr_row TYPE REF TO data.
 
-    SPLIT val AT cv_char_utilities_newline INTO TABLE DATA(lt_rows).
+    SPLIT val AT cv_char_util_newline INTO TABLE DATA(lt_rows).
     SPLIT lt_rows[ 1 ] AT `;` INTO TABLE DATA(lt_cols).
 
     LOOP AT lt_cols REFERENCE INTO DATA(lr_col).
@@ -2135,9 +2135,9 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
 
     LOOP AT it_source INTO DATA(lv_source).
       IF strlen( lv_source ) > 1.
-        result = result && lv_source+1 && cv_char_utilities_newline.
+        result = result && lv_source+1 && cv_char_util_newline.
       ELSE.
-        result = result && cv_char_utilities_newline.
+        result = result && cv_char_util_newline.
       ENDIF.
     ENDLOOP.
 
@@ -5407,7 +5407,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
         CREATE DATA lr_line TYPE (`SOLI`).
         ASSIGN lr_line->* TO <line>.
 
-        DATA(lt_lines) = c_split( val = body sep = cv_char_utilities_newline ).
+        DATA(lt_lines) = c_split( val = body sep = cv_char_util_newline ).
         LOOP AT lt_lines INTO DATA(lv_body_line).
           ASSIGN COMPONENT `LINE` OF STRUCTURE <line> TO <field>.
           <field> = lv_body_line.

--- a/src/00/03/z2ui5_cl_util_msg.clas.abap
+++ b/src/00/03/z2ui5_cl_util_msg.clas.abap
@@ -286,7 +286,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
 
     result = concat_lines_of(
       table = VALUE string_table( FOR <r> IN msg_get( val = val val2 = val2 ) ( |- { <r>-text }| ) )
-      sep   = z2ui5_cl_util=>cv_char_utilities_newline ).
+      sep   = z2ui5_cl_util=>cv_char_util_newline ).
 
   ENDMETHOD.
 

--- a/src/00/03/z2ui5_cx_util_error.clas.abap
+++ b/src/00/03/z2ui5_cx_util_error.clas.abap
@@ -55,7 +55,7 @@ CLASS z2ui5_cx_util_error IMPLEMENTATION.
     IF previous IS BOUND.
       DATA(lo_x) = previous.
       WHILE lo_x IS BOUND.
-        result = result && z2ui5_cl_util=>cv_char_utilities_newline && lo_x->get_text( ).
+        result = result && z2ui5_cl_util=>cv_char_util_newline && lo_x->get_text( ).
         lo_x = lo_x->previous.
       ENDWHILE.
     ENDIF.


### PR DESCRIPTION
cv_char_utilities_horizontal_tab (32 chars) exceeds the SAP 30-char identifier limit and breaks activation on real systems (on-system Code Inspector SYNTAX_CHECK; abaplint does not flag it). Shorten the class segment uniformly char_utilities -> char_util for all four constants:

  cv_char_util_newline / _cr_lf / _horizontal_tab / _charsize

Follow-up to PR #2395, which was squash-merged before this fix landed.


Claude-Session: https://claude.ai/code/session_01QxG7xwQn45up8XWPHkLBTU

# Description

<!-- A clear description of what this PR changes and why the change is needed. -->

## How to test

<!-- Steps to verify the change: app snippet, test to run, or scenario to click through. -->

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no
