### PR TITLE
Remove unused z2ui5_if_action interface from documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,6 @@ src/
 │   ├── z2ui5_if_app.intf.abap          # Main app interface (version constant)
 │   ├── z2ui5_if_client.intf.abap       # Client interaction methods
 │   ├── z2ui5_if_types.intf.abap        # Shared type definitions
-│   ├── z2ui5_if_action.intf.abap       # Generic action interface (gen method)
 │   ├── z2ui5_if_exit.intf.abap         # Customization exit points
 │   ├── z2ui5_cl_http_handler.clas.abap # HTTP entry point
 │   ├── z2ui5_cl_xml_view.clas.abap     # Fluent XML view builder (~850KB)


### PR DESCRIPTION
# Description

This PR removes the reference to `z2ui5_if_action.intf.abap` from the AGENTS.md documentation. The interface is no longer part of the codebase and should not be listed in the project structure documentation.

## How to test

N/A - Documentation-only change

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01QUrKMhizsH7gGX4kDVftxq