### PR TITLE
Fix variable reference in message utility loop

### DIFF
--- a/src/99/01/z2ui5_cl_util_msg.clas.abap
+++ b/src/99/01/z2ui5_cl_util_msg.clas.abap
@@ -190,7 +190,7 @@ CLASS z2ui5_cl_util_msg IMPLEMENTATION.
             LOOP AT lt_attri_o REFERENCE INTO DATA(ls_attri_o)
                  WHERE visibility = `U`.
               DATA(lv_name) = ls_attri_o->name.
-              ASSIGN val->(lv_name) TO <comp>.
+              ASSIGN lx->(lv_name) TO <comp>.
               ls_result = msg_map( name = ls_attri_o->name val = <comp> is_msg = ls_result ).
             ENDLOOP.
             INSERT ls_result INTO TABLE result.


### PR DESCRIPTION
# Description

Fixed a bug in `z2ui5_cl_util_msg` where the wrong variable was being referenced in the attribute loop. Changed `ASSIGN val->(lv_name)` to `ASSIGN lx->(lv_name)` to correctly reference the loop variable instead of an undefined or incorrect variable.

This ensures that message attributes are properly assigned from the correct source object during iteration.

## How to test

Existing unit tests for the message utility class should pass. The fix corrects the variable reference to match the intended loop logic.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01HgxF3prYH92zLMM394di5x