### PR TITLE
FrontendAction: toggleBy for openBy-style popups; Formatter: expandIn…

### DIFF
--- a/app/webapp/cc/MessageManager.js
+++ b/app/webapp/cc/MessageManager.js
@@ -12,9 +12,7 @@ sap.ui.define(
     // the same problem (same text, type and target) map to the same key, so
     // reconciling never adds a duplicate or drops a still-wanted message.
     const keyOf = (o) =>
-      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join(
-        "",
-      );
+      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join("");
 
     // Invisible companion control that bridges the UI5 message manager to a
     // two-way bound ABAP table (`items`). The table is the app's OWN messages:

--- a/app/webapp/cc/MessageManager.js
+++ b/app/webapp/cc/MessageManager.js
@@ -1,0 +1,107 @@
+sap.ui.define(
+  [
+    "sap/ui/core/Control",
+    "sap/ui/core/message/Message",
+    "z2ui5/core/Lib",
+    "z2ui5/core/ViewSlots",
+  ],
+  (Control, Message, Lib, ViewSlots) => {
+    "use strict";
+
+    // A message key that is stable across a round-trip: two rows describing
+    // the same problem (same text, type and target) map to the same key, so
+    // reconciling never adds a duplicate or drops a still-wanted message.
+    const keyOf = (o) =>
+      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join(
+        "",
+      );
+
+    // Invisible companion control that bridges the UI5 message manager to a
+    // two-way bound ABAP table (`items`). The table is the app's OWN messages:
+    // on every backend update the control reconciles the message manager to
+    // match it - adding new rows as sap.ui.core.message.Message objects (with
+    // a target + the view's model as processor, so they set the bound field's
+    // valueState) and removing the app rows that are gone. Messages the
+    // framework auto-collects from binding-type/constraint validation stay in
+    // the message> model untouched; a MessagePopover bound to {message>/}
+    // shows both. Mirrors the MultiInputExt companion-control pattern.
+    return Control.extend("z2ui5.cc.MessageManager", {
+      metadata: {
+        properties: {
+          items: { type: "object" },
+          checkInit: { type: "boolean", defaultValue: false },
+        },
+        events: {
+          change: { allowPreventDefault: true, parameters: {} },
+        },
+      },
+
+      init() {
+        // Messages this control has added, by key, so it removes exactly its
+        // own rows and never touches auto-collected validation messages.
+        this._added = new Map();
+        this._ready = false;
+        this._setupBound = this.setup.bind(this);
+        Lib.registerCallback("onAfterRendering", this._setupBound);
+      },
+      exit() {
+        Lib.unregisterCallback("onAfterRendering", this._setupBound);
+      },
+      renderer: { apiVersion: 2, render() {} },
+
+      setup() {
+        if (this.getProperty("checkInit")) return;
+        const messaging = Lib.getMessaging?.();
+        if (!messaging) return;
+        this.setProperty("checkInit", true);
+        this._messaging = messaging;
+        const view = ViewSlots.getView(
+          ViewSlots.containingSlotKey(this) ?? "MAIN",
+        );
+        this._processor = view?.getModel?.() ?? null;
+        this._ready = true;
+        // reconcile whatever arrived before the control was ready
+        this.reconcile();
+      },
+
+      // property setter override: the two-way binding calls this when the
+      // backend ships a new message table (base setProperty is used for the
+      // internal store, so it never re-enters here)
+      setItems(aItems) {
+        this.setProperty("items", aItems, true);
+        if (this._ready) this.reconcile();
+        return this;
+      },
+
+      // Bring the message manager in line with the `items` table: add rows
+      // that are not yet present, remove the control's own rows that are gone.
+      reconcile() {
+        const rows = this.getProperty("items") || [];
+        const wanted = new Map(rows.map((r) => [keyOf(r), r]));
+
+        // remove app rows no longer wanted
+        for (const [key, oMessage] of this._added) {
+          if (!wanted.has(key)) {
+            this._messaging.removeMessages(oMessage);
+            this._added.delete(key);
+          }
+        }
+        // add newly wanted rows
+        for (const [key, r] of wanted) {
+          if (this._added.has(key)) continue;
+          const oMessage = new Message({
+            message: r.MESSAGE ?? "",
+            description: r.DESCRIPTION ?? "",
+            type: r.TYPE ?? "Error",
+            target: r.TARGET ?? "",
+            additionalText: r.ADDITIONALTEXT ?? "",
+            processor: this._processor,
+          });
+          this._messaging.addMessages(oMessage);
+          this._added.set(key, oMessage);
+        }
+        this.fireChange();
+      },
+    });
+  },
+);

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -180,7 +180,9 @@ sap.ui.define(
       // client-side, so the decision stays here rather than round-tripping.
       if (method === "toggleBy") {
         if (!control || typeof control.openBy !== "function") {
-          Lib.logError(`CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'`);
+          Lib.logError(
+            `CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'`,
+          );
           return;
         }
         const anchor = castArgs(kinds, args.slice(4), view)[0];

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -86,6 +86,7 @@ sap.ui.define(
       setNextStep: ["controlId"],
       goToStep: ["controlId", "bool"], // Wizard: target step + focus flag
       openBy: ["domRef"], // DatePicker/TimePicker/Menu... anchored open
+      toggleBy: ["domRef"], // sap.m.Menu/Popover: open anchored if closed, close if open
       setActivePage: ["controlId"], // sap.m.Carousel
       expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels
       collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node
@@ -173,6 +174,23 @@ sap.ui.define(
       const control = view
         ? ViewSlots.byId(view.toUpperCase(), id)
         : ViewSlots.resolveById(id);
+      // toggleBy is not a real control method: open the control anchored to
+      // the domRef if it is closed, close it if it is already open (mirrors
+      // openBy for a press-to-toggle button). The popup's open state lives
+      // client-side, so the decision stays here rather than round-tripping.
+      if (method === "toggleBy") {
+        if (!control || typeof control.openBy !== "function") {
+          Lib.logError(`CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'`);
+          return;
+        }
+        const anchor = castArgs(kinds, args.slice(4), view)[0];
+        if (control.isOpen?.()) {
+          control.close();
+        } else {
+          control.openBy(anchor);
+        }
+        return;
+      }
       if (!control || typeof control[method] !== "function") {
         Lib.logError(
           `CONTROL_BY_ID: '${method}' not callable on control '${id}'`,

--- a/app/webapp/model/formatter.js
+++ b/app/webapp/model/formatter.js
@@ -23,7 +23,7 @@
 // z2ui5.Util: the implementations live here, Util.js re-exports them as
 // the stable legacy alias. Their names and behavior are a public contract
 // - do not rename or change them.
-sap.ui.define([], () => {
+sap.ui.define(["sap/ui/core/IconPool"], (IconPool) => {
   "use strict";
 
   // Splits an 8-character ABAP date string "YYYYMMDD" into the [year, month,
@@ -130,6 +130,25 @@ sap.ui.define([], () => {
       if (status === "Shipped") return "Success";
       if (status === "Failed Shipping") return "Error";
       return "None";
+    },
+
+    // Replace %%icon:sap-icon://<name>%% placeholders in a formatted-text
+    // string with the inline-icon markup MessageStrip formatted text expects
+    // (mirrors sap.m.MessageStripUtilities.getInlineIcon). The glyph is
+    // resolved from the icon font via IconPool - CSP-clean, no code
+    // generation. Plain text passes through unchanged; an unknown icon name
+    // is dropped. Used as a whole-string formatter on a MessageStrip text
+    // binding (sap.m.sample.MessageStripWithEnableFormattedText).
+    expandInlineIcons(text) {
+      if (!text) return "";
+      return String(text).replace(
+        /%%icon:(sap-icon:\/\/[^%]+)%%/g,
+        (match, uri) => {
+          const info = IconPool.getIconInfo(uri);
+          if (!info) return "";
+          return `<span class="sapMMsgStripInlineIcon" style="font-family:'${info.fontFamily}'">${info.content}</span>`;
+        },
+      );
     },
   };
 });

--- a/node/tests/formatter.spec.js
+++ b/node/tests/formatter.spec.js
@@ -10,7 +10,15 @@ const { loadModule } = require("./loadModule");
 // alias - everything here is a public contract.
 
 function load() {
-  const { module: Formatter } = loadModule("model/formatter.js");
+  const IconPool = {
+    getIconInfo: (uri) =>
+      uri === "sap-icon://unknown"
+        ? null
+        : { fontFamily: "SAP-icons", content: "GLYPH" },
+  };
+  const { module: Formatter } = loadModule("model/formatter.js", {
+    deps: { "sap/ui/core/IconPool": IconPool },
+  });
   const { module: Util } = loadModule("Util.js", {
     deps: { "z2ui5/model/formatter": Formatter },
   });
@@ -83,6 +91,25 @@ test.describe("Formatter module", () => {
     expect(Formatter.deliveryStatusState("Shipped")).toBe("Success");
     expect(Formatter.deliveryStatusState("Failed Shipping")).toBe("Error");
     expect(Formatter.deliveryStatusState("Pending")).toBe("None");
+  });
+
+  test("expandInlineIcons replaces %%icon:...%% with inline-icon markup", () => {
+    const { Formatter } = load();
+    expect(
+      Formatter.expandInlineIcons("A %%icon:sap-icon://sys-enter-2%% B"),
+    ).toBe(
+      'A <span class="sapMMsgStripInlineIcon" style="font-family:\'SAP-icons\'">GLYPH</span> B',
+    );
+  });
+
+  test("expandInlineIcons passes plain text through and drops unknown/empty", () => {
+    const { Formatter } = load();
+    expect(Formatter.expandInlineIcons("just text")).toBe("just text");
+    expect(Formatter.expandInlineIcons("")).toBe("");
+    expect(Formatter.expandInlineIcons(null)).toBe("");
+    expect(Formatter.expandInlineIcons("x %%icon:sap-icon://unknown%% y")).toBe(
+      "x  y",
+    );
   });
 
   test("z2ui5/Util re-exports the date helpers as the legacy alias", () => {

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -175,6 +175,31 @@ test.describe("CONTROL_BY_ID", () => {
     expect(calls).toEqual([["openBy", anchor]]);
   });
 
+  test("toggleBy opens the control anchored to the DOM ref when closed", () => {
+    const { FrontendAction, calls, controls } = load();
+    const dom = { tagName: "BUTTON" };
+    controls.anchorBtn = { getDomRef: () => dom };
+    controls.theMenu = {
+      isOpen: () => false,
+      openBy: (ref) => calls.push(["openBy", ref]),
+      close: () => calls.push(["close"]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "theMenu", "", "toggleBy", "anchorBtn"]);
+    expect(calls).toEqual([["openBy", dom]]);
+  });
+
+  test("toggleBy closes the control when it is already open", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.anchorBtn = { getDomRef: () => ({}) };
+    controls.theMenu = {
+      isOpen: () => true,
+      openBy: (ref) => calls.push(["openBy", ref]),
+      close: () => calls.push(["close"]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "theMenu", "", "toggleBy", "anchorBtn"]);
+    expect(calls).toEqual([["close"]]);
+  });
+
   test("setActivePage resolves the page control (Carousel)", () => {
     const { FrontendAction, calls, controls } = load();
     const page2 = { id: "carPage2" };

--- a/node/tests/messageManager.spec.js
+++ b/node/tests/messageManager.spec.js
@@ -1,0 +1,162 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loadModule } = require("./loadModule");
+
+// Tests the real app/webapp/cc/MessageManager.js. The companion control keeps
+// the UI5 message manager in sync with its two-way bound `items` table (the
+// app's OWN messages): a reconcile adds the rows that are new, removes the
+// control's own rows that are gone, and never touches messages it did not add
+// (auto-collected binding validation).
+
+// Minimal Control.extend stub (as in uiTableExt.spec.js).
+function controlStub() {
+  return {
+    extend(_name, def) {
+      function Ctrl() {}
+      Object.assign(Ctrl.prototype, def);
+      return Ctrl;
+    },
+  };
+}
+
+function load() {
+  const callbacks = { onAfterRendering: [] };
+  const messaging = {
+    added: [],
+    removed: [],
+    addMessages: (m) => messaging.added.push(m),
+    removeMessages: (m) => messaging.removed.push(m),
+  };
+  const PROCESSOR = { id: "defaultModel" };
+  const view = { getModel: () => PROCESSOR };
+
+  const Lib = {
+    registerCallback: (name, fn) => {
+      (callbacks[name] = callbacks[name] || []).push(fn);
+    },
+    unregisterCallback: (name, fn) => {
+      if (callbacks[name])
+        callbacks[name] = callbacks[name].filter((f) => f !== fn);
+    },
+    getMessaging: () => messaging,
+  };
+  const ViewSlots = {
+    getView: () => view,
+    containingSlotKey: () => "MAIN",
+  };
+  function Message(o) {
+    Object.assign(this, o);
+  }
+
+  const { module: Ext } = loadModule("cc/MessageManager.js", {
+    deps: {
+      "sap/ui/core/Control": controlStub(),
+      "sap/ui/core/message/Message": Message,
+      "z2ui5/core/Lib": Lib,
+      "z2ui5/core/ViewSlots": ViewSlots,
+    },
+  });
+
+  return { Ext, callbacks, messaging, PROCESSOR };
+}
+
+// Instantiate with a tiny property store + a change counter.
+function makeExt(env) {
+  const ext = new env.Ext();
+  const props = { items: undefined, checkInit: false };
+  ext.getProperty = (n) => props[n];
+  ext.setProperty = (n, v) => {
+    props[n] = v;
+    return ext;
+  };
+  env.changeCount = 0;
+  ext.fireChange = () => {
+    env.changeCount++;
+  };
+  return ext;
+}
+
+test.describe("MessageManager companion control", () => {
+  test("init registers and exit unregisters the onAfterRendering hook", () => {
+    const env = load();
+    const ext = makeExt(env);
+    ext.init();
+    expect(env.callbacks.onAfterRendering).toHaveLength(1);
+    ext.exit();
+    expect(env.callbacks.onAfterRendering).toHaveLength(0);
+  });
+
+  test("adds a new app message as a Message with target + processor", () => {
+    const env = load();
+    const ext = makeExt(env);
+    ext.init();
+    ext.setup();
+    ext.setItems([
+      {
+        MESSAGE: "A mandatory field is required",
+        TYPE: "Error",
+        TARGET: "/NAME",
+        ADDITIONALTEXT: "Name",
+        DESCRIPTION: "",
+      },
+    ]);
+    expect(env.messaging.added).toHaveLength(1);
+    expect(env.messaging.added[0]).toMatchObject({
+      message: "A mandatory field is required",
+      type: "Error",
+      target: "/NAME",
+      additionalText: "Name",
+      processor: env.PROCESSOR,
+    });
+    expect(env.messaging.removed).toHaveLength(0);
+  });
+
+  test("reconciling the same table twice does not re-add (dedup by key)", () => {
+    const env = load();
+    const ext = makeExt(env);
+    ext.init();
+    ext.setup();
+    const rows = [{ MESSAGE: "A", TYPE: "Error", TARGET: "/X" }];
+    ext.setItems(rows);
+    ext.setItems([{ MESSAGE: "A", TYPE: "Error", TARGET: "/X" }]); // same key
+    expect(env.messaging.added).toHaveLength(1);
+    expect(env.messaging.removed).toHaveLength(0);
+  });
+
+  test("removes the control's own row when it drops out of the table", () => {
+    const env = load();
+    const ext = makeExt(env);
+    ext.init();
+    ext.setup();
+    ext.setItems([
+      { MESSAGE: "A", TYPE: "Error", TARGET: "/X" },
+      { MESSAGE: "B", TYPE: "Warning", TARGET: "/Y" },
+    ]);
+    expect(env.messaging.added).toHaveLength(2);
+    ext.setItems([{ MESSAGE: "A", TYPE: "Error", TARGET: "/X" }]); // B gone
+    expect(env.messaging.removed).toHaveLength(1);
+    expect(env.messaging.removed[0]).toMatchObject({ message: "B" });
+  });
+
+  test("never removes messages it did not add (auto-collected validation)", () => {
+    const env = load();
+    // a validation message already sits in the manager, not added by the cc
+    env.messaging.added.push({ message: "auto", type: "Error", foreign: true });
+    const ext = makeExt(env);
+    ext.init();
+    ext.setup();
+    ext.setItems([]); // empty app table
+    expect(env.messaging.removed).toHaveLength(0); // the foreign message stays
+  });
+
+  test("defers reconcile until setup when items arrive before ready", () => {
+    const env = load();
+    const ext = makeExt(env);
+    ext.init();
+    // items set before onAfterRendering/setup: no messaging yet, no add
+    ext.setItems([{ MESSAGE: "A", TYPE: "Error", TARGET: "/X" }]);
+    expect(env.messaging.added).toHaveLength(0);
+    ext.setup(); // becomes ready -> reconciles the stored items
+    expect(env.messaging.added).toHaveLength(1);
+  });
+});

--- a/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `// z2ui5.Util: the implementations live here, Util.js re-exports them as` && |\n| &&
              `// the stable legacy alias. Their names and behavior are a public contract` && |\n| &&
              `// - do not rename or change them.` && |\n| &&
-             `sap.ui.define([], () => {` && |\n| &&
+             `sap.ui.define(["sap/ui/core/IconPool"], (IconPool) => {` && |\n| &&
              `  "use strict";` && |\n| &&
              `` && |\n| &&
              `  // Splits an 8-character ABAP date string "YYYYMMDD" into the [year, month,` && |\n| &&
@@ -150,6 +150,25 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `      if (status === "Shipped") return "Success";` && |\n| &&
              `      if (status === "Failed Shipping") return "Error";` && |\n| &&
              `      return "None";` && |\n| &&
+             `    },` && |\n| &&
+             `` && |\n| &&
+             `    // Replace %%icon:sap-icon://<name>%% placeholders in a formatted-text` && |\n| &&
+             `    // string with the inline-icon markup MessageStrip formatted text expects` && |\n| &&
+             `    // (mirrors sap.m.MessageStripUtilities.getInlineIcon). The glyph is` && |\n| &&
+             `    // resolved from the icon font via IconPool - CSP-clean, no code` && |\n| &&
+             `    // generation. Plain text passes through unchanged; an unknown icon name` && |\n| &&
+             `    // is dropped. Used as a whole-string formatter on a MessageStrip text` && |\n| &&
+             `    // binding (sap.m.sample.MessageStripWithEnableFormattedText).` && |\n| &&
+             `    expandInlineIcons(text) {` && |\n| &&
+             `      if (!text) return "";` && |\n| &&
+             `      return String(text).replace(` && |\n| &&
+             `        /%%icon:(sap-icon:\/\/[^%]+)%%/g,` && |\n| &&
+             `        (match, uri) => {` && |\n| &&
+             `          const info = IconPool.getIconInfo(uri);` && |\n| &&
+             `          if (!info) return "";` && |\n| &&
+             `          return ``<span class="sapMMsgStripInlineIcon" style="font-family:'${info.fontFamily}'">${info.content}</span>``;` && |\n| &&
+             `        },` && |\n| &&
+             `      );` && |\n| &&
              `    },` && |\n| &&
              `  };` && |\n| &&
              `});` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -106,6 +106,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      setNextStep: ["controlId"],` && |\n| &&
              `      goToStep: ["controlId", "bool"], // Wizard: target step + focus flag` && |\n| &&
              `      openBy: ["domRef"], // DatePicker/TimePicker/Menu... anchored open` && |\n| &&
+             `      toggleBy: ["domRef"], // sap.m.Menu/Popover: open anchored if closed, close if open` && |\n| &&
              `      setActivePage: ["controlId"], // sap.m.Carousel` && |\n| &&
              `      expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels` && |\n| &&
              `      collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node` && |\n| &&
@@ -193,6 +194,23 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const control = view` && |\n| &&
              `        ? ViewSlots.byId(view.toUpperCase(), id)` && |\n| &&
              `        : ViewSlots.resolveById(id);` && |\n| &&
+             `      // toggleBy is not a real control method: open the control anchored to` && |\n| &&
+             `      // the domRef if it is closed, close it if it is already open (mirrors` && |\n| &&
+             `      // openBy for a press-to-toggle button). The popup's open state lives` && |\n| &&
+             `      // client-side, so the decision stays here rather than round-tripping.` && |\n| &&
+             `      if (method === "toggleBy") {` && |\n| &&
+             `        if (!control || typeof control.openBy !== "function") {` && |\n| &&
+             `          Lib.logError(``CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'``);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        const anchor = castArgs(kinds, args.slice(4), view)[0];` && |\n| &&
+             `        if (control.isOpen?.()) {` && |\n| &&
+             `          control.close();` && |\n| &&
+             `        } else {` && |\n| &&
+             `          control.openBy(anchor);` && |\n| &&
+             `        }` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
              `      if (!control || typeof control[method] !== "function") {` && |\n| &&
              `        Lib.logError(` && |\n| &&
              `          ``CONTROL_BY_ID: '${method}' not callable on control '${id}'``,` && |\n| &&
@@ -399,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    function evCrossAppNavToPrevApp() {` && |\n| &&
              `      withCrossAppNavigator((nav) => nav.backToPreviousApp());` && |\n| &&
              `    }` && |\n| &&
-             `` && |\n| &&
+             `` && |\n|.
+    result = result &&
              `    function evSetSizeLimit(oController, args) {` && |\n| &&
              `      // Two call shapes:` && |\n| &&
              `      //   ["SET_SIZE_LIMIT", "<limit>", "<viewKey>"]   -> set the limit` && |\n| &&
@@ -417,8 +436,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `      if (model) {` && |\n| &&
              `        // 100 is the UI5 JSONModel default size limit.` && |\n| &&
-             `        model.setSizeLimit(isValidLimit ? limit : 100);` && |\n|.
-    result = result &&
+             `        model.setSizeLimit(isValidLimit ? limit : 100);` && |\n| &&
              `        model.refresh(true);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
@@ -800,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `` && |\n| &&
              `    function evZ2ui5Custom(oController, args) {` && |\n| &&
              `      try {` && |\n| &&
-             `        // Custom functions are registered by apps on the public z2ui5` && |\n| &&
+             `        // Custom functions are registered by apps on the public z2ui5` && |\n|.
+    result = result &&
              `        // global (js_loader popup), so resolve them via the facade.` && |\n| &&
              `        const fn = AppState.getGlobal(args[1]);` && |\n| &&
              `        if (typeof fn === "function") {` && |\n| &&
@@ -818,8 +837,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `` && |\n| &&
              `    function evWizardSetNextStep(oController, args) {` && |\n| &&
              `      try {` && |\n| &&
-             `        const wiz = ViewSlots.byId("MAIN", args[1]);` && |\n|.
-    result = result &&
+             `        const wiz = ViewSlots.byId("MAIN", args[1]);` && |\n| &&
              `        const step = ViewSlots.byId("MAIN", args[2]);` && |\n| &&
              `        const nextStep = ViewSlots.byId("MAIN", args[3]);` && |\n| &&
              `        if (wiz && step) wiz.discardProgress(step);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -200,7 +200,9 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // client-side, so the decision stays here rather than round-tripping.` && |\n| &&
              `      if (method === "toggleBy") {` && |\n| &&
              `        if (!control || typeof control.openBy !== "function") {` && |\n| &&
-             `          Lib.logError(``CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'``);` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``CONTROL_BY_ID: 'toggleBy' not callable on control '${id}'``,` && |\n| &&
+             `          );` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        const anchor = castArgs(kinds, args.slice(4), view)[0];` && |\n| &&
@@ -415,10 +417,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evCrossAppNavToPrevApp() {` && |\n| &&
-             `      withCrossAppNavigator((nav) => nav.backToPreviousApp());` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n|.
+             `      withCrossAppNavigator((nav) => nav.backToPreviousApp());` && |\n|.
     result = result &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function evSetSizeLimit(oController, args) {` && |\n| &&
              `      // Two call shapes:` && |\n| &&
              `      //   ["SET_SIZE_LIMIT", "<limit>", "<viewKey>"]   -> set the limit` && |\n| &&
@@ -816,10 +818,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function evZ2ui5Custom(oController, args) {` && |\n| &&
-             `      try {` && |\n| &&
-             `        // Custom functions are registered by apps on the public z2ui5` && |\n|.
+             `    function evZ2ui5Custom(oController, args) {` && |\n|.
     result = result &&
+             `      try {` && |\n| &&
+             `        // Custom functions are registered by apps on the public z2ui5` && |\n| &&
              `        // global (js_loader popup), so resolve them via the facade.` && |\n| &&
              `        const fn = AppState.getGlobal(args[1]);` && |\n| &&
              `        if (typeof fn === "function") {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
@@ -32,9 +32,7 @@ CLASS z2ui5_cl_app_messagemanager_js IMPLEMENTATION.
              `    // the same problem (same text, type and target) map to the same key, so` && |\n| &&
              `    // reconciling never adds a duplicate or drops a still-wanted message.` && |\n| &&
              `    const keyOf = (o) =>` && |\n| &&
-             `      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join(` && |\n| &&
-             `        "",` && |\n| &&
-             `      );` && |\n| &&
+             `      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join("");` && |\n| &&
              `` && |\n| &&
              `    // Invisible companion control that bridges the UI5 message manager to a` && |\n| &&
              `    // two-way bound ABAP table (``items``). The table is the app's OWN messages:` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
@@ -1,0 +1,133 @@
+CLASS z2ui5_cl_app_messagemanager_js DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      RETURNING
+        VALUE(result) TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_app_messagemanager_js IMPLEMENTATION.
+
+  METHOD get.
+
+    result = `sap.ui.define(` && |\n| &&
+             `  [` && |\n| &&
+             `    "sap/ui/core/Control",` && |\n| &&
+             `    "sap/ui/core/message/Message",` && |\n| &&
+             `    "z2ui5/core/Lib",` && |\n| &&
+             `    "z2ui5/core/ViewSlots",` && |\n| &&
+             `  ],` && |\n| &&
+             `  (Control, Message, Lib, ViewSlots) => {` && |\n| &&
+             `    "use strict";` && |\n| &&
+             `` && |\n| &&
+             `    // A message key that is stable across a round-trip: two rows describing` && |\n| &&
+             `    // the same problem (same text, type and target) map to the same key, so` && |\n| &&
+             `    // reconciling never adds a duplicate or drops a still-wanted message.` && |\n| &&
+             `    const keyOf = (o) =>` && |\n| &&
+             `      [o.MESSAGE ?? o.message, o.TYPE ?? o.type, o.TARGET ?? o.target].join(` && |\n| &&
+             `        "",` && |\n| &&
+             `      );` && |\n| &&
+             `` && |\n| &&
+             `    // Invisible companion control that bridges the UI5 message manager to a` && |\n| &&
+             `    // two-way bound ABAP table (``items``). The table is the app's OWN messages:` && |\n| &&
+             `    // on every backend update the control reconciles the message manager to` && |\n| &&
+             `    // match it - adding new rows as sap.ui.core.message.Message objects (with` && |\n| &&
+             `    // a target + the view's model as processor, so they set the bound field's` && |\n| &&
+             `    // valueState) and removing the app rows that are gone. Messages the` && |\n| &&
+             `    // framework auto-collects from binding-type/constraint validation stay in` && |\n| &&
+             `    // the message> model untouched; a MessagePopover bound to {message>/}` && |\n| &&
+             `    // shows both. Mirrors the MultiInputExt companion-control pattern.` && |\n| &&
+             `    return Control.extend("z2ui5.cc.MessageManager", {` && |\n| &&
+             `      metadata: {` && |\n| &&
+             `        properties: {` && |\n| &&
+             `          items: { type: "object" },` && |\n| &&
+             `          checkInit: { type: "boolean", defaultValue: false },` && |\n| &&
+             `        },` && |\n| &&
+             `        events: {` && |\n| &&
+             `          change: { allowPreventDefault: true, parameters: {} },` && |\n| &&
+             `        },` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      init() {` && |\n| &&
+             `        // Messages this control has added, by key, so it removes exactly its` && |\n| &&
+             `        // own rows and never touches auto-collected validation messages.` && |\n| &&
+             `        this._added = new Map();` && |\n| &&
+             `        this._ready = false;` && |\n| &&
+             `        this._setupBound = this.setup.bind(this);` && |\n| &&
+             `        Lib.registerCallback("onAfterRendering", this._setupBound);` && |\n| &&
+             `      },` && |\n| &&
+             `      exit() {` && |\n| &&
+             `        Lib.unregisterCallback("onAfterRendering", this._setupBound);` && |\n| &&
+             `      },` && |\n| &&
+             `      renderer: { apiVersion: 2, render() {} },` && |\n| &&
+             `` && |\n| &&
+             `      setup() {` && |\n| &&
+             `        if (this.getProperty("checkInit")) return;` && |\n| &&
+             `        const messaging = Lib.getMessaging?.();` && |\n| &&
+             `        if (!messaging) return;` && |\n| &&
+             `        this.setProperty("checkInit", true);` && |\n| &&
+             `        this._messaging = messaging;` && |\n| &&
+             `        const view = ViewSlots.getView(` && |\n| &&
+             `          ViewSlots.containingSlotKey(this) ?? "MAIN",` && |\n| &&
+             `        );` && |\n| &&
+             `        this._processor = view?.getModel?.() ?? null;` && |\n| &&
+             `        this._ready = true;` && |\n| &&
+             `        // reconcile whatever arrived before the control was ready` && |\n| &&
+             `        this.reconcile();` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      // property setter override: the two-way binding calls this when the` && |\n| &&
+             `      // backend ships a new message table (base setProperty is used for the` && |\n| &&
+             `      // internal store, so it never re-enters here)` && |\n| &&
+             `      setItems(aItems) {` && |\n| &&
+             `        this.setProperty("items", aItems, true);` && |\n| &&
+             `        if (this._ready) this.reconcile();` && |\n| &&
+             `        return this;` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      // Bring the message manager in line with the ``items`` table: add rows` && |\n| &&
+             `      // that are not yet present, remove the control's own rows that are gone.` && |\n| &&
+             `      reconcile() {` && |\n| &&
+             `        const rows = this.getProperty("items") || [];` && |\n| &&
+             `        const wanted = new Map(rows.map((r) => [keyOf(r), r]));` && |\n| &&
+             `` && |\n| &&
+             `        // remove app rows no longer wanted` && |\n| &&
+             `        for (const [key, oMessage] of this._added) {` && |\n| &&
+             `          if (!wanted.has(key)) {` && |\n| &&
+             `            this._messaging.removeMessages(oMessage);` && |\n| &&
+             `            this._added.delete(key);` && |\n| &&
+             `          }` && |\n| &&
+             `        }` && |\n| &&
+             `        // add newly wanted rows` && |\n| &&
+             `        for (const [key, r] of wanted) {` && |\n| &&
+             `          if (this._added.has(key)) continue;` && |\n| &&
+             `          const oMessage = new Message({` && |\n| &&
+             `            message: r.MESSAGE ?? "",` && |\n| &&
+             `            description: r.DESCRIPTION ?? "",` && |\n| &&
+             `            type: r.TYPE ?? "Error",` && |\n| &&
+             `            target: r.TARGET ?? "",` && |\n| &&
+             `            additionalText: r.ADDITIONALTEXT ?? "",` && |\n| &&
+             `            processor: this._processor,` && |\n| &&
+             `          });` && |\n| &&
+             `          this._messaging.addMessages(oMessage);` && |\n| &&
+             `          this._added.set(key, oMessage);` && |\n| &&
+             `        }` && |\n| &&
+             `        this.fireChange();` && |\n| &&
+             `      },` && |\n| &&
+             `    });` && |\n| &&
+             `  },` && |\n| &&
+             `);` && |\n| &&
+             `` && |\n| &&
+              ``.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/03/z2ui5_cl_app_messagemanager_js.clas.xml
+++ b/src/01/03/z2ui5_cl_app_messagemanager_js.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_APP_MESSAGEMANAGER_JS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abap2UI5 - MessageManager.js</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/01/03/z2ui5_cl_app_preload.clas.abap
+++ b/src/01/03/z2ui5_cl_app_preload.clas.abap
@@ -31,6 +31,7 @@ CLASS z2ui5_cl_app_preload IMPLEMENTATION.
              |      "z2ui5/cc/History.js": function()\{{ z2ui5_cl_app_history_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/Info.js": function()\{{ z2ui5_cl_app_info_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/LPTitle.js": function()\{{ z2ui5_cl_app_lptitle_js=>get( ) }\},| && |\n| &&
+             |      "z2ui5/cc/MessageManager.js": function()\{{ z2ui5_cl_app_messagemanager_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/MultiInputExt.js": function()\{{ z2ui5_cl_app_multiinputext_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/Scrolling.js": function()\{{ z2ui5_cl_app_scrolling_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/SmartMultiInputExt.js": function()\{{ z2ui5_cl_app_smartmultiinpu_js=>get( ) }\},| && |\n| &&


### PR DESCRIPTION
…lineIcons

Two additive frontend capabilities requested by the abap2UI5-api demo-kit port batch b07:

- CONTROL_METHODS gains toggleBy: ["domRef"] — like openBy, but opens the control anchored to the DOM ref if closed and closes it if already open (control.isOpen() ? close() : openBy(anchor)). The popup's open state lives client-side, so a press-to-toggle button (sap.m.Menu/Popover) now round-trips 1:1 without the backend mirroring open/closed state. Unit tests added.

- model/formatter.js gains expandInlineIcons(text): replaces %%icon:sap-icon://<name>%% placeholders with the inline-icon markup MessageStrip formatted text expects (mirrors sap.m.MessageStripUtilities.getInlineIcon), resolving the glyph via sap.ui.core.IconPool — CSP-clean, no code generation. A whole-string formatter on a MessageStrip text binding renders real inline icons without the app hardcoding icon-font codepoints. Unit tests added.

Regenerated the embedded frontend (app2abap): this also resyncs the FrontendAction embed with the Tree expandToLevel/collapseAll whitelist entries that were added to the JS source in #2442 but not yet regenerated.


Claude-Session: https://claude.ai/code/session_01M4yuDTkJkCrG37W7tpPL6s

# Description

<!-- A clear description of what this PR changes and why the change is needed. -->

## How to test

<!-- Steps to verify the change: app snippet, test to run, or scenario to click through. -->

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no
