### PR TITLE
Fix nav_app_leave to handle empty and unbound data references

### DIFF
--- a/src/00/03/z2ui5_cl_abap2ui5_context.clas.abap
+++ b/src/00/03/z2ui5_cl_abap2ui5_context.clas.abap
@@ -776,6 +776,10 @@ CLASS z2ui5_cl_abap2ui5_context IMPLEMENTATION.
 
     IF rtti_check_ref_data( from ).
       ASSIGN from->* TO <from>.
+      IF <from> IS NOT ASSIGNED.
+        " unbound data reference - nothing to copy, return an initial reference
+        RETURN.
+      ENDIF.
     ELSE.
       ASSIGN from TO <from>.
     ENDIF.

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -245,7 +245,9 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
     mo_action->ms_next-o_app_leave = app.
     mo_action->ms_next-next_event  = event.
 
-    IF r_data IS NOT INITIAL.
+    " IS SUPPLIED (not IS NOT INITIAL) so an intentionally empty return
+    " value still reaches the previous app (https://github.com/abap2UI5/abap2UI5/issues/2404)
+    IF r_data IS SUPPLIED.
       mo_action->ms_next-r_data = z2ui5_cl_abap2ui5_context=>conv_copy_ref_data( r_data ).
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -49,6 +49,9 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_nav_app_call_id_stable FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_leave_event  FOR TESTING RAISING cx_static_check.
     METHODS test_nav_app_leave_r_data FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_leave_r_data_empty FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_leave_r_data_not_sup FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_leave_r_data_unbound FOR TESTING RAISING cx_static_check.
     METHODS test_check_app_prev_stack FOR TESTING RAISING cx_static_check.
     METHODS test_set_push_state       FOR TESTING RAISING cx_static_check.
     METHODS test_set_nav_back         FOR TESTING RAISING cx_static_check.
@@ -539,6 +542,57 @@ CLASS ltcl_test_client IMPLEMENTATION.
                               r_data = lv_data ).
 
     cl_abap_unit_assert=>assert_bound( mo_action->ms_next-r_data ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_leave_r_data_empty.
+
+    DATA lo_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lv_data TYPE string.
+    FIELD-SYMBOLS <data> TYPE data.
+    lo_app = NEW #( ).
+    li_client ?= mo_client.
+
+    li_client->nav_app_leave( app    = lo_app
+                              event  = `MY_EVENT`
+                              r_data = lv_data ).
+
+    " an intentionally empty return value must still reach the previous app (issue #2404)
+    cl_abap_unit_assert=>assert_bound( mo_action->ms_next-r_data ).
+    ASSIGN mo_action->ms_next-r_data->* TO <data>.
+    cl_abap_unit_assert=>assert_initial( <data> ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_leave_r_data_not_sup.
+
+    DATA lo_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    lo_app = NEW #( ).
+    li_client ?= mo_client.
+
+    li_client->nav_app_leave( app   = lo_app
+                              event = `MY_EVENT` ).
+
+    cl_abap_unit_assert=>assert_not_bound( mo_action->ms_next-r_data ).
+
+  ENDMETHOD.
+
+  METHOD test_nav_leave_r_data_unbound.
+
+    DATA lo_app TYPE REF TO ltcl_test_app.
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    DATA lr_data TYPE REF TO data.
+    lo_app = NEW #( ).
+    li_client ?= mo_client.
+
+    li_client->nav_app_leave( app    = lo_app
+                              event  = `MY_EVENT`
+                              r_data = lr_data ).
+
+    " an unbound data reference has no value to copy and must not dump
+    cl_abap_unit_assert=>assert_not_bound( mo_action->ms_next-r_data ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

This PR fixes issue #2404 where `nav_app_leave` was not properly handling intentionally empty return values and unbound data references.

## Changes

1. **z2ui5_cl_core_client.clas.abap**: Changed the condition from `IF r_data IS NOT INITIAL` to `IF r_data IS SUPPLIED` when processing the return data parameter. This ensures that an intentionally empty (but supplied) return value still reaches the previous app, rather than being discarded.

2. **z2ui5_cl_abap2ui5_context.clas.abap**: Added a safety check in `conv_copy_ref_data` to handle unbound data references. When a data reference is unbound (not assigned), the method now returns early with an initial reference instead of attempting to dereference it, preventing potential dumps.

3. **z2ui5_cl_core_client.clas.testclasses.abap**: Added three new unit tests to cover the edge cases:
   - `test_nav_leave_r_data_empty`: Verifies that an intentionally empty return value reaches the previous app
   - `test_nav_leave_r_data_not_sup`: Verifies that when no return data is supplied, none is passed forward
   - `test_nav_leave_r_data_unbound`: Verifies that an unbound data reference doesn't cause a dump

## How to test

Run the unit tests in `z2ui5_cl_core_client.clas.testclasses.abap`:
- `test_nav_leave_r_data_empty`
- `test_nav_leave_r_data_not_sup`
- `test_nav_leave_r_data_unbound`

All three tests should pass, confirming that the navigation leave functionality correctly handles empty, unsupplied, and unbound data references.

## Checklist

- [x] Unit tests added/updated where it makes sense (`.testclasses.abap`)
- [x] Changes address the specific issue with data reference handling

https://claude.ai/code/session_011o2xRMjpgPiAQCJoejWHMe