### PR TITLE
Fix stale iframe content in Developer Tools Source Code tab

### DIFF
--- a/app/webapp/core/DeveloperTools.fragment.xml
+++ b/app/webapp/core/DeveloperTools.fragment.xml
@@ -102,7 +102,11 @@
             />
         </VBox>
         <VBox visible="{/source_visible}">
-            <core:HTML id="sourceHtml"/>
+            <!-- preferDOM defaults to true, which restores the preserved
+                 iframe DOM of a previous open instead of the freshly set
+                 content - the Source Code tab then kept showing the class
+                 of the previously running app. -->
+            <core:HTML id="sourceHtml" preferDOM="false"/>
         </VBox>
         <!-- sap.m.Dialog only gained a public `footer` aggregation around
              1.110; on older releases (e.g. 1.71) a <footer> tag is resolved

--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -527,9 +527,12 @@ sap.ui.define(
         const appName = sFront?.APP || "";
         const appId = encodeURIComponent(appName);
         const url = `${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main`;
-        contentControl.setProperty(
-          "content",
-          `<iframe id="test" src="${url}" style="width:100%;height:85vh;border:none;" />`,
+        // setContent (not a bare setProperty) so an already rendered iframe
+        // is replaced in the live DOM; a plain property set never reached
+        // the DOM once the control had rendered, leaving a stale class
+        // on screen after navigating to another app.
+        contentControl.setContent(
+          `<iframe src="${url}" style="width:100%;height:85vh;border:none;" />`,
         );
 
         if (!oModel) return;

--- a/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
@@ -122,7 +122,11 @@ CLASS z2ui5_cl_app_developertool_xml IMPLEMENTATION.
              `            />` &&
              `        </VBox>` &&
              `        <VBox visible="{/source_visible}">` &&
-             `            <core:HTML id="sourceHtml"/>` &&
+             `            <!-- preferDOM defaults to true, which restores the preserved` &&
+             `                 iframe DOM of a previous open instead of the freshly set` &&
+             `                 content - the Source Code tab then kept showing the class` &&
+             `                 of the previously running app. -->` &&
+             `            <core:HTML id="sourceHtml" preferDOM="false"/>` &&
              `        </VBox>` &&
              `        <!-- sap.m.Dialog only gained a public ``footer`` aggregation around` &&
              `             1.110; on older releases (e.g. 1.71) a <footer> tag is resolved` &&

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -548,9 +548,12 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `        const appName = sFront?.APP || "";` && |\n| &&
              `        const appId = encodeURIComponent(appName);` && |\n| &&
              `        const url = ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n| &&
-             `        contentControl.setProperty(` && |\n| &&
-             `          "content",` && |\n| &&
-             `          ``<iframe id="test" src="${url}" style="width:100%;height:85vh;border:none;" />``,` && |\n| &&
+             `        // setContent (not a bare setProperty) so an already rendered iframe` && |\n| &&
+             `        // is replaced in the live DOM; a plain property set never reached` && |\n| &&
+             `        // the DOM once the control had rendered, leaving a stale class` && |\n| &&
+             `        // on screen after navigating to another app.` && |\n| &&
+             `        contentControl.setContent(` && |\n| &&
+             `          ``<iframe src="${url}" style="width:100%;height:85vh;border:none;" />``,` && |\n| &&
              `        );` && |\n| &&
              `` && |\n| &&
              `        if (!oModel) return;` && |\n| &&


### PR DESCRIPTION
# Description

Fixes an issue where the Source Code tab in Developer Tools would display stale class content from a previously viewed app after navigating to a different app.

## Root Causes

1. **Incorrect API usage**: The code was using `setProperty("content", ...)` instead of `setContent(...)`. The `setProperty` method doesn't update the live DOM once the control has already rendered, leaving stale content on screen.

2. **DOM preservation**: The `core:HTML` control had `preferDOM` defaulting to `true`, which restores preserved iframe DOM from previous opens instead of using freshly set content.

## Changes

- **DeveloperTools.js**: Changed `contentControl.setProperty("content", ...)` to `contentControl.setContent(...)` to properly update the rendered iframe in the live DOM
- **DeveloperTools.fragment.xml**: Added `preferDOM="false"` to the `core:HTML` control to ensure fresh content is rendered instead of restoring stale DOM
- **Removed debug attribute**: Removed the `id="test"` attribute from the iframe as it was unnecessary
- **Added explanatory comments**: Documented why these specific API choices are necessary

## How to test

1. Open Developer Tools and navigate to the Source Code tab
2. View a class from one app
3. Navigate to a different app
4. Open the Source Code tab again
5. Verify that the correct class from the new app is displayed (not the previous app's class)

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md) - changes are auto-generated from source files
- [x] Public API in `src/02/` only changed additively - no public API changes
- [x] Changes were made via abapGit: no - source files modified, ABAP files auto-generated

https://claude.ai/code/session_01Etg3uantjUDnnNL8xjsic7