### PR TITLE
Add "Open in ABAP Development Tools" link to Source Code tab

### DIFF
--- a/app/webapp/core/DeveloperTools.fragment.xml
+++ b/app/webapp/core/DeveloperTools.fragment.xml
@@ -102,6 +102,18 @@
             />
         </VBox>
         <VBox visible="{/source_visible}">
+            <!-- The inline iframe below is only a preview: some systems block
+                 framing the ADT endpoint and the ADT jump link inside it never
+                 navigates. This top-level Link opens the same source in a new
+                 tab, where its "Open in ABAP Development Tools" link works. -->
+            <Toolbar>
+                <ToolbarSpacer/>
+                <Link
+                    text="Open in ABAP Development Tools"
+                    visible="{/hasSource}"
+                    press=".onOpenAbapInAdt"
+                />
+            </Toolbar>
             <!-- preferDOM defaults to true, which restores the preserved
                  iframe DOM of a previous open instead of the freshly set
                  content - the Source Code tab then kept showing the class

--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -518,27 +518,52 @@ sap.ui.define(
         }
       },
 
+      // The ADT REST endpoint that renders the running app's ABAP class
+      // source. Empty when the app class name is unknown (no response yet).
+      getAbapSourceUrl() {
+        const appName = AppState.state.responseData?.S_FRONT?.APP || "";
+        if (!appName) return "";
+        const appId = encodeURIComponent(appName);
+        return `${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main`;
+      },
+
+      // Open the ABAP class source as a top-level document in a new browser
+      // tab. The ADT REST endpoint renders it with syntax highlighting and its
+      // own "Open in ABAP Development Tools" link; opening it top-level is what
+      // lets that link's adt:// navigation reach the desktop ADT. From inside
+      // the inline iframe below the jump never worked - browsers suppress a
+      // custom-scheme navigation started in a subframe, and some systems block
+      // framing the ADT endpoint entirely (X-Frame-Options), so the preview is
+      // just blank there. noopener keeps the new tab from reaching back into
+      // window.opener.
+      onOpenAbapInAdt() {
+        const url = this.getAbapSourceUrl();
+        if (!url) return;
+        window.open(url, "_blank", "noopener,noreferrer");
+      },
+
       // Show the ABAP source of the running app inside an iframe.
       showAbapSource(oModel) {
         const contentControl = Fragment.byId(FRAGMENT_ID, "sourceHtml");
         if (!contentControl) return;
 
-        const sFront = AppState.state.responseData?.S_FRONT;
-        const appName = sFront?.APP || "";
-        const appId = encodeURIComponent(appName);
-        const url = `${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main`;
+        const url = this.getAbapSourceUrl();
         // setContent (not a bare setProperty) so an already rendered iframe
         // is replaced in the live DOM; a plain property set never reached
         // the DOM once the control had rendered, leaving a stale class
         // on screen after navigating to another app.
         contentControl.setContent(
-          `<iframe src="${url}" style="width:100%;height:85vh;border:none;" />`,
+          url
+            ? `<iframe src="${url}" style="width:100%;height:85vh;border:none;" />`
+            : "",
         );
 
         if (!oModel) return;
         const modelData = oModel.getData();
         modelData.editor_visible = false;
         modelData.source_visible = true;
+        // Drives the "Open in ABAP Development Tools" link's visibility.
+        modelData.hasSource = Boolean(url);
         oModel.refresh();
       },
 
@@ -613,6 +638,7 @@ sap.ui.define(
             type: "json",
             source_visible: false,
             editor_visible: true,
+            hasSource: false,
             hasError: Boolean(AppState.state.lastError),
             hasRetry: typeof AppState.state.lastError?.onRetry === "function",
             value: value,

--- a/node/tests/developerTools.spec.js
+++ b/node/tests/developerTools.spec.js
@@ -26,14 +26,16 @@ function fakeXmlView(viewContent) {
 function loadDeveloperTools({
   views = {},
   oResponse = null,
+  responseData = null,
   errors,
   lastError = null,
   logoutCalls,
   reopenCalls,
   fragment,
+  windowStub,
 } = {}) {
   const AppState = {
-    state: { oResponse, responseData: null, oBody: null, errors, lastError },
+    state: { oResponse, responseData, oBody: null, errors, lastError },
     getGlobal: () => undefined,
   };
   const ViewSlots = { getView: (key) => views[key] };
@@ -71,6 +73,10 @@ function loadDeveloperTools({
         transformToDocument() {
           return null;
         }
+      },
+      window: windowStub || {
+        location: { origin: "https://sap.example.com" },
+        open() {},
       },
     },
   });
@@ -358,6 +364,77 @@ test.describe("Close / Escape returns to the error popup", () => {
     expect(destroyed).toBe(true);
     expect(DeveloperTools.oDialog).toBe(null);
     expect(reopenCalls).toEqual([]);
+  });
+});
+
+test.describe("Source Code tab / ADT jump", () => {
+  const APP = "Z2UI5_CL_MY_APP";
+  const EXPECTED_URL =
+    "https://sap.example.com/sap/bc/adt/oo/classes/Z2UI5_CL_MY_APP/source/main";
+
+  test("getAbapSourceUrl builds the ADT source endpoint for the running app", () => {
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData: { S_FRONT: { APP: APP } },
+    });
+    expect(DeveloperTools.getAbapSourceUrl()).toBe(EXPECTED_URL);
+  });
+
+  test("getAbapSourceUrl is empty when the app class name is unknown", () => {
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData: { S_FRONT: {} },
+    });
+    expect(DeveloperTools.getAbapSourceUrl()).toBe("");
+  });
+
+  test("onOpenAbapInAdt opens the source top-level in a new tab", () => {
+    const opened = [];
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData: { S_FRONT: { APP: APP } },
+      windowStub: {
+        location: { origin: "https://sap.example.com" },
+        open: (url, target, features) => opened.push({ url, target, features }),
+      },
+    });
+    DeveloperTools.onOpenAbapInAdt();
+    expect(opened).toEqual([
+      {
+        url: EXPECTED_URL,
+        target: "_blank",
+        features: "noopener,noreferrer",
+      },
+    ]);
+  });
+
+  test("onOpenAbapInAdt does nothing when the app class name is unknown", () => {
+    const opened = [];
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData: { S_FRONT: {} },
+      windowStub: {
+        location: { origin: "https://sap.example.com" },
+        open: (url) => opened.push(url),
+      },
+    });
+    DeveloperTools.onOpenAbapInAdt();
+    expect(opened).toEqual([]);
+  });
+
+  test("showAbapSource frames the source and flags hasSource for the link", () => {
+    let content = null;
+    const fragment = {
+      byId: () => ({
+        setContent: (html) => (content = html),
+      }),
+    };
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData: { S_FRONT: { APP: APP } },
+      fragment,
+    });
+    const modelData = {};
+    DeveloperTools.showAbapSource({ getData: () => modelData, refresh() {} });
+    expect(content).toContain(`src="${EXPECTED_URL}"`);
+    expect(modelData.source_visible).toBe(true);
+    expect(modelData.editor_visible).toBe(false);
+    expect(modelData.hasSource).toBe(true);
   });
 });
 

--- a/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
@@ -122,6 +122,18 @@ CLASS z2ui5_cl_app_developertool_xml IMPLEMENTATION.
              `            />` &&
              `        </VBox>` &&
              `        <VBox visible="{/source_visible}">` &&
+             `            <!-- The inline iframe below is only a preview: some systems block` &&
+             `                 framing the ADT endpoint and the ADT jump link inside it never` &&
+             `                 navigates. This top-level Link opens the same source in a new` &&
+             `                 tab, where its "Open in ABAP Development Tools" link works. -->` &&
+             `            <Toolbar>` &&
+             `                <ToolbarSpacer/>` &&
+             `                <Link` &&
+             `                    text="Open in ABAP Development Tools"` &&
+             `                    visible="{/hasSource}"` &&
+             `                    press=".onOpenAbapInAdt"` &&
+             `                />` &&
+             `            </Toolbar>` &&
              `            <!-- preferDOM defaults to true, which restores the preserved` &&
              `                 iframe DOM of a previous open instead of the freshly set` &&
              `                 content - the Source Code tab then kept showing the class` &&

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -539,27 +539,52 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
+             `      // The ADT REST endpoint that renders the running app's ABAP class` && |\n| &&
+             `      // source. Empty when the app class name is unknown (no response yet).` && |\n| &&
+             `      getAbapSourceUrl() {` && |\n| &&
+             `        const appName = AppState.state.responseData?.S_FRONT?.APP || "";` && |\n| &&
+             `        if (!appName) return "";` && |\n| &&
+             `        const appId = encodeURIComponent(appName);` && |\n| &&
+             `        return ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      // Open the ABAP class source as a top-level document in a new browser` && |\n| &&
+             `      // tab. The ADT REST endpoint renders it with syntax highlighting and its` && |\n| &&
+             `      // own "Open in ABAP Development Tools" link; opening it top-level is what` && |\n| &&
+             `      // lets that link's adt:// navigation reach the desktop ADT. From inside` && |\n| &&
+             `      // the inline iframe below the jump never worked - browsers suppress a` && |\n| &&
+             `      // custom-scheme navigation started in a subframe, and some systems block` && |\n| &&
+             `      // framing the ADT endpoint entirely (X-Frame-Options), so the preview is` && |\n| &&
+             `      // just blank there. noopener keeps the new tab from reaching back into` && |\n| &&
+             `      // window.opener.` && |\n| &&
+             `      onOpenAbapInAdt() {` && |\n| &&
+             `        const url = this.getAbapSourceUrl();` && |\n| &&
+             `        if (!url) return;` && |\n| &&
+             `        window.open(url, "_blank", "noopener,noreferrer");` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
              `      // Show the ABAP source of the running app inside an iframe.` && |\n| &&
              `      showAbapSource(oModel) {` && |\n| &&
              `        const contentControl = Fragment.byId(FRAGMENT_ID, "sourceHtml");` && |\n| &&
              `        if (!contentControl) return;` && |\n| &&
              `` && |\n| &&
-             `        const sFront = AppState.state.responseData?.S_FRONT;` && |\n| &&
-             `        const appName = sFront?.APP || "";` && |\n| &&
-             `        const appId = encodeURIComponent(appName);` && |\n| &&
-             `        const url = ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n| &&
+             `        const url = this.getAbapSourceUrl();` && |\n| &&
              `        // setContent (not a bare setProperty) so an already rendered iframe` && |\n| &&
              `        // is replaced in the live DOM; a plain property set never reached` && |\n| &&
              `        // the DOM once the control had rendered, leaving a stale class` && |\n| &&
              `        // on screen after navigating to another app.` && |\n| &&
              `        contentControl.setContent(` && |\n| &&
-             `          ``<iframe src="${url}" style="width:100%;height:85vh;border:none;" />``,` && |\n| &&
+             `          url` && |\n| &&
+             `            ? ``<iframe src="${url}" style="width:100%;height:85vh;border:none;" />``` && |\n| &&
+             `            : "",` && |\n| &&
              `        );` && |\n| &&
              `` && |\n| &&
              `        if (!oModel) return;` && |\n| &&
              `        const modelData = oModel.getData();` && |\n| &&
              `        modelData.editor_visible = false;` && |\n| &&
              `        modelData.source_visible = true;` && |\n| &&
+             `        // Drives the "Open in ABAP Development Tools" link's visibility.` && |\n| &&
+             `        modelData.hasSource = Boolean(url);` && |\n| &&
              `        oModel.refresh();` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -634,6 +659,7 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `            type: "json",` && |\n| &&
              `            source_visible: false,` && |\n| &&
              `            editor_visible: true,` && |\n| &&
+             `            hasSource: false,` && |\n| &&
              `            hasError: Boolean(AppState.state.lastError),` && |\n| &&
              `            hasRetry: typeof AppState.state.lastError?.onRetry === "function",` && |\n| &&
              `            value: value,` && |\n| &&


### PR DESCRIPTION
# Description

Adds a new "Open in ABAP Development Tools" link to the Source Code tab in the Developer Tools. This link opens the ABAP class source in a new browser tab where the ADT jump functionality works properly.

The change extracts the URL building logic into a new `getAbapSourceUrl()` method and adds a new `onOpenAbapInAdt()` method that opens the URL in a new tab with appropriate security flags (`noopener,noreferrer`). The inline iframe preview is retained but now has a companion top-level link, since some systems block framing the ADT endpoint and the ADT jump link inside the iframe never navigates.

The model data now includes a `hasSource` flag that controls the visibility of the link, which is only shown when the app class name is known.

## How to test

1. Open the Developer Tools and navigate to the Source Code tab
2. Verify that the "Open in ABAP Development Tools" link appears in the toolbar
3. Click the link and verify it opens the ABAP class source in a new tab
4. Verify the link is hidden when no app class name is available (before first response)
5. Run the unit tests: `npm test -- developerTools.spec.js`

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (added 4 new test cases)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes are generated from source)
- [x] Public API in `src/02/` only changed additively (new methods added)
- [x] Changes were made via abapGit: no (manual source code changes)

https://claude.ai/code/session_015rpBcsTHfdfYXG59UaeQBU