### PR TITLE
chore: update abaplint to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.142.0",
       "license": "MIT",
       "devDependencies": {
-        "@abaplint/cli": "^2.119.24",
-        "@abaplint/database-sqlite": "^2.11.78",
-        "@abaplint/runtime": "^2.13.28",
-        "@abaplint/transpiler-cli": "^2.13.28",
+        "@abaplint/cli": "^2.119.63",
+        "@abaplint/database-sqlite": "^2.13.40",
+        "@abaplint/runtime": "^2.13.38",
+        "@abaplint/transpiler-cli": "^2.13.38",
         "@playwright/test": "^1.61.1",
         "express": "^5.2.1"
       },
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.119.24",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.24.tgz",
-      "integrity": "sha512-9ppE7p9Kk4JJpTijwLG4g3aCFKMa1dLPNYldIZma394e/X7M0vzi+jW9rNXHcambiVeUGhLspUuYSgY/aKpJPw==",
+      "version": "2.119.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.63.tgz",
+      "integrity": "sha512-k9lzs7G37YivfHdenPoj9N0YbxHmmy1IHnuXH6X/pCWtKYH2bycn5MfPjo1UnwWyJWSHhGk7d7aaJLJtpDbeGg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@abaplint/database-sqlite": {
-      "version": "2.11.78",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.11.78.tgz",
-      "integrity": "sha512-1s5GhhwzcupKQhK2lZW7GKIvsz/WukgjuLk2oHmlSXWGFtapLYO9wJCtUSmSNTMNuXXaVt8ks2t2RH8SVj6hCg==",
+      "version": "2.13.40",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.13.40.tgz",
+      "integrity": "sha512-mgY84XJtoNThMXxNrsw9eq3Emc98lHMFlGJ9swz6nFJ5x+sivp5/lhr0SBJmFPnbg0KBj+dRb4Xgg3mKBABazQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.28",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.28.tgz",
-      "integrity": "sha512-2YmYU/qVSEzVnhn7jL/iTgDxVrUdrvb6kudChyn6arZkA8qEqUlj5xHWceemrGdzvt8GLyP4aWklIQN/DrKR/w==",
+      "version": "2.13.38",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.38.tgz",
+      "integrity": "sha512-Wr2rJXNvBDuoGsOLrAmr8hcaUwooPtK/zifegn8QDYUnB6nWMeSv61rNIcKyPKzO5QFl3TW5dLmIuBCWbyMYiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.13.28",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.28.tgz",
-      "integrity": "sha512-bYR7rNKaID8upJLjDvwyU/aZPFPozL1XDG5uWykYO7/TG+THiA3rf6tS/3kDzz9wG9zddyBNdvhYT0f8kDB4+A==",
+      "version": "2.13.38",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.38.tgz",
+      "integrity": "sha512-1b7XVrer4u5Zcxhl0Bts8R28ujGf34KYMt5kimMYwc+qXbMb1F5smHP6imL8Whn4n2pGCz5aZN1R/ny0U22mTw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@abaplint/cli": "^2.119.63",
         "@abaplint/database-sqlite": "^2.13.40",
-        "@abaplint/runtime": "^2.13.38",
+        "@abaplint/runtime": "2.13.37",
         "@abaplint/transpiler-cli": "^2.13.38",
         "@playwright/test": "^1.61.1",
         "express": "^5.2.1"
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.38",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.38.tgz",
-      "integrity": "sha512-Wr2rJXNvBDuoGsOLrAmr8hcaUwooPtK/zifegn8QDYUnB6nWMeSv61rNIcKyPKzO5QFl3TW5dLmIuBCWbyMYiw==",
+      "version": "2.13.37",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.37.tgz",
+      "integrity": "sha512-GwTTNLj7kiAaAgviMbKNSMKFErJ9F7H5+6NYIh9MlvkX9KbG1bMS89csa+tj/MmklWGGZacLQmYrBe5ikbrvCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abaplint/cli": "^2.119.24",
-    "@abaplint/database-sqlite": "^2.11.78",
-    "@abaplint/runtime": "^2.13.28",
-    "@abaplint/transpiler-cli": "^2.13.28",
+    "@abaplint/cli": "^2.119.63",
+    "@abaplint/database-sqlite": "^2.13.40",
+    "@abaplint/runtime": "^2.13.38",
+    "@abaplint/transpiler-cli": "^2.13.38",
     "@playwright/test": "^1.61.1",
     "express": "^5.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@abaplint/cli": "^2.119.63",
     "@abaplint/database-sqlite": "^2.13.40",
-    "@abaplint/runtime": "^2.13.38",
+    "@abaplint/runtime": "2.13.37",
     "@abaplint/transpiler-cli": "^2.13.38",
     "@playwright/test": "^1.61.1",
     "express": "^5.2.1"

--- a/src/00/03/01/z2ui5_cl_util_db.clas.abap
+++ b/src/00/03/01/z2ui5_cl_util_db.clas.abap
@@ -124,8 +124,7 @@ CLASS z2ui5_cl_util_db IMPLEMENTATION.
       lr_handle3 = VALUE #( ( sign = `I` option = `EQ` low = handle3 ) ).
     ENDIF.
 
-    SELECT FROM z2ui5_t_91
-      FIELDS *
+    SELECT * FROM z2ui5_t_91
       WHERE uname   IN @lr_uname
         AND handle  IN @lr_handle
         AND handle2 IN @lr_handle2


### PR DESCRIPTION
# Description

Updates the abaplint toolchain to the latest versions:

| Package | Before | After |
|---|---|---|
| `@abaplint/cli` | ^2.119.24 | ^2.119.63 |
| `@abaplint/database-sqlite` | ^2.11.78 | ^2.13.40 |
| `@abaplint/transpiler-cli` | ^2.13.28 | ^2.13.38 |
| `@abaplint/runtime` | ^2.13.28 | **2.13.37 (pinned)** |

Two upstream regressions surfaced during the update and are handled as follows:

1. **Downport regression in `@abaplint/cli` >= 2.119.30:** the strict-mode list form `SELECT FROM ... FIELDS * ... INTO CORRESPONDING FIELDS OF TABLE @result` is no longer downported correctly for 7.02 — the `@` escapes are removed but the `INTO` clause stays at the end, producing invalid classic syntax (4 `check_syntax` errors in `z2ui5_cl_util_db`). The semantically identical `SELECT * FROM ...` form downports cleanly, so the one affected statement in `src/00/03/01/z2ui5_cl_util_db.clas.abap` was rewritten to that form (no behavior change).

2. **Packed-decimal regression in `@abaplint/runtime` 2.13.38:** the packed type was rewritten to a scaled BigInt representation, but JS numbers are converted via `BigInt(Math.round(value * 10^decimals))`, which is imprecise in double arithmetic for timestamp-sized values (dec 21,7). `cl_abap_tstmp=>add( secs = 120 )` then yields `...0115.9991296` instead of `...0116.0000000`, making `time_diff_seconds` return 119 and the unit test `ltcl_unit_test_conversion->test_time_diff_seconds` fail intermittently. The runtime is therefore pinned to **2.13.37** (last good version, verified by bisect) until this is fixed upstream — worth reporting to [abaplint/transpiler](https://github.com/abaplint/transpiler).

## How to test

```bash
npm ci
npx abaplint                                        # 0 issues
npx abaplint .github/abaplint/abap_standard.jsonc   # 0 issues
npx abaplint .github/abaplint/abap_cloud.jsonc      # 0 issues
npm run auto_downport                               # 0 issues (was 4 errors without the SELECT rewrite)
npm run auto_transpile
npm run unit                                        # 825 tests pass (ran 6x to confirm no flakiness)
```

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — no test changes needed, existing suite covers the affected code
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md) — exception: one semantically identical SQL rewrite in `src/00/03/01/z2ui5_cl_util_db.clas.abap` (project-owned utility, not part of the mirrored AJSON/S-RTTI folders) required for the downport, see point 1 above
- [x] Public API in `src/02/` only changed additively — not touched
- [ ] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmEuTitkXiLzAizm4Lq6AV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmEuTitkXiLzAizm4Lq6AV)_