### PR TITLE
fix: use typed exception ref in msg_get_by_oref

### DIFF
--- a/src/00/03/z2ui5_cl_abap2ui5_context.clas.abap
+++ b/src/00/03/z2ui5_cl_abap2ui5_context.clas.abap
@@ -1988,7 +1988,7 @@ CLASS z2ui5_cl_abap2ui5_context IMPLEMENTATION.
         LOOP AT lt_attri_o REFERENCE INTO DATA(ls_attri_o)
              WHERE visibility = `U`.
           DATA(lv_name) = ls_attri_o->name.
-          ASSIGN val->(lv_name) TO <comp>.
+          ASSIGN lx->(lv_name) TO <comp>.
           IF sy-subrc <> 0.
             CONTINUE.
           ENDIF.

--- a/src/99/z2ui5_cl_util.clas.abap
+++ b/src/99/z2ui5_cl_util.clas.abap
@@ -4624,7 +4624,7 @@ CLASS z2ui5_cl_util IMPLEMENTATION.
         LOOP AT lt_attri_o REFERENCE INTO DATA(ls_attri_o)
              WHERE visibility = `U`.
           DATA(lv_name) = ls_attri_o->name.
-          ASSIGN val->(lv_name) TO <comp>.
+          ASSIGN lx->(lv_name) TO <comp>.
           IF sy-subrc <> 0.
             CONTINUE.
           ENDIF.


### PR DESCRIPTION
## Summary

Fixes the `msg_get_by_oref` compatibility issue by using the already-cast `lx` exception reference instead of `val` when assigning component attributes.

## Changes

- Update [src/99/z2ui5_cl_util.clas.abap](src/99/z2ui5_cl_util.clas.abap) to use:
  - `ASSIGN lx->(lv_name) TO <comp>.`
- Update [src/00/03/z2ui5_cl_abap2ui5_context.clas.abap](src/00/03/z2ui5_cl_abap2ui5_context.clas.abap) to use:
  - `ASSIGN lx->(lv_name) TO <comp>.`

## Why

`lx` is already defined as a properly typed `TYPE REF TO cx_root` within the `TRY` block. Older ABAP releases reject the previous `ASSIGN val->(lv_name) TO <comp>.` form in this context, while the typed `lx` reference compiles correctly and preserves the same behavior.

## Validation

- `npx abaplint`
- Result: `0 issue(s) found, 295 file(s) analyzed`