### PR TITLE
Add Tree expand/collapse actions to FrontendAction

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -87,6 +87,8 @@ sap.ui.define(
       goToStep: ["controlId", "bool"], // Wizard: target step + focus flag
       openBy: ["domRef"], // DatePicker/TimePicker/Menu... anchored open
       setActivePage: ["controlId"], // sap.m.Carousel
+      expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels
+      collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node
     };
 
     // global object -> lazy getter + its allowed methods (with arg kinds).


### PR DESCRIPTION
# Description

This PR adds support for two new frontend actions for tree controls:
- `expandToLevel`: Expands a tree to a specified number of levels (accepts an integer parameter)
- `collapseAll`: Collapses all nodes in a tree (accepts no parameters)

These actions are applicable to both `sap.m.Tree` and `sap.ui.table.TreeTable` controls, enabling programmatic control over tree expansion state.

## How to test

No testing needed. This is a configuration change that registers new action types in the FrontendAction handler. The actions will be validated and executed through existing framework mechanisms.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01Th7ijPdeYf2maHgcUFH3Xr