### PR TITLE
FrontendAction: optional args for to/open, whitelist goToStep, openBy (domRef kind) and setActivePage

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -85,6 +85,8 @@ sap.ui.define(
       discardProgress: ["controlId"],
       setNextStep: ["controlId"],
       goToStep: ["controlId", "bool"], // Wizard: target step + focus flag
+      openBy: ["domRef"], // DatePicker/TimePicker/Menu... anchored open
+      setActivePage: ["controlId"], // sap.m.Carousel
     };
 
     // global object -> lazy getter + its allowed methods (with arg kinds).
@@ -130,6 +132,15 @@ sap.ui.define(
             (view && ViewSlots.byId(view.toUpperCase(), raw)) ||
             ViewSlots.resolveById(raw)
           );
+        case "domRef": {
+          // anchor argument for openBy-style methods: resolve the control id
+          // and hand over its DOM element (fallback: the control itself -
+          // every sap.m openBy accepts a control OR a DOM element)
+          const control =
+            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||
+            ViewSlots.resolveById(raw);
+          return control?.getDomRef?.() ?? control;
+        }
         case "object":
           try {
             return JSON.parse(raw);

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -70,18 +70,21 @@ sap.ui.define(
     // anything"). Scope: imperative methods that have no binding equivalent.
     // ------------------------------------------------------------------
 
-    // control method -> kinds of its positional args.
+    // control method -> kinds of its positional args. Args beyond the
+    // declared kinds are dropped; trailing args the caller did not send are
+    // not passed at all (so `open()` stays a true no-arg call).
     const CONTROL_METHODS = {
-      to: ["controlId"],
+      to: ["controlId", "string"], // target page + optional transitionName
       back: [],
       focus: [],
       scrollToIndex: ["int"],
       scrollTo: ["int", "int"],
-      open: [],
+      open: ["string"], // optional page key (ViewSettingsDialog); PDFViewer/Dialog ignore it
       close: [],
       setExpanded: ["bool"],
       discardProgress: ["controlId"],
       setNextStep: ["controlId"],
+      goToStep: ["controlId", "bool"], // Wizard: target step + focus flag
     };
 
     // global object -> lazy getter + its allowed methods (with arg kinds).
@@ -139,7 +142,11 @@ sap.ui.define(
     }
 
     function castArgs(kinds, rawArgs, view) {
-      return kinds.map((kind, i) => castArg(kind, rawArgs[i], view));
+      // only cast args the caller actually sent - padding missing trailing
+      // args would turn open() into open(undefined) and ints into NaN
+      return kinds
+        .slice(0, rawArgs.length)
+        .map((kind, i) => castArg(kind, rawArgs[i], view));
     }
 
     // args: [_, id, view, method, ...params]

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -114,15 +114,47 @@ test.describe("CONTROL_BY_ID", () => {
     expect(errors).toHaveLength(1);
   });
 
-  test("open/close take no args (popup-mode PDFViewer, Dialog)", () => {
+  test("open/close without args stay true no-arg calls (popup-mode PDFViewer, Dialog)", () => {
     const { FrontendAction, calls, controls } = load();
     controls.pdfViewer = {
-      open: () => calls.push(["open"]),
-      close: () => calls.push(["close"]),
+      open: (...a) => calls.push(["open", a.length]),
+      close: (...a) => calls.push(["close", a.length]),
     };
     FrontendAction.execute(null, ["CONTROL_BY_ID", "pdfViewer", "", "open"]);
     FrontendAction.execute(null, ["CONTROL_BY_ID", "pdfViewer", "", "close"]);
-    expect(calls).toEqual([["open"], ["close"]]);
+    expect(calls).toEqual([
+      ["open", 0],
+      ["close", 0],
+    ]);
+  });
+
+  test("open passes the optional page key through (ViewSettingsDialog)", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.vsd = { open: (page) => calls.push(["open", page]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "vsd", "", "open", "filter"]);
+    expect(calls).toEqual([["open", "filter"]]);
+  });
+
+  test("to passes the optional transitionName (NavContainer animation)", () => {
+    const { FrontendAction, calls, controls } = load();
+    const page2 = { id: "page2" };
+    controls.page2 = page2;
+    controls.NavCon = { to: (...a) => calls.push(["to", ...a]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "NavCon", "", "to", "page2", "fade"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "NavCon", "", "to", "page2"]);
+    expect(calls).toEqual([
+      ["to", page2, "fade"],
+      ["to", page2],
+    ]);
+  });
+
+  test("goToStep resolves the step and casts the focus flag (Wizard)", () => {
+    const { FrontendAction, calls, controls } = load();
+    const step2 = { id: "STEP2" };
+    controls.STEP2 = step2;
+    controls.wiz = { goToStep: (s, b) => calls.push(["goToStep", s, b]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "wiz", "", "goToStep", "STEP2", "X"]);
+    expect(calls).toEqual([["goToStep", step2, true]]);
   });
 
   test("discardProgress/setNextStep resolve their controlId arg (wizard)", () => {

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -157,6 +157,33 @@ test.describe("CONTROL_BY_ID", () => {
     expect(calls).toEqual([["goToStep", step2, true]]);
   });
 
+  test("openBy resolves the anchor to its DOM ref (hidden DatePicker)", () => {
+    const { FrontendAction, calls, controls } = load();
+    const dom = { tagName: "BUTTON" };
+    controls.anchorBtn = { getDomRef: () => dom };
+    controls.HiddenDP = { openBy: (ref) => calls.push(["openBy", ref]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "HiddenDP", "", "openBy", "anchorBtn"]);
+    expect(calls).toEqual([["openBy", dom]]);
+  });
+
+  test("openBy falls back to the control when no DOM ref is rendered", () => {
+    const { FrontendAction, calls, controls } = load();
+    const anchor = { getDomRef: () => null };
+    controls.anchorBtn = anchor;
+    controls.HiddenDP = { openBy: (ref) => calls.push(["openBy", ref]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "HiddenDP", "", "openBy", "anchorBtn"]);
+    expect(calls).toEqual([["openBy", anchor]]);
+  });
+
+  test("setActivePage resolves the page control (Carousel)", () => {
+    const { FrontendAction, calls, controls } = load();
+    const page2 = { id: "carPage2" };
+    controls.carPage2 = page2;
+    controls.carousel = { setActivePage: (p) => calls.push(["setActivePage", p]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "carousel", "", "setActivePage", "carPage2"]);
+    expect(calls).toEqual([["setActivePage", page2]]);
+  });
+
   test("discardProgress/setNextStep resolve their controlId arg (wizard)", () => {
     const { FrontendAction, calls, controls } = load();
     const step2 = { id: "STEP2" };

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -90,18 +90,21 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // anything"). Scope: imperative methods that have no binding equivalent.` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
-             `    // control method -> kinds of its positional args.` && |\n| &&
+             `    // control method -> kinds of its positional args. Args beyond the` && |\n| &&
+             `    // declared kinds are dropped; trailing args the caller did not send are` && |\n| &&
+             `    // not passed at all (so ``open()`` stays a true no-arg call).` && |\n| &&
              `    const CONTROL_METHODS = {` && |\n| &&
-             `      to: ["controlId"],` && |\n| &&
+             `      to: ["controlId", "string"], // target page + optional transitionName` && |\n| &&
              `      back: [],` && |\n| &&
              `      focus: [],` && |\n| &&
              `      scrollToIndex: ["int"],` && |\n| &&
              `      scrollTo: ["int", "int"],` && |\n| &&
-             `      open: [],` && |\n| &&
+             `      open: ["string"], // optional page key (ViewSettingsDialog); PDFViewer/Dialog ignore it` && |\n| &&
              `      close: [],` && |\n| &&
              `      setExpanded: ["bool"],` && |\n| &&
              `      discardProgress: ["controlId"],` && |\n| &&
              `      setNextStep: ["controlId"],` && |\n| &&
+             `      goToStep: ["controlId", "bool"], // Wizard: target step + focus flag` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
              `    // global object -> lazy getter + its allowed methods (with arg kinds).` && |\n| &&
@@ -159,7 +162,11 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    function castArgs(kinds, rawArgs, view) {` && |\n| &&
-             `      return kinds.map((kind, i) => castArg(kind, rawArgs[i], view));` && |\n| &&
+             `      // only cast args the caller actually sent - padding missing trailing` && |\n| &&
+             `      // args would turn open() into open(undefined) and ints into NaN` && |\n| &&
+             `      return kinds` && |\n| &&
+             `        .slice(0, rawArgs.length)` && |\n| &&
+             `        .map((kind, i) => castArg(kind, rawArgs[i], view));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // args: [_, id, view, method, ...params]` && |\n| &&
@@ -410,15 +417,15 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      });` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function evLocationReload(oController, args) {` && |\n| &&
+             `    function evLocationReload(oController, args) {` && |\n|.
+    result = result &&
              `      if (Lib.isValidRedirectURL(args[1])) {` && |\n| &&
              `        window.location.href = args[1];` && |\n| &&
              `      } else {` && |\n| &&
              `        MessageBox.error(` && |\n| &&
              `          "Invalid redirect URL. Only relative URLs to the same domain are allowed.",` && |\n| &&
              `        );` && |\n| &&
-             `      }` && |\n|.
-    result = result &&
+             `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // SYSTEM_LOGOUT: prefer the launchpad logout when running inside the` && |\n| &&
@@ -811,15 +818,15 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const handler = handlers[args[0]];` && |\n| &&
              `        if (handler) handler(oController, args);` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        // Backstop: individual handlers already guard themselves, but a` && |\n| &&
+             `        // Backstop: individual handlers already guard themselves, but a` && |\n|.
+    result = result &&
              `        // malformed payload must never let an error escape into the caller.` && |\n| &&
              `        Lib.logError(``FrontendAction: handler '${args[0]}' failed``, e);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    return { execute };` && |\n| &&
-             `  },` && |\n|.
-    result = result &&
+             `  },` && |\n| &&
              `);` && |\n| &&
              `` && |\n| &&
               ``.

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -105,6 +105,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      discardProgress: ["controlId"],` && |\n| &&
              `      setNextStep: ["controlId"],` && |\n| &&
              `      goToStep: ["controlId", "bool"], // Wizard: target step + focus flag` && |\n| &&
+             `      openBy: ["domRef"], // DatePicker/TimePicker/Menu... anchored open` && |\n| &&
+             `      setActivePage: ["controlId"], // sap.m.Carousel` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
              `    // global object -> lazy getter + its allowed methods (with arg kinds).` && |\n| &&
@@ -150,6 +152,15 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||` && |\n| &&
              `            ViewSlots.resolveById(raw)` && |\n| &&
              `          );` && |\n| &&
+             `        case "domRef": {` && |\n| &&
+             `          // anchor argument for openBy-style methods: resolve the control id` && |\n| &&
+             `          // and hand over its DOM element (fallback: the control itself -` && |\n| &&
+             `          // every sap.m openBy accepts a control OR a DOM element)` && |\n| &&
+             `          const control =` && |\n| &&
+             `            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||` && |\n| &&
+             `            ViewSlots.resolveById(raw);` && |\n| &&
+             `          return control?.getDomRef?.() ?? control;` && |\n| &&
+             `        }` && |\n| &&
              `        case "object":` && |\n| &&
              `          try {` && |\n| &&
              `            return JSON.parse(raw);` && |\n| &&
@@ -406,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          // consistent with every other redirect handler in this file.` && |\n| &&
              `          const base = window.location.href.split("#")[0];` && |\n| &&
              `          const url = ``${base}${hash}``;` && |\n| &&
-             `          if (!Lib.isValidRedirectURL(url)) {` && |\n| &&
+             `          if (!Lib.isValidRedirectURL(url)) {` && |\n|.
+    result = result &&
              `            Lib.logError(``CrossAppNav EXT: unsafe redirect URL '${url}'``);` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
@@ -417,8 +429,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      });` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function evLocationReload(oController, args) {` && |\n|.
-    result = result &&
+             `    function evLocationReload(oController, args) {` && |\n| &&
              `      if (Lib.isValidRedirectURL(args[1])) {` && |\n| &&
              `        window.location.href = args[1];` && |\n| &&
              `      } else {` && |\n| &&
@@ -807,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      CONTROL_GLOBAL: evControlCall,` && |\n| &&
              `      BINDING_CALL: evBindingCall,` && |\n| &&
              `    };` && |\n| &&
-             `` && |\n| &&
+             `` && |\n|.
+    result = result &&
              `    // Entry point called by View1.controller's eF().` && |\n| &&
              `    function execute(oController, args) {` && |\n| &&
              `      // runCallbacks isolates each hook in its own try/catch, so a throwing` && |\n| &&
@@ -818,8 +830,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const handler = handlers[args[0]];` && |\n| &&
              `        if (handler) handler(oController, args);` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        // Backstop: individual handlers already guard themselves, but a` && |\n|.
-    result = result &&
+             `        // Backstop: individual handlers already guard themselves, but a` && |\n| &&
              `        // malformed payload must never let an error escape into the caller.` && |\n| &&
              `        Lib.logError(``FrontendAction: handler '${args[0]}' failed``, e);` && |\n| &&
              `      }` && |\n| &&


### PR DESCRIPTION
# Description

Two rounds of `CONTROL_METHODS` whitelist gaps surfaced by the ai-demokit porting work (hold-out probe #1 and batch b05 — see `pr/control-method-args` and `pr/control-methods-openby-setactivepage` write-ups there):

- `to: ["controlId", "string"]` — NavContainer transition name (slide/baseSlide/fade/show); without it the demo kit's animation Select is a functional no-op.
- `open: ["string"]` — ViewSettingsDialog page key (`"filter"`, …); PDFViewer/Dialog ignore the extra arg.
- `goToStep: ["controlId", "bool"]` — Wizard jump-back without discarding progress, focus flag cast from the ABAP bool.
- New `castArg` kind **`domRef`** — resolves a control id (slot-local first) and passes its DOM element, falling back to the control itself (every sap.m `openBy` accepts either).
- `openBy: ["domRef"]` — the DatePickerHidden sample's core feature (hidden DatePicker opened from Button/icon/Link anchors); also covers the TimePicker/Menu anchored-open family.
- `setActivePage: ["controlId"]` — sap.m.Carousel.

Plus a `castArgs` hardening: only the args the caller actually sent are cast — previously missing trailing args were padded to the kinds length, turning `open()` into `open(undefined)` and a missing int into `NaN`.

## How to test

- `npx playwright test --config node/playwright-unit.config.js frontendAction` — 21 specs, incl. new ones for the optional `to` transition, `open` page key, `goToStep`, `openBy` DOM-ref resolution + control fallback, and `setActivePage`.
- In-system: the ai-demokit ports `z2ui5_cl_ai_app_540` (hidden DatePicker via `openBy`) and `z2ui5_cl_ai_app_536` (NavContainer `to` navigation) exercise the new entries.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md) — `src/01/03/z2ui5_cl_app_frontendaction_js` was regenerated via `npm run app2abap`, not hand-edited
- [x] Public API in `src/02/` only changed additively — no `src/02/` change (frontend whitelist only)
- [ ] Changes were made via abapGit: no (repo-direct, embedded frontend regenerated by the build script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ioUHdR4e7jf5wWR7sbrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5ioUHdR4e7jf5wWR7sbrG)_