### PR TITLE
FrontendAction: compound filter groups for BINDING_CALL (AND-of-ORs from data)

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -234,8 +234,64 @@ sap.ui.define(
     // The backend arg serializer keeps empty args between filled ones as ''
     // placeholders but trims trailing empties, so all optionals sit at the
     // end and may arrive as undefined.
+    // Compound form of the filter payload: ONE param carrying a JSON array
+    // of groups, each group an array of [path, operator, value1, value2?]
+    // rows - OR inside a group, AND across groups (the FacetFilter /
+    // ViewSettingsDialog multi-facet shape). Data only: paths, whitelisted
+    // operators and values - never code. An empty groups array clears.
+    function buildFilterGroups(binding, json) {
+      let groups;
+      try {
+        groups = JSON.parse(json);
+      } catch {
+        Lib.logError("BINDING_CALL: malformed filter groups JSON");
+        return;
+      }
+      if (!Array.isArray(groups)) {
+        Lib.logError("BINDING_CALL: filter groups must be an array");
+        return;
+      }
+      groups = groups.filter((g) => Array.isArray(g) && g.length);
+      if (!groups.length) {
+        binding.filter([]);
+        return;
+      }
+      const outer = [];
+      for (const group of groups) {
+        const inner = [];
+        for (const row of group) {
+          const [path, operator, value1, value2] = Array.isArray(row)
+            ? row
+            : [];
+          if (typeof path !== "string" || !FILTER_OPERATORS.has(operator)) {
+            Lib.logError(
+              `BINDING_CALL: bad filter row (path '${path}' / operator '${operator}')`,
+            );
+            return;
+          }
+          inner.push(
+            new Filter(path, FilterOperator[operator], value1, value2),
+          );
+        }
+        outer.push(new Filter(inner, false)); // OR inside the group
+      }
+      binding.filter([new Filter(outer, true)]); // AND across the groups
+    }
+
     const BINDING_METHODS = {
-      filter(binding, [path, operator, value1, value2]) {
+      filter(binding, params) {
+        const [path, operator, value1, value2] = params;
+        // A single param that starts with '[' is the compound groups JSON -
+        // a model path can never start with '[', so the sniff is
+        // unambiguous and the positional single-filter form stays as-is.
+        if (
+          params.length === 1 &&
+          typeof path === "string" &&
+          path.trimStart().startsWith("[")
+        ) {
+          buildFilterGroups(binding, path);
+          return;
+        }
         // No filter values at all -> clear the filter (the demo kit search
         // pattern: an emptied search field). A one-sided range (empty
         // value1 but a set value2, e.g. BT with only an upper bound) is a

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -341,6 +341,50 @@ test.describe("BINDING_CALL", () => {
     });
   });
 
+  test("compound groups JSON builds AND-of-ORs (FacetFilter shape)", () => {
+    const { FrontendAction, calls, controls } = load();
+    withListBinding(controls, calls);
+    const json = JSON.stringify([
+      [["CATEGORY", "EQ", "Accessories"], ["CATEGORY", "EQ", "Laptops"]],
+      [["SUPPLIER_NAME", "EQ", "Technocom"]],
+    ]);
+    FrontendAction.execute(null, ["BINDING_CALL", "idList", "items", "filter", json]);
+    expect(calls).toHaveLength(1);
+    const [name, filters] = calls[0];
+    expect(name).toBe("filter");
+    expect(filters).toHaveLength(1);
+    const root = filters[0]; // mock Filter stores (aFilters, bAnd) as (path, operator)
+    expect(root.operator).toBe(true); // AND across groups
+    expect(root.path).toHaveLength(2);
+    expect(root.path[0].operator).toBe(false); // OR inside the group
+    expect(root.path[0].path).toHaveLength(2);
+    expect(root.path[0].path[0]).toMatchObject({ path: "CATEGORY", operator: "EQ", value1: "Accessories" });
+    expect(root.path[1].path[0]).toMatchObject({ path: "SUPPLIER_NAME", operator: "EQ", value1: "Technocom" });
+  });
+
+  test("empty compound groups clear the filter; empty inner groups are skipped", () => {
+    const { FrontendAction, calls, controls } = load();
+    withListBinding(controls, calls);
+    FrontendAction.execute(null, ["BINDING_CALL", "idList", "items", "filter", "[]"]);
+    FrontendAction.execute(null, ["BINDING_CALL", "idList", "items", "filter", "[[],[]]"]);
+    expect(calls).toEqual([
+      ["filter", []],
+      ["filter", []],
+    ]);
+  });
+
+  test("compound groups reject bad operators and malformed JSON", () => {
+    const { FrontendAction, calls, errors, controls } = load();
+    withListBinding(controls, calls);
+    FrontendAction.execute(null, [
+      "BINDING_CALL", "idList", "items", "filter",
+      JSON.stringify([[["NAME", "DROP TABLE", "x"]]]),
+    ]);
+    FrontendAction.execute(null, ["BINDING_CALL", "idList", "items", "filter", "[not json"]);
+    expect(calls).toHaveLength(0);
+    expect(errors).toHaveLength(2);
+  });
+
   test("logs when the control or binding is missing", () => {
     const { FrontendAction, calls, errors } = load();
     FrontendAction.execute(null, [

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -254,8 +254,64 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // The backend arg serializer keeps empty args between filled ones as ''` && |\n| &&
              `    // placeholders but trims trailing empties, so all optionals sit at the` && |\n| &&
              `    // end and may arrive as undefined.` && |\n| &&
+             `    // Compound form of the filter payload: ONE param carrying a JSON array` && |\n| &&
+             `    // of groups, each group an array of [path, operator, value1, value2?]` && |\n| &&
+             `    // rows - OR inside a group, AND across groups (the FacetFilter /` && |\n| &&
+             `    // ViewSettingsDialog multi-facet shape). Data only: paths, whitelisted` && |\n| &&
+             `    // operators and values - never code. An empty groups array clears.` && |\n| &&
+             `    function buildFilterGroups(binding, json) {` && |\n| &&
+             `      let groups;` && |\n| &&
+             `      try {` && |\n| &&
+             `        groups = JSON.parse(json);` && |\n| &&
+             `      } catch {` && |\n| &&
+             `        Lib.logError("BINDING_CALL: malformed filter groups JSON");` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      if (!Array.isArray(groups)) {` && |\n| &&
+             `        Lib.logError("BINDING_CALL: filter groups must be an array");` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      groups = groups.filter((g) => Array.isArray(g) && g.length);` && |\n| &&
+             `      if (!groups.length) {` && |\n| &&
+             `        binding.filter([]);` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      const outer = [];` && |\n| &&
+             `      for (const group of groups) {` && |\n| &&
+             `        const inner = [];` && |\n| &&
+             `        for (const row of group) {` && |\n| &&
+             `          const [path, operator, value1, value2] = Array.isArray(row)` && |\n| &&
+             `            ? row` && |\n| &&
+             `            : [];` && |\n| &&
+             `          if (typeof path !== "string" || !FILTER_OPERATORS.has(operator)) {` && |\n| &&
+             `            Lib.logError(` && |\n| &&
+             `              ``BINDING_CALL: bad filter row (path '${path}' / operator '${operator}')``,` && |\n| &&
+             `            );` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n| &&
+             `          inner.push(` && |\n| &&
+             `            new Filter(path, FilterOperator[operator], value1, value2),` && |\n| &&
+             `          );` && |\n| &&
+             `        }` && |\n| &&
+             `        outer.push(new Filter(inner, false)); // OR inside the group` && |\n| &&
+             `      }` && |\n| &&
+             `      binding.filter([new Filter(outer, true)]); // AND across the groups` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    const BINDING_METHODS = {` && |\n| &&
-             `      filter(binding, [path, operator, value1, value2]) {` && |\n| &&
+             `      filter(binding, params) {` && |\n| &&
+             `        const [path, operator, value1, value2] = params;` && |\n| &&
+             `        // A single param that starts with '[' is the compound groups JSON -` && |\n| &&
+             `        // a model path can never start with '[', so the sniff is` && |\n| &&
+             `        // unambiguous and the positional single-filter form stays as-is.` && |\n| &&
+             `        if (` && |\n| &&
+             `          params.length === 1 &&` && |\n| &&
+             `          typeof path === "string" &&` && |\n| &&
+             `          path.trimStart().startsWith("[")` && |\n| &&
+             `        ) {` && |\n| &&
+             `          buildFilterGroups(binding, path);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
              `        // No filter values at all -> clear the filter (the demo kit search` && |\n| &&
              `        // pattern: an emptied search field). A one-sided range (empty` && |\n| &&
              `        // value1 but a set value2, e.g. BT with only an upper bound) is a` && |\n| &&
@@ -361,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        // 100 is the UI5 JSONModel default size limit.` && |\n| &&
              `        model.setSizeLimit(isValidLimit ? limit : 100);` && |\n| &&
              `        model.refresh(true);` && |\n| &&
-             `      }` && |\n| &&
+             `      }` && |\n|.
+    result = result &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evSetODataModel(oController, args) {` && |\n| &&
@@ -417,8 +474,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          // consistent with every other redirect handler in this file.` && |\n| &&
              `          const base = window.location.href.split("#")[0];` && |\n| &&
              `          const url = ``${base}${hash}``;` && |\n| &&
-             `          if (!Lib.isValidRedirectURL(url)) {` && |\n|.
-    result = result &&
+             `          if (!Lib.isValidRedirectURL(url)) {` && |\n| &&
              `            Lib.logError(``CrossAppNav EXT: unsafe redirect URL '${url}'``);` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
@@ -762,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      try {` && |\n| &&
              `        const wiz = ViewSlots.byId("MAIN", args[1]);` && |\n| &&
              `        const step = ViewSlots.byId("MAIN", args[2]);` && |\n| &&
-             `        const nextStep = ViewSlots.byId("MAIN", args[3]);` && |\n| &&
+             `        const nextStep = ViewSlots.byId("MAIN", args[3]);` && |\n|.
+    result = result &&
              `        if (wiz && step) wiz.discardProgress(step);` && |\n| &&
              `        if (step && nextStep) step.setNextStep(nextStep);` && |\n| &&
              `      } catch (e) {` && |\n| &&
@@ -818,8 +875,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      CONTROL_GLOBAL: evControlCall,` && |\n| &&
              `      BINDING_CALL: evBindingCall,` && |\n| &&
              `    };` && |\n| &&
-             `` && |\n|.
-    result = result &&
+             `` && |\n| &&
              `    // Entry point called by View1.controller's eF().` && |\n| &&
              `    function execute(oController, args) {` && |\n| &&
              `      // runCallbacks isolates each hook in its own try/catch, so a throwing` && |\n| &&


### PR DESCRIPTION
# Description

Implements the ai-demokit request `pr/binding-call-compound-filters` (hit by the FacetFilterLight port): the `filter` binding method now also accepts ONE param carrying a JSON array of groups, each group a list of `[path, operator, value1, value2?]` rows — OR inside a group, AND across the groups. This is the standard multi-facet shape (FacetFilter, ViewSettingsDialog multi-key filters, combined search + facet filtering).

- Data only: paths, `FILTER_OPERATORS`-whitelisted operators and values; malformed JSON / non-array payloads / bad rows are rejected with a logged error; an empty groups array clears the filter.
- The sniff is unambiguous — a model path can never start with `[` — so the positional single-filter form is byte-compatible and untouched.

## How to test

- `npx playwright test --config node/playwright-unit.config.js frontendAction` — 24 specs, incl. new ones: compound AND-of-ORs shape, empty/inner-empty groups clearing, bad-operator and malformed-JSON rejection.
- In-system: the ai-demokit port `z2ui5_cl_ai_app_401` (FacetFilterLight) now schedules the compound filter from its facet selections.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md) — `src/01/03/z2ui5_cl_app_frontendaction_js` regenerated via `npm run app2abap`
- [x] Public API in `src/02/` only changed additively — no `src/02/` change (frontend payload extension only)
- [ ] Changes were made via abapGit: no (repo-direct, embedded frontend regenerated by the build script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5ioUHdR4e7jf5wWR7sbrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5ioUHdR4e7jf5wWR7sbrG)_