### PR TITLE
docs: add PR title guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,16 @@ refactor: extract methods in core handler
 test: add unit tests for utility class
 ```
 
+### Pull request titles
+
+- **The PR title becomes the squash-merge commit subject — make it describe
+  the change.** Before merging, replace any auto-generated title (e.g. a
+  branch name like `Claude/...-abc123`) with a short descriptive title that
+  states what actually changed.
+- **One topic per PR.** A structural change (moving classes between packages,
+  renaming, restructuring) must not ride along in a PR titled for an
+  unrelated fix — split it into its own PR so the history stays searchable.
+
 ## Important Rules for AI Assistants
 
 These rules apply to AI assistants **modifying the framework** (this repo). For AI assistants **building apps**, see <https://abap2ui5.github.io/docs/advanced/agent.html> instead.


### PR DESCRIPTION
# Description

Added documentation guidelines for pull request titles in AGENTS.md. This clarifies that PR titles should be descriptive of the actual changes (since they become squash-merge commit subjects) and emphasizes keeping one topic per PR to maintain searchable history.

## How to test

N/A - Documentation only change

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (N/A)
- [x] No manual edits under `src/00/` or `src/01/03/` (N/A)
- [x] Public API in `src/02/` only changed additively (N/A)
- [x] Changes were made via abapGit: no

https://claude.ai/code/session_01F6ZLY4zwg3tr9P7z4tiR9d