### PR TITLE
Mark _bind_edit and view parameter as obsolete

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -393,7 +393,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
                             type    = z2ui5_if_core_types=>cs_bind_type-two_way
                             config  = VALUE #(
 *                                              view = view
-                                              path_only           = path
+                                              path_only            = path
                                               custom_filter        = custom_filter
                                               custom_filter_back   = custom_filter_back
                                               custom_mapper        = custom_mapper

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -221,7 +221,7 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val                  TYPE data
       path                 TYPE abap_bool                     DEFAULT abap_false
-      view                 TYPE clike                         DEFAULT cs_view-main
+      view                 TYPE clike                         DEFAULT cs_view-main "obsolet - inaktiv, wird intern nicht weitergegeben
       custom_mapper        TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_mapper_back   TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_filter        TYPE REF TO z2ui5_if_ajson_filter  OPTIONAL
@@ -236,7 +236,7 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val                  TYPE data
       path                 TYPE abap_bool                     DEFAULT abap_false
-      view                 TYPE clike                         DEFAULT cs_view-main
+      view                 TYPE clike                         DEFAULT cs_view-main "obsolet - inaktiv, wird intern nicht weitergegeben
       custom_mapper        TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_mapper_back   TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_filter        TYPE REF TO z2ui5_if_ajson_filter  OPTIONAL

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -221,7 +221,8 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val                  TYPE data
       path                 TYPE abap_bool                     DEFAULT abap_false
-      view                 TYPE clike                         DEFAULT cs_view-main "obsolet - inaktiv, wird intern nicht weitergegeben
+      "obsolet - inaktiv, wird intern nicht weitergegeben
+      view                 TYPE clike                         DEFAULT cs_view-main
       custom_mapper        TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_mapper_back   TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_filter        TYPE REF TO z2ui5_if_ajson_filter  OPTIONAL
@@ -237,7 +238,8 @@ INTERFACE z2ui5_if_client
     IMPORTING
       val                  TYPE data
       path                 TYPE abap_bool                     DEFAULT abap_false
-      view                 TYPE clike                         DEFAULT cs_view-main "obsolet - inaktiv, wird intern nicht weitergegeben
+      "obsolet - inaktiv, wird intern nicht weitergegeben
+      view                 TYPE clike                         DEFAULT cs_view-main
       custom_mapper        TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_mapper_back   TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
       custom_filter        TYPE REF TO z2ui5_if_ajson_filter  OPTIONAL

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -232,6 +232,7 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result)        TYPE string.
 
+  "! obsolet - identisch zu _bind (beide two-way), bitte _bind verwenden
   METHODS _bind_edit
     IMPORTING
       val                  TYPE data


### PR DESCRIPTION
# Description

This PR marks the `_bind_edit` method and the `view` parameter in both `_bind` and `_bind_edit` methods as obsolete.

**Changes:**
- Added comment to `_bind_edit` method indicating it is obsolete and identical to `_bind` (both provide two-way binding), with recommendation to use `_bind` instead
- Added inline comments to the `view` parameter in both `_bind` and `_bind_edit` methods indicating it is obsolete, inactive, and not passed internally
- These are documentation-only changes to the interface definition

## How to test

N/A - Documentation-only changes to interface comments

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_012t1RGjFwgQtjYhfFvPdWbp