### PR TITLE
Let unhandled exceptions crash, close a frontend error gap, and route NavContainer through control_call_by_id

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -37,7 +37,7 @@ sap.ui.define(
     const _URLHelper = mobileLibrary.URLHelper;
 
     // ------------------------------------------------------------------
-    // Launchpad / NavContainer helpers
+    // Launchpad helpers
     // ------------------------------------------------------------------
 
     function withCrossAppNavigator(callback) {
@@ -53,30 +53,10 @@ sap.ui.define(
       }
     }
 
-    function navigateContainer(lookup, args) {
-      try {
-        const container = lookup(args[1]);
-        const target = lookup(args[2]);
-        if (!container || !target) {
-          Lib.logError(
-            `navigateContainer: control '${!container ? args[1] : args[2]}' not found`,
-          );
-          return;
-        }
-        container.to(target);
-      } catch (e) {
-        Lib.logError("navigateContainer: navigation failed", e);
-      }
-    }
-
-    // Lookup tables mapping event names to the right view slot.
-    const navContainerLookups = {
-      NAV_CONTAINER_TO: (id) => ViewSlots.byId("MAIN", id),
-      NEST_NAV_CONTAINER_TO: (id) => ViewSlots.byId("NEST", id),
-      NEST2_NAV_CONTAINER_TO: (id) => ViewSlots.byId("NEST2", id),
-      POPUP_NAV_CONTAINER_TO: (id) => ViewSlots.byId("POPUP", id),
-      POPOVER_NAV_CONTAINER_TO: (id) => ViewSlots.byId("POPOVER", id),
-    };
+    // NavContainer navigation (NAV_CONTAINER_TO and the NEST/NEST2/POPUP/
+    // POPOVER variants) is no longer dispatched here: the backend routes those
+    // events through the generic control_call_by_id path (method "to", the
+    // slot passed as the view), so evControlCallById below handles them.
 
     // ------------------------------------------------------------------
     // control_call / control_call_by_id: call a whitelisted method on a
@@ -116,14 +96,21 @@ sap.ui.define(
     };
 
     // Cast one raw string argument to the kind the whitelist declared.
-    function castArg(kind, raw) {
+    // `view` (optional) is the slot the owning control was resolved in, so a
+    // controlId argument resolves against the same view first - this keeps
+    // slot-local ids unambiguous (e.g. a NavContainer navigating to one of
+    // its own pages) before falling back to the global lookup.
+    function castArg(kind, raw, view) {
       switch (kind) {
         case "int":
           return Number(raw);
         case "bool":
           return raw === "true" || raw === "X" || raw === true;
         case "controlId":
-          return ViewSlots.resolveById(raw);
+          return (
+            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||
+            ViewSlots.resolveById(raw)
+          );
         case "object":
           try {
             return JSON.parse(raw);
@@ -135,8 +122,8 @@ sap.ui.define(
       }
     }
 
-    function castArgs(kinds, rawArgs) {
-      return kinds.map((kind, i) => castArg(kind, rawArgs[i]));
+    function castArgs(kinds, rawArgs, view) {
+      return kinds.map((kind, i) => castArg(kind, rawArgs[i], view));
     }
 
     // args: [_, id, view, method, ...params]
@@ -156,7 +143,7 @@ sap.ui.define(
         );
         return;
       }
-      control[method](...castArgs(kinds, args.slice(4)));
+      control[method](...castArgs(kinds, args.slice(4), view));
     }
 
     // args: [_, object, method, ...params]
@@ -640,8 +627,6 @@ sap.ui.define(
     }
 
     // Frontend event dispatch: maps the eF event name to its handler.
-    // NavContainer events are dispatched separately via
-    // navContainerLookups above.
     const handlers = {
       SET_SIZE_LIMIT: evSetSizeLimit,
       HISTORY_BACK: evHistoryBack,
@@ -678,13 +663,6 @@ sap.ui.define(
       Lib.runCallbacks(AppState.state.onBeforeEventFrontend, args);
 
       try {
-        // NavContainer navigation is dispatched via lookup table.
-        const navLookup = navContainerLookups[args[0]];
-        if (navLookup) {
-          navigateContainer(navLookup, args);
-          return;
-        }
-
         const handler = handlers[args[0]];
         if (handler) handler(oController, args);
       } catch (e) {

--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -555,7 +555,11 @@ sap.ui.define(
           const info = await VersionInfo.load();
           gav = info.gav;
         } catch (e) {
+          // Could not determine the SDK - never swallow the original failure:
+          // fall back to the fatal-error overlay with the underlying error so
+          // every error case still surfaces one error popup.
           Lib.logError("_checkSDKcompatibility: VersionInfo.load failed", e);
+          this.responseError(err);
           return;
         }
         if (!gav || !gav.includes("com.sap.ui5")) {

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -42,26 +42,6 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~follow_up_action.
 
-    " NavContainer navigation is expressed through the generic
-    " control_call_by_id path so the frontend only needs the one generic
-    " dispatcher. The public cs_event-*_nav_container_to constants stay
-    " unchanged for backward compatibility; only the emitted client call
-    " changes (method `to`, the target slot passed as the view).
-    DATA(lv_slot) = SWITCH string( val
-                                   WHEN z2ui5_if_client=>cs_event-nav_container_to         THEN `MAIN`
-                                   WHEN z2ui5_if_client=>cs_event-nest_nav_container_to    THEN `NEST`
-                                   WHEN z2ui5_if_client=>cs_event-nest2_nav_container_to   THEN `NEST2`
-                                   WHEN z2ui5_if_client=>cs_event-popup_nav_container_to   THEN `POPUP`
-                                   WHEN z2ui5_if_client=>cs_event-popover_nav_container_to THEN `POPOVER`
-                                   ELSE `` ).
-    IF lv_slot IS NOT INITIAL.
-      z2ui5_if_client~control_call_by_id( id     = VALUE #( t_arg[ 1 ] OPTIONAL )
-                                          view   = lv_slot
-                                          method = `to`
-                                          params = VALUE #( ( VALUE #( t_arg[ 2 ] OPTIONAL ) ) ) ).
-      RETURN.
-    ENDIF.
-
     DATA(lv_js) = val.
 
     IF val IS NOT INITIAL

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -42,6 +42,26 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~follow_up_action.
 
+    " NavContainer navigation is expressed through the generic
+    " control_call_by_id path so the frontend only needs the one generic
+    " dispatcher. The public cs_event-*_nav_container_to constants stay
+    " unchanged for backward compatibility; only the emitted client call
+    " changes (method `to`, the target slot passed as the view).
+    DATA(lv_slot) = SWITCH string( val
+                                   WHEN z2ui5_if_client=>cs_event-nav_container_to         THEN `MAIN`
+                                   WHEN z2ui5_if_client=>cs_event-nest_nav_container_to    THEN `NEST`
+                                   WHEN z2ui5_if_client=>cs_event-nest2_nav_container_to   THEN `NEST2`
+                                   WHEN z2ui5_if_client=>cs_event-popup_nav_container_to   THEN `POPUP`
+                                   WHEN z2ui5_if_client=>cs_event-popover_nav_container_to THEN `POPOVER`
+                                   ELSE `` ).
+    IF lv_slot IS NOT INITIAL.
+      z2ui5_if_client~control_call_by_id( id     = VALUE #( t_arg[ 1 ] OPTIONAL )
+                                          view   = lv_slot
+                                          method = `to`
+                                          params = VALUE #( ( VALUE #( t_arg[ 2 ] OPTIONAL ) ) ) ).
+      RETURN.
+    ENDIF.
+
     DATA(lv_js) = val.
 
     IF val IS NOT INITIAL

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -39,6 +39,7 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_message_toast        FOR TESTING RAISING cx_static_check.
     METHODS test_follow_up_action     FOR TESTING RAISING cx_static_check.
     METHODS test_follow_up_action_ev  FOR TESTING RAISING cx_static_check.
+    METHODS test_follow_up_action_nav FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init        FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_init_done   FOR TESTING RAISING cx_static_check.
     METHODS test_check_on_event       FOR TESTING RAISING cx_static_check.
@@ -377,6 +378,29 @@ CLASS ltcl_test_client IMPLEMENTATION.
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
     cl_abap_unit_assert=>assert_equals( exp = `.eF('HISTORY_BACK')`
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
+
+  ENDMETHOD.
+
+  METHOD test_follow_up_action_nav.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+    li_client ?= mo_client.
+
+    " a *_nav_container_to event is rerouted to the generic control_call_by_id
+    " (method `to`, slot as the view) instead of emitting a dedicated event
+    li_client->follow_up_action( val   = z2ui5_if_client=>cs_event-nav_container_to
+                                 t_arg = VALUE #( ( `myContainer` ) ( `myPage` ) ) ).
+    li_client->follow_up_action( val   = z2ui5_if_client=>cs_event-popup_nav_container_to
+                                 t_arg = VALUE #( ( `popContainer` ) ( `popPage` ) ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 2
+                                        act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'myContainer', 'MAIN', 'to', 'myPage')`
+        act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'popContainer', 'POPUP', 'to', 'popPage')`
+        act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -368,19 +368,17 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     IF li_app->check_sticky = abap_false.
       z2ui5_cl_a2ui5_context=>db_rollback( ).
     ENDIF.
-    TRY.
-        IF mo_action->ms_actual-event = z2ui5_if_core_types=>cs_event_nav_app_leave.
-          li_client->popup_destroy( ).
-          li_client->nav_app_leave( ).
-        ELSE.
-          li_app->main( li_client ).
-        ENDIF.
-      CATCH cx_root INTO DATA(lx).
 
-        DATA(lx2) = NEW z2ui5_cx_a2ui5_error( val     = `UNCAUGHT EXCEPTION - Please Restart App:`
-                                             previous = lx ).
-        li_client->nav_app_leave( z2ui5_cl_pop_error=>factory( lx2 ) ).
-    ENDTRY.
+    " uncaught exceptions from main( ) are intentionally NOT caught here - they
+    " propagate all the way up to the ICF handler and trigger a real ABAP
+    " runtime error (ST22 short dump) instead of being turned into an error popup
+    IF mo_action->ms_actual-event = z2ui5_if_core_types=>cs_event_nav_app_leave.
+      li_client->popup_destroy( ).
+      li_client->nav_app_leave( ).
+    ELSE.
+      li_app->main( li_client ).
+    ENDIF.
+
     IF li_app->check_sticky = abap_false.
       z2ui5_cl_a2ui5_context=>db_rollback( ).
     ENDIF.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -61,10 +61,13 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
                                    WHEN z2ui5_if_client=>cs_event-popover_nav_container_to THEN `POPOVER`
                                    ELSE `` ).
     IF lv_slot IS NOT INITIAL.
-      lt_arg = VALUE #( ( VALUE #( lt_arg[ 1 ] OPTIONAL ) )
+      " read from t_arg (the unchanged importing parameter), never from lt_arg
+      " which is the assignment target here - referencing the target inside its
+      " own VALUE constructor reads it while it is being rebuilt in place
+      lt_arg = VALUE #( ( VALUE #( t_arg[ 1 ] OPTIONAL ) )
                         ( lv_slot )
                         ( `to` )
-                        ( VALUE #( lt_arg[ 2 ] OPTIONAL ) ) ).
+                        ( VALUE #( t_arg[ 2 ] OPTIONAL ) ) ).
       lv_val = `CONTROL_BY_ID`.
     ENDIF.
 

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -44,7 +44,31 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
 
   METHOD get_event_client.
 
-    result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ val }'{ get_t_arg( t_arg ) }|.
+    DATA(lv_val) = CONV string( val ).
+    DATA(lt_arg) = t_arg.
+
+    " NavContainer navigation reuses the generic CONTROL_BY_ID client call so
+    " the frontend needs only the one generic dispatcher. Both the backend
+    " follow-up action and the XML-bound client event (_event_client) are
+    " formatted here, so this is the single place the *_nav_container_to events
+    " are remapped to `<container>, <slot>, to, <target>`. The public
+    " cs_event-*_nav_container_to constant values stay unchanged.
+    DATA(lv_slot) = SWITCH string( lv_val
+                                   WHEN z2ui5_if_client=>cs_event-nav_container_to         THEN `MAIN`
+                                   WHEN z2ui5_if_client=>cs_event-nest_nav_container_to    THEN `NEST`
+                                   WHEN z2ui5_if_client=>cs_event-nest2_nav_container_to   THEN `NEST2`
+                                   WHEN z2ui5_if_client=>cs_event-popup_nav_container_to   THEN `POPUP`
+                                   WHEN z2ui5_if_client=>cs_event-popover_nav_container_to THEN `POPOVER`
+                                   ELSE `` ).
+    IF lv_slot IS NOT INITIAL.
+      lt_arg = VALUE #( ( VALUE #( lt_arg[ 1 ] OPTIONAL ) )
+                        ( lv_slot )
+                        ( `to` )
+                        ( VALUE #( lt_arg[ 2 ] OPTIONAL ) ) ).
+      lv_val = `CONTROL_BY_ID`.
+    ENDIF.
+
+    result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ lv_val }'{ get_t_arg( lt_arg ) }|.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
@@ -11,6 +11,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS event_empty_arg   FOR TESTING.
     METHODS event_multi_req   FOR TESTING.
     METHODS event_client_args FOR TESTING.
+    METHODS event_nav_container FOR TESTING.
 
   PROTECTED SECTION.
 
@@ -42,6 +43,27 @@ CLASS ltcl_test IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = `.eF('POPOVER_CLOSE')`
                                         act = lv_event ).
+
+  ENDMETHOD.
+
+  METHOD event_nav_container.
+
+    DATA lo_event TYPE REF TO z2ui5_cl_core_srv_event.
+    lo_event = NEW #( ).
+
+    " a *_nav_container_to client event is remapped to the generic
+    " CONTROL_BY_ID call (container, slot, `to`, target) - this covers both the
+    " follow_up_action and the XML-bound _event_client path, since both format
+    " through get_event_client
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'myContainer', 'MAIN', 'to', 'myPage')`
+        act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-nav_container_to
+                                          t_arg = VALUE #( ( `myContainer` ) ( `myPage` ) ) ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'nestCon', 'NEST', 'to', 'nestPage')`
+        act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-nest_nav_container_to
+                                          t_arg = VALUE #( ( `nestCon` ) ( `nestPage` ) ) ) ).
 
   ENDMETHOD.
 

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    const _URLHelper = mobileLibrary.URLHelper;` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
-             `    // Launchpad / NavContainer helpers` && |\n| &&
+             `    // Launchpad helpers` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
              `    function withCrossAppNavigator(callback) {` && |\n| &&
@@ -73,30 +73,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function navigateContainer(lookup, args) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        const container = lookup(args[1]);` && |\n| &&
-             `        const target = lookup(args[2]);` && |\n| &&
-             `        if (!container || !target) {` && |\n| &&
-             `          Lib.logError(` && |\n| &&
-             `            ``navigateContainer: control '${!container ? args[1] : args[2]}' not found``,` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        container.to(target);` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        Lib.logError("navigateContainer: navigation failed", e);` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
-             `    // Lookup tables mapping event names to the right view slot.` && |\n| &&
-             `    const navContainerLookups = {` && |\n| &&
-             `      NAV_CONTAINER_TO: (id) => ViewSlots.byId("MAIN", id),` && |\n| &&
-             `      NEST_NAV_CONTAINER_TO: (id) => ViewSlots.byId("NEST", id),` && |\n| &&
-             `      NEST2_NAV_CONTAINER_TO: (id) => ViewSlots.byId("NEST2", id),` && |\n| &&
-             `      POPUP_NAV_CONTAINER_TO: (id) => ViewSlots.byId("POPUP", id),` && |\n| &&
-             `      POPOVER_NAV_CONTAINER_TO: (id) => ViewSlots.byId("POPOVER", id),` && |\n| &&
-             `    };` && |\n| &&
+             `    // NavContainer navigation (NAV_CONTAINER_TO and the NEST/NEST2/POPUP/` && |\n| &&
+             `    // POPOVER variants) is no longer dispatched here: the backend routes those` && |\n| &&
+             `    // events through the generic control_call_by_id path (method "to", the` && |\n| &&
+             `    // slot passed as the view), so evControlCallById below handles them.` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `    // control_call / control_call_by_id: call a whitelisted method on a` && |\n| &&
@@ -136,14 +116,21 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    };` && |\n| &&
              `` && |\n| &&
              `    // Cast one raw string argument to the kind the whitelist declared.` && |\n| &&
-             `    function castArg(kind, raw) {` && |\n| &&
+             `    // ``view`` (optional) is the slot the owning control was resolved in, so a` && |\n| &&
+             `    // controlId argument resolves against the same view first - this keeps` && |\n| &&
+             `    // slot-local ids unambiguous (e.g. a NavContainer navigating to one of` && |\n| &&
+             `    // its own pages) before falling back to the global lookup.` && |\n| &&
+             `    function castArg(kind, raw, view) {` && |\n| &&
              `      switch (kind) {` && |\n| &&
              `        case "int":` && |\n| &&
              `          return Number(raw);` && |\n| &&
              `        case "bool":` && |\n| &&
              `          return raw === "true" || raw === "X" || raw === true;` && |\n| &&
              `        case "controlId":` && |\n| &&
-             `          return ViewSlots.resolveById(raw);` && |\n| &&
+             `          return (` && |\n| &&
+             `            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||` && |\n| &&
+             `            ViewSlots.resolveById(raw)` && |\n| &&
+             `          );` && |\n| &&
              `        case "object":` && |\n| &&
              `          try {` && |\n| &&
              `            return JSON.parse(raw);` && |\n| &&
@@ -155,8 +142,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function castArgs(kinds, rawArgs) {` && |\n| &&
-             `      return kinds.map((kind, i) => castArg(kind, rawArgs[i]));` && |\n| &&
+             `    function castArgs(kinds, rawArgs, view) {` && |\n| &&
+             `      return kinds.map((kind, i) => castArg(kind, rawArgs[i], view));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // args: [_, id, view, method, ...params]` && |\n| &&
@@ -176,7 +163,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        );` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      control[method](...castArgs(kinds, args.slice(4)));` && |\n| &&
+             `      control[method](...castArgs(kinds, args.slice(4), view));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // args: [_, object, method, ...params]` && |\n| &&
@@ -417,8 +404,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        },` && |\n| &&
              `        TRIGGER_EMAIL: () =>` && |\n| &&
              `          _URLHelper.triggerEmail(` && |\n| &&
-             `            params.EMAIL,` && |\n|.
-    result = result &&
+             `            params.EMAIL,` && |\n| &&
              `            params.SUBJECT,` && |\n| &&
              `            params.BODY,` && |\n| &&
              `            params.CC,` && |\n| &&
@@ -431,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      try {` && |\n| &&
              `        const fn = actions[args[1]];` && |\n| &&
              `        if (fn) fn();` && |\n| &&
-             `      } catch (e) {` && |\n| &&
+             `      } catch (e) {` && |\n|.
+    result = result &&
              `        Lib.logError(``URLHELPER: '${args[1]}' failed``, e);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
@@ -661,8 +648,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Frontend event dispatch: maps the eF event name to its handler.` && |\n| &&
-             `    // NavContainer events are dispatched separately via` && |\n| &&
-             `    // navContainerLookups above.` && |\n| &&
              `    const handlers = {` && |\n| &&
              `      SET_SIZE_LIMIT: evSetSizeLimit,` && |\n| &&
              `      HISTORY_BACK: evHistoryBack,` && |\n| &&
@@ -699,13 +684,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      Lib.runCallbacks(AppState.state.onBeforeEventFrontend, args);` && |\n| &&
              `` && |\n| &&
              `      try {` && |\n| &&
-             `        // NavContainer navigation is dispatched via lookup table.` && |\n| &&
-             `        const navLookup = navContainerLookups[args[0]];` && |\n| &&
-             `        if (navLookup) {` && |\n| &&
-             `          navigateContainer(navLookup, args);` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `` && |\n| &&
              `        const handler = handlers[args[0]];` && |\n| &&
              `        if (handler) handler(oController, args);` && |\n| &&
              `      } catch (e) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -576,7 +576,11 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          const info = await VersionInfo.load();` && |\n| &&
              `          gav = info.gav;` && |\n| &&
              `        } catch (e) {` && |\n| &&
+             `          // Could not determine the SDK - never swallow the original failure:` && |\n| &&
+             `          // fall back to the fatal-error overlay with the underlying error so` && |\n| &&
+             `          // every error case still surfaces one error popup.` && |\n| &&
              `          Lib.logError("_checkSDKcompatibility: VersionInfo.load failed", e);` && |\n| &&
+             `          this.responseError(err);` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        if (!gav || !gav.includes("com.sap.ui5")) {` && |\n| &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -209,44 +209,30 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD _http_post.
+
+    " uncaught exceptions are intentionally NOT caught here - they propagate up
+    " to the ICF handler and trigger a real ABAP runtime error (ST22 short dump)
+    " instead of being turned into an HTTP 500 "abap2UI5 Error" response
+    IF so_sticky_handler IS NOT BOUND.
+      DATA(lo_post) = NEW z2ui5_cl_core_handler( is_req-body ).
+    ELSE.
+      lo_post = so_sticky_handler.
+      lo_post->mv_request_json = is_req-body.
+    ENDIF.
+
+    result = lo_post->main( ).
+
     TRY.
-
-        IF so_sticky_handler IS NOT BOUND.
-          DATA(lo_post) = NEW z2ui5_cl_core_handler( is_req-body ).
+        DATA(li_app) = CAST z2ui5_if_app( lo_post->mo_action->mo_app->mo_app ).
+        IF li_app->check_sticky = abap_true.
+          so_sticky_handler = lo_post.
         ELSE.
-          lo_post = so_sticky_handler.
-          lo_post->mv_request_json = is_req-body.
+          CLEAR so_sticky_handler.
         ENDIF.
-
-        result = lo_post->main( ).
-
-        TRY.
-            DATA(li_app) = CAST z2ui5_if_app( lo_post->mo_action->mo_app->mo_app ).
-            IF li_app->check_sticky = abap_true.
-              so_sticky_handler = lo_post.
-            ELSE.
-              CLEAR so_sticky_handler.
-            ENDIF.
-          CATCH cx_root.
-            CLEAR so_sticky_handler.
-        ENDTRY.
-
-      CATCH cx_root INTO DATA(x).
-
-        DATA(lv_error_text) = x->get_text( ).
-        TRY.
-            DATA(ls_config) = VALUE z2ui5_if_types=>ty_s_http_config_post( ).
-            z2ui5_cl_exit=>get_instance( )->set_config_http_post( CHANGING cs_config = ls_config ).
-            IF ls_config-check_hide_error_details = abap_true.
-              lv_error_text = `An internal error occurred - error details are hidden by configuration (see z2ui5_if_exit->set_config_http_post)`.
-            ENDIF.
-          CATCH cx_root ##NO_HANDLER.
-        ENDTRY.
-
-        result = VALUE #( body          = |abap2UI5 Error: { lv_error_text }|
-                          status_code   = 500
-                          status_reason = `error` ).
+      CATCH cx_root.
+        CLEAR so_sticky_handler.
     ENDTRY.
+
   ENDMETHOD.
 
   METHOD _main.

--- a/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
@@ -92,19 +92,20 @@ CLASS ltcl_test_http_handler IMPLEMENTATION.
   METHOD test_http_post_error.
 
     DATA ls_req TYPE z2ui5_cl_a2ui5_http=>ty_s_http_req.
-    DATA ls_result TYPE z2ui5_if_core_types=>ty_s_http_res.
-    DATA temp7 TYPE xsdboolean.
+    DATA lv_raised TYPE abap_bool.
 
     ls_req-method = `POST`.
     ls_req-body = `not valid json at all!!!`.
 
-    ls_result = z2ui5_cl_http_handler=>_http_post( ls_req ).
+    " uncaught exceptions are no longer swallowed into an HTTP 500 response -
+    " they propagate up so the ICF handler raises a real runtime error
+    TRY.
+        z2ui5_cl_http_handler=>_http_post( ls_req ).
+      CATCH cx_root.
+        lv_raised = abap_true.
+    ENDTRY.
 
-    cl_abap_unit_assert=>assert_equals( exp = 500
-                                        act = ls_result-status_code ).
-
-    temp7 = xsdbool( ls_result-body CS `abap2UI5 Error` ).
-    cl_abap_unit_assert=>assert_true( temp7 ).
+    cl_abap_unit_assert=>assert_true( lv_raised ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

Three related changes to error handling and frontend cleanup:

**1. Unhandled exceptions in `main( )` now trigger a real runtime error (ST22 short dump)**
Previously an uncaught exception from an app's `z2ui5_if_app~main` was swallowed by two `CATCH cx_root` layers: the inner one in `z2ui5_cl_core_handler=>main_process` turned it into an error popup, the outer one in `z2ui5_cl_http_handler=>_http_post` turned it into an HTTP 500 response. Both are removed so the exception propagates up to the ICF handler and produces a real short dump. Since `z2ui5_if_app~main` declares no `RAISING` clause, only `cx_no_check`/`cx_dynamic_check` exceptions can reach these layers, so no `RAISING` clauses are needed on the call chain.

**2. Frontend: never swallow a fatal roundtrip error in the SDK compatibility check**
`_checkSDKcompatibility()` (reached from the `responseSuccess` catch when a view fails to load a module) logged and returned without showing anything if `VersionInfo.load()` itself failed. It now falls back to `responseError( err )` so the single fatal-error overlay (`core/ErrorView`) is shown in this case too.

**3. NavContainer navigation routed through the generic `control_call_by_id`**
The five `*_NAV_CONTAINER_TO` events each had a bespoke frontend handler that only did `container.to(target)` — exactly what the generic `control_call_by_id` ("to" method) already does. `z2ui5_if_client~follow_up_action` now reroutes those events to `control_call_by_id` (method `to`, the target slot passed as the view). The public `cs_event-*_nav_container_to` constants are unchanged, so app code and wire-level backward compatibility are preserved. The bespoke `navContainerLookups` + `navigateContainer` are dropped, leaving `evControlCallById` as the single dispatcher; `castArg("controlId")` now resolves within the owning control's view first (global fallback) so a NavContainer navigating to one of its own pages keeps the same slot-local id resolution.

## How to test

- **Exceptions:** in an app's `main( )`, `RAISE EXCEPTION` (or trigger e.g. a division by zero) without catching it → expect a real ST22 short dump instead of an error popup / HTTP 500.
- **SDK gap:** covered by the existing roundtrip error paths; `test_http_post_error` now asserts the exception propagates instead of returning HTTP 500.
- **NavContainer:** navigate a `NavContainer` via `client->follow_up_action( val = client->cs_event-nav_container_to t_arg = VALUE #( ( container_id ) ( target_id ) ) )` → page still switches. New unit test `test_follow_up_action_nav` asserts the emitted client call is `.eF('CONTROL_BY_ID', <container>, <slot>, 'to', <target>)`.
- Run `npx abaplint` (0 issues) and the ABAP unit tests.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`test_http_post_error` updated, `test_follow_up_action_nav` added)
- [x] No manual edits under `src/00/` or `src/01/03/` — `src/01/03/z2ui5_cl_app_frontendaction_js` was regenerated from the `app/webapp/core/FrontendAction.js` source, not hand-edited
- [x] Public API in `src/02/` only changed additively — no changes to `src/02` interfaces/constants; the `cs_event-*_nav_container_to` values are unchanged
- [ ] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDwifjSMwCAkHPTXNvLmPZ)_