### PR TITLE
Remove XX model prefix from paths and API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ Browser (UI5 SPA)                          ABAP Backend
        │──── HTTP GET ─────────────────────────→│  Returns HTML + embedded UI5 app
        │←─── HTML page ────────────────────────│
        │                                        │
-       │──── POST {S_FRONT, XX model} ────────→│  1. Parse JSON request
+       │──── POST {S_FRONT, MODEL} ────────────→│  1. Parse JSON request
        │                                        │  2. Load draft (session) from DB
-       │                                        │  3. Apply model changes (XX → ABAP vars)
+       │                                        │  3. Apply model changes (MODEL → ABAP vars)
        │                                        │  4. Call app->main(client)
        │                                        │  5. App builds view / handles events
        │                                        │  6. Save new draft to DB
@@ -48,7 +48,7 @@ Browser (UI5 SPA)                          ABAP Backend
        │──── POST (next event) ───────────────→│  ... repeat
 ```
 
-**Request JSON** contains `S_FRONT` (event name, draft ID, browser state) and `XX` (two-way binding changes as deltas).
+**Request JSON** contains `S_FRONT` (event name, draft ID, browser state) and `MODEL` (view model changes as deltas).
 **Response JSON** contains a new draft ID, view XML strings (if view changed), the full JSON model, messages, and follow-up actions.
 
 #### Launchpad Special Case — Request Body Wrapping
@@ -117,14 +117,20 @@ The framework provides **transparent two-way data binding** between ABAP variabl
 
 | Method | Path Format | Direction | Use Case |
 |---|---|---|---|
-| `client->_bind_edit(var)` | `{/XX/attribute}` | ABAP ↔ UI (two-way) | Input fields, editable data |
-| `client->_bind(var)` | `{/attribute}` | ABAP → UI (read-only) | Display fields, labels |
+| `client->_bind(var)` | `{/attribute}` | ABAP ↔ UI (two-way) | Any bound data — input, display, tables |
+| `client->_bind_edit(var)` | `{/attribute}` | ABAP ↔ UI (two-way) | Obsolete alias of `_bind`, kept for compatibility |
 
 **How it works:**
-1. When you call `_bind_edit(name)`, the framework discovers the ABAP attribute via RTTI and maps it to a UI5 model path `/XX/name`
+1. When you call `_bind(name)`, the framework discovers the ABAP attribute via RTTI and maps it to a UI5 model path `/name`
 2. On outbound (ABAP → browser): all bound attributes are serialized to JSON and sent as `MODEL`
-3. On inbound (browser → ABAP): only `/XX/` prefixed attributes (two-way) are read back from the request and written into the ABAP variables
+3. On inbound (browser → ABAP): the edited model paths are read back from the request `MODEL` container and written into the ABAP variables
 4. Table bindings use **delta updates** — only changed rows/cells are transferred
+
+> **Historical note:** two-way data used to live under a dedicated `XX/` view-model
+> node (`_bind_edit` → `/XX/name`) so the frontend knew which subtree to transport
+> back, while `_bind` wrote read-only data to the root. Delta handling made that
+> separation obsolete: everything is now written to the root model the same way and
+> `_bind`/`_bind_edit` behave identically.
 
 ### Session Persistence (Draft Service)
 

--- a/app/webapp/cc/Scrolling.js
+++ b/app/webapp/cc/Scrolling.js
@@ -49,7 +49,7 @@ sap.ui.define(
         if (!items) return;
         try {
           // Resolve the binding path so we can mark only changed entries
-          // as dirty in xxChangedPaths.
+          // as dirty in changedPaths.
           const bindingInfo = this.getBindingInfo("items");
           const bindingPath =
             bindingInfo?.parts?.[0]?.path ?? bindingInfo?.path;
@@ -58,7 +58,7 @@ sap.ui.define(
             if (item.V !== scrollTop) {
               item.V = scrollTop;
               if (bindingPath) {
-                AppState.state.xxChangedPaths.add(`${bindingPath}/${index}/V`);
+                AppState.state.changedPaths.add(`${bindingPath}/${index}/V`);
               }
             }
           }

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -47,7 +47,7 @@ sap.ui.define(
 
     return Controller.extend("z2ui5.controller.View1", {
       // ------------------------------------------------------------------
-      // Model change tracking - remembers which /XX/ paths the user edited
+      // Model change tracking - remembers which model paths the user edited
       // so the next roundtrip only ships the delta.
       // ------------------------------------------------------------------
       _trackChanges(oModel) {
@@ -62,8 +62,8 @@ sap.ui.define(
           // Resolve relative paths against the binding context.
           const changedPath =
             ctx && !raw.startsWith("/") ? `${ctx.getPath()}/${raw}` : raw;
-          if (changedPath.startsWith("/XX/")) {
-            AppState.state.xxChangedPaths.add(changedPath);
+          if (changedPath.startsWith("/")) {
+            AppState.state.changedPaths.add(changedPath);
           }
         });
         return oModel;
@@ -386,15 +386,14 @@ sap.ui.define(
 
         Lib.runCallbacks(AppState.state.onBeforeRoundtrip);
 
-        // If the user edited /XX/ paths, send only the delta to keep the
+        // If the user edited model paths, send only the delta to keep the
         // payload small.
-        if (oModel && AppState.state.xxChangedPaths.size > 0) {
+        if (oModel && AppState.state.changedPaths.size > 0) {
           const data = oModel.getData();
-          const xx = data?.XX;
-          if (xx) {
-            oBody.XX = Lib.buildDeltaFromPaths(
-              AppState.state.xxChangedPaths,
-              xx,
+          if (data) {
+            oBody.MODEL = Lib.buildDeltaFromPaths(
+              AppState.state.changedPaths,
+              data,
             );
           }
         }

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -61,7 +61,7 @@
 //                     the developer tools)
 //   contextId         stateful session id, header transport (Server)
 //   isBusy            roundtrip in flight (View1.eB / Server)
-//   xxChangedPaths    Set of edited /XX/ model paths for the delta (View1)
+//   changedPaths      Set of edited model paths for the delta (View1)
 //   checkNestAfter, checkNestAfter2  nested views rebuilt this roundtrip
 //   search            overrides location.search in S_FRONT; never written
 //                     by the framework itself, set externally (custom JS)
@@ -107,7 +107,7 @@ sap.ui.define([], () => {
       responseData: null,
       contextId: null,
       isBusy: false,
-      xxChangedPaths: new Set(),
+      changedPaths: new Set(),
       checkNestAfter: false,
       checkNestAfter2: false,
       search: null,

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -329,23 +329,23 @@ sap.ui.define(
     }
 
     // Build the delta object sent to the backend. `paths` is the set of
-    // /XX/... paths that the user edited; `xx` is the full XX model data.
+    // model paths that the user edited; `model` is the full view model data.
     // Table edits become (recursively nested) __delta structures, so a cell
     // edit in a nested/tree table ships only the changed cell instead of
     // the whole outer table.
-    function buildDeltaFromPaths(paths, xx) {
+    function buildDeltaFromPaths(paths, modelData) {
       const delta = {};
       for (const path of paths) {
-        // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>" with
+        // path looks like "/<attr>" or "/<attr>/<row>/<field>" with
         // arbitrarily deep <row>/<subtable> repetitions for nested tables
-        const parts = path.slice(4).split("/");
+        const parts = path.slice(1).split("/");
         const attr = parts[0];
         const steps = parseDeltaSteps(parts.slice(1));
         if (!steps) {
           // Scalar or unrecognized shape -> ship the whole attribute. The
           // full value always wins over any queued delta: both read the
           // same current model data, so it is a superset of every delta.
-          delta[attr] = xx[attr];
+          delta[attr] = modelData[attr];
           continue;
         }
         // A full attribute queued by another path already carries every
@@ -354,7 +354,7 @@ sap.ui.define(
         if (attr in delta && !delta[attr]?.__delta) continue;
         if (!delta[attr]?.__delta) delta[attr] = { __delta: {} };
         let node = delta[attr];
-        let model = xx[attr];
+        let model = modelData[attr];
         for (const { row, field, leaf } of steps) {
           const rows = node.__delta;
           if (!rows[row]) rows[row] = {};

--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -117,7 +117,7 @@ sap.ui.define(
     // Wire format - request (POST body; VIEWNAME/ARGUMENTS are folded into
     // S_FRONT before sending, empty fields are removed):
     //   { "value": {
-    //       "XX": {                        // two-way model delta
+    //       "MODEL": {                     // view model delta
     //         "NAME": "new value",         //   scalar: full attribute
     //         "TAB": { "__delta": { "0": { "COL1": "new cell" } } }
     //       },
@@ -146,7 +146,7 @@ sap.ui.define(
     //         "SET_NAV_BACK": ""           // browser/history follow-ups
     //       }
     //     },
-    //     "MODEL": { "XX": {...}, ... }    // full JSON view model, becomes
+    //     "MODEL": { "NAME": ..., ... }    // full JSON view model, becomes
     //   }                                  // the view's binding model
     //
     // Inspect live payloads via the developer tools (Ctrl+F12): "Previous
@@ -427,7 +427,7 @@ sap.ui.define(
         // and these keys are not present in the JSON sent over the wire.
         if (!sFront.T_EVENT_ARG?.length) delete sFront.T_EVENT_ARG;
         if (sFront.SEARCH === "") delete sFront.SEARCH;
-        if (!oBody.XX) delete oBody.XX;
+        if (!oBody.MODEL) delete oBody.MODEL;
 
         this.readHttp(oBody);
       },
@@ -592,7 +592,7 @@ sap.ui.define(
 
           // Step 4: hand the parsed response to the success handler.
           AppState.state.responseData = responseData;
-          AppState.state.xxChangedPaths = new Set();
+          AppState.state.changedPaths = new Set();
           this.responseSuccess({
             ID: responseData.S_FRONT.ID,
             PARAMS: responseData.S_FRONT.PARAMS,

--- a/node/tests/appState.spec.js
+++ b/node/tests/appState.spec.js
@@ -33,7 +33,7 @@ test.describe("initGlobal", () => {
     expect(ctx.z2ui5.timers).toEqual({});
     expect(ctx.z2ui5.viewSizeLimits).toEqual({});
     expect(ctx.z2ui5.onBeforeRoundtrip).toEqual([]);
-    expect(ctx.z2ui5.xxChangedPaths.size).toBe(0);
+    expect(ctx.z2ui5.changedPaths.size).toBe(0);
   });
 
   test("keeps an existing global object", () => {

--- a/node/tests/buildDeltaFromPaths.spec.js
+++ b/node/tests/buildDeltaFromPaths.spec.js
@@ -8,7 +8,7 @@ const { Lib } = loadLib();
 const _buildDeltaFromPaths = Lib.buildDeltaFromPaths;
 
 // ── Test data ───────────────────────────────────────────────────────────
-const SAMPLE_XX = {
+const SAMPLE_MODEL = {
   NAME: "Max Mustermann",
   STATUS: "ACTIVE",
   COUNT: 42,
@@ -26,14 +26,14 @@ const SAMPLE_XX = {
 // ── 1. Simple properties ────────────────────────────────────────────────
 test.describe("Simple property changes", () => {
   test("single scalar property", () => {
-    const paths = new Set(["/XX/NAME"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/NAME"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({ NAME: "Max Mustermann" });
   });
 
   test("multiple scalar properties", () => {
-    const paths = new Set(["/XX/NAME", "/XX/STATUS"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/NAME", "/STATUS"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       NAME: "Max Mustermann",
       STATUS: "ACTIVE",
@@ -41,8 +41,8 @@ test.describe("Simple property changes", () => {
   });
 
   test("numeric scalar property", () => {
-    const paths = new Set(["/XX/COUNT"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/COUNT"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({ COUNT: 42 });
   });
 });
@@ -50,24 +50,24 @@ test.describe("Simple property changes", () => {
 // ── 2. Table cell edits (delta) ─────────────────────────────────────────
 test.describe("Table cell edits → __delta", () => {
   test("single cell edit", () => {
-    const paths = new Set(["/XX/TABLE1/0/COL1"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/0/COL1"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 0: { COL1: "A1" } } },
     });
   });
 
   test("multiple cells in same row", () => {
-    const paths = new Set(["/XX/TABLE1/1/COL1", "/XX/TABLE1/1/COL2"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/1/COL1", "/TABLE1/1/COL2"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 1: { COL1: "A2", COL2: "B2" } } },
     });
   });
 
   test("cells in different rows", () => {
-    const paths = new Set(["/XX/TABLE1/0/COL1", "/XX/TABLE1/2/COL3"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/0/COL1", "/TABLE1/2/COL3"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: {
         __delta: {
@@ -79,8 +79,8 @@ test.describe("Table cell edits → __delta", () => {
   });
 
   test("cells in different tables", () => {
-    const paths = new Set(["/XX/TABLE1/0/COL1", "/XX/TABLE2/1/VALUE"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/0/COL1", "/TABLE2/1/VALUE"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 0: { COL1: "A1" } } },
       TABLE2: { __delta: { 1: { VALUE: "200" } } },
@@ -89,17 +89,17 @@ test.describe("Table cell edits → __delta", () => {
 
   test("all cells in every row of a table", () => {
     const paths = new Set([
-      "/XX/TABLE1/0/COL1",
-      "/XX/TABLE1/0/COL2",
-      "/XX/TABLE1/0/COL3",
-      "/XX/TABLE1/1/COL1",
-      "/XX/TABLE1/1/COL2",
-      "/XX/TABLE1/1/COL3",
-      "/XX/TABLE1/2/COL1",
-      "/XX/TABLE1/2/COL2",
-      "/XX/TABLE1/2/COL3",
+      "/TABLE1/0/COL1",
+      "/TABLE1/0/COL2",
+      "/TABLE1/0/COL3",
+      "/TABLE1/1/COL1",
+      "/TABLE1/1/COL2",
+      "/TABLE1/1/COL3",
+      "/TABLE1/2/COL1",
+      "/TABLE1/2/COL2",
+      "/TABLE1/2/COL3",
     ]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: {
         __delta: {
@@ -115,8 +115,8 @@ test.describe("Table cell edits → __delta", () => {
 // ── 3. Mixed: scalars + table cells ─────────────────────────────────────
 test.describe("Mixed changes (scalar + table)", () => {
   test("scalar and table cell together", () => {
-    const paths = new Set(["/XX/NAME", "/XX/TABLE1/2/COL2"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/NAME", "/TABLE1/2/COL2"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       NAME: "Max Mustermann",
       TABLE1: { __delta: { 2: { COL2: "B3" } } },
@@ -125,12 +125,12 @@ test.describe("Mixed changes (scalar + table)", () => {
 
   test("multiple scalars and multiple table cells", () => {
     const paths = new Set([
-      "/XX/NAME",
-      "/XX/STATUS",
-      "/XX/TABLE1/0/COL1",
-      "/XX/TABLE2/1/FIELD",
+      "/NAME",
+      "/STATUS",
+      "/TABLE1/0/COL1",
+      "/TABLE2/1/FIELD",
     ]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       NAME: "Max Mustermann",
       STATUS: "ACTIVE",
@@ -143,24 +143,24 @@ test.describe("Mixed changes (scalar + table)", () => {
 // ── 4. Fallback: whole table / row-level paths ──────────────────────────
 test.describe("Fallback paths → full value", () => {
   test("whole table path sends full array", () => {
-    // e.g. model.setProperty("/XX/TABLE1", newArray)
-    const paths = new Set(["/XX/TABLE1"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
-    expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    // e.g. model.setProperty("/TABLE1", newArray)
+    const paths = new Set(["/TABLE1"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
+    expect(result).toEqual({ TABLE1: SAMPLE_MODEL.TABLE1 });
   });
 
   test("row-level path (2 parts) sends full array", () => {
-    // e.g. model.setProperty("/XX/TABLE1/0", newRow)
-    const paths = new Set(["/XX/TABLE1/0"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
-    expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    // e.g. model.setProperty("/TABLE1/0", newRow)
+    const paths = new Set(["/TABLE1/0"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
+    expect(result).toEqual({ TABLE1: SAMPLE_MODEL.TABLE1 });
   });
 
   test("non-numeric index treated as simple property", () => {
-    // e.g. "/XX/TABLE1/abc" → parts = ["TABLE1","abc"], isNaN("abc") = true → else
-    const paths = new Set(["/XX/TABLE1/abc"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
-    expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    // e.g. "/TABLE1/abc" → parts = ["TABLE1","abc"], isNaN("abc") = true → else
+    const paths = new Set(["/TABLE1/abc"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
+    expect(result).toEqual({ TABLE1: SAMPLE_MODEL.TABLE1 });
   });
 });
 
@@ -168,38 +168,38 @@ test.describe("Fallback paths → full value", () => {
 test.describe("Edge cases", () => {
   test("empty paths set returns empty delta", () => {
     const paths = new Set();
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({});
   });
 
-  test("missing attribute in XX returns undefined", () => {
-    const paths = new Set(["/XX/NONEXISTENT"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+  test("missing attribute returns undefined", () => {
+    const paths = new Set(["/NONEXISTENT"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({ NONEXISTENT: undefined });
   });
 
   test("out-of-bounds row index returns undefined cell value", () => {
-    const paths = new Set(["/XX/TABLE1/99/COL1"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/99/COL1"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 99: { COL1: undefined } } },
     });
   });
 
   test("missing column name returns undefined cell value", () => {
-    const paths = new Set(["/XX/TABLE1/0/NONEXISTENT"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/0/NONEXISTENT"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 0: { NONEXISTENT: undefined } } },
     });
   });
 
   test("struct member below a field ships the whole field value", () => {
-    // "/XX/TABLE1/0/COL1/deep" → COL1 carries something deeper, so the
+    // "/TABLE1/0/COL1/deep" → COL1 carries something deeper, so the
     // whole current value at row 0 / COL1 is shipped as the leaf - that
     // always covers the deeper edit too.
-    const paths = new Set(["/XX/TABLE1/0/COL1/deep"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1/0/COL1/deep"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
       TABLE1: { __delta: { 0: { COL1: "A1" } } },
     });
@@ -208,7 +208,7 @@ test.describe("Edge cases", () => {
 
 // ── 5b. Tree table (nested sub-table) edits ─────────────────────────────
 test.describe("Tree table nested edits → nested __delta", () => {
-  const TREE_XX = {
+  const TREE_MODEL = {
     MT_TREE: [
       {
         USER: "Manager",
@@ -223,9 +223,9 @@ test.describe("Tree table nested edits → nested __delta", () => {
   };
 
   test("checkbox on a tree child node ships a nested cell delta", () => {
-    // UI5 tree table edit path: /XX/MT_TREE/0/NODES/1/VALIDATED
-    const paths = new Set(["/XX/MT_TREE/0/NODES/1/VALIDATED"]);
-    const result = _buildDeltaFromPaths(paths, TREE_XX);
+    // UI5 tree table edit path: /MT_TREE/0/NODES/1/VALIDATED
+    const paths = new Set(["/MT_TREE/0/NODES/1/VALIDATED"]);
+    const result = _buildDeltaFromPaths(paths, TREE_MODEL);
     expect(result).toEqual({
       MT_TREE: {
         __delta: {
@@ -236,8 +236,8 @@ test.describe("Tree table nested edits → nested __delta", () => {
   });
 
   test("edit on a tree root node still uses a flat cell delta", () => {
-    const paths = new Set(["/XX/MT_TREE/0/VALIDATED"]);
-    const result = _buildDeltaFromPaths(paths, TREE_XX);
+    const paths = new Set(["/MT_TREE/0/VALIDATED"]);
+    const result = _buildDeltaFromPaths(paths, TREE_MODEL);
     expect(result).toEqual({
       MT_TREE: { __delta: { 0: { VALIDATED: false } } },
     });
@@ -245,11 +245,11 @@ test.describe("Tree table nested edits → nested __delta", () => {
 
   test("edits on several tree levels merge into one delta", () => {
     const paths = new Set([
-      "/XX/MT_TREE/0/ENABLED",
-      "/XX/MT_TREE/0/NODES/0/USER",
-      "/XX/MT_TREE/0/NODES/1/VALIDATED",
+      "/MT_TREE/0/ENABLED",
+      "/MT_TREE/0/NODES/0/USER",
+      "/MT_TREE/0/NODES/1/VALIDATED",
     ]);
-    const result = _buildDeltaFromPaths(paths, TREE_XX);
+    const result = _buildDeltaFromPaths(paths, TREE_MODEL);
     expect(result).toEqual({
       MT_TREE: {
         __delta: {
@@ -268,11 +268,11 @@ test.describe("Tree table nested edits → nested __delta", () => {
   });
 
   test("two-level nesting ships only the innermost cell", () => {
-    const DEEP_XX = {
+    const DEEP_MODEL = {
       T_OUTER: [{ T_MID: [{ T_INNER: [{ VAL: "leaf" }] }] }],
     };
-    const paths = new Set(["/XX/T_OUTER/0/T_MID/0/T_INNER/0/VAL"]);
-    const result = _buildDeltaFromPaths(paths, DEEP_XX);
+    const paths = new Set(["/T_OUTER/0/T_MID/0/T_INNER/0/VAL"]);
+    const result = _buildDeltaFromPaths(paths, DEEP_MODEL);
     expect(result).toEqual({
       T_OUTER: {
         __delta: {
@@ -289,11 +289,11 @@ test.describe("Tree table nested edits → nested __delta", () => {
   });
 
   test("struct member inside a row ships the whole struct", () => {
-    const STRUCT_XX = {
+    const STRUCT_MODEL = {
       T_TAB: [{ S_ADR: { CITY: "Berlin", ZIP: "10115" } }],
     };
-    const paths = new Set(["/XX/T_TAB/0/S_ADR/CITY"]);
-    const result = _buildDeltaFromPaths(paths, STRUCT_XX);
+    const paths = new Set(["/T_TAB/0/S_ADR/CITY"]);
+    const result = _buildDeltaFromPaths(paths, STRUCT_MODEL);
     expect(result).toEqual({
       T_TAB: {
         __delta: { 0: { S_ADR: { CITY: "Berlin", ZIP: "10115" } } },
@@ -302,26 +302,26 @@ test.describe("Tree table nested edits → nested __delta", () => {
   });
 
   test("leaf edit on a subtable field wins over its nested delta", () => {
-    // e.g. setProperty("/XX/MT_TREE/0/NODES", newArray) after a cell edit:
+    // e.g. setProperty("/MT_TREE/0/NODES", newArray) after a cell edit:
     // the whole current sub-table replaces the queued nested delta.
     const paths = new Set([
-      "/XX/MT_TREE/0/NODES/1/VALIDATED",
-      "/XX/MT_TREE/0/NODES",
+      "/MT_TREE/0/NODES/1/VALIDATED",
+      "/MT_TREE/0/NODES",
     ]);
-    const result = _buildDeltaFromPaths(paths, TREE_XX);
+    const result = _buildDeltaFromPaths(paths, TREE_MODEL);
     expect(result).toEqual({
-      MT_TREE: { __delta: { 0: { NODES: TREE_XX.MT_TREE[0].NODES } } },
+      MT_TREE: { __delta: { 0: { NODES: TREE_MODEL.MT_TREE[0].NODES } } },
     });
   });
 
   test("nested edit after a whole subtable value keeps the whole value", () => {
     const paths = new Set([
-      "/XX/MT_TREE/0/NODES",
-      "/XX/MT_TREE/0/NODES/1/VALIDATED",
+      "/MT_TREE/0/NODES",
+      "/MT_TREE/0/NODES/1/VALIDATED",
     ]);
-    const result = _buildDeltaFromPaths(paths, TREE_XX);
+    const result = _buildDeltaFromPaths(paths, TREE_MODEL);
     expect(result).toEqual({
-      MT_TREE: { __delta: { 0: { NODES: TREE_XX.MT_TREE[0].NODES } } },
+      MT_TREE: { __delta: { 0: { NODES: TREE_MODEL.MT_TREE[0].NODES } } },
     });
   });
 });
@@ -340,7 +340,7 @@ test.describe("Row insert/delete scenarios", () => {
       ],
     };
     // After roundtrip, Set was reset. User now edits cell in new row 3:
-    const paths = new Set(["/XX/TABLE1/3/COL2"]);
+    const paths = new Set(["/TABLE1/3/COL2"]);
     const result = _buildDeltaFromPaths(paths, xxAfterInsert);
     expect(result).toEqual({
       TABLE1: { __delta: { 3: { COL2: "NEW_B1" } } },
@@ -356,7 +356,7 @@ test.describe("Row insert/delete scenarios", () => {
       ],
     };
     // After roundtrip reset, user edits row 0 (previously row 1):
-    const paths = new Set(["/XX/TABLE1/0/COL1"]);
+    const paths = new Set(["/TABLE1/0/COL1"]);
     const result = _buildDeltaFromPaths(paths, xxAfterDelete);
     expect(result).toEqual({
       TABLE1: { __delta: { 0: { COL1: "A2" } } },
@@ -364,11 +364,11 @@ test.describe("Row insert/delete scenarios", () => {
   });
 
   test("full table replacement via setProperty sends complete array", () => {
-    // Simulates client-side: model.setProperty("/XX/TABLE1", newArray)
+    // Simulates client-side: model.setProperty("/TABLE1", newArray)
     const xxWithNewTable = {
       TABLE1: [{ COL1: "X1" }, { COL1: "X2" }],
     };
-    const paths = new Set(["/XX/TABLE1"]);
+    const paths = new Set(["/TABLE1"]);
     const result = _buildDeltaFromPaths(paths, xxWithNewTable);
     expect(result).toEqual({
       TABLE1: [{ COL1: "X1" }, { COL1: "X2" }],
@@ -383,22 +383,22 @@ test.describe("Overwrite / priority behavior", () => {
   // read the same current model data, so the full array is a superset of
   // any cell delta and can never lose changes.
   test("full-table path after cell path overwrites delta with full array", () => {
-    const paths = new Set(["/XX/TABLE1/0/COL1", "/XX/TABLE1"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
-    expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    const paths = new Set(["/TABLE1/0/COL1", "/TABLE1"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
+    expect(result).toEqual({ TABLE1: SAMPLE_MODEL.TABLE1 });
   });
 
   test("cell path after full-table path keeps the full array", () => {
-    const paths = new Set(["/XX/TABLE1", "/XX/TABLE1/0/COL1"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
-    expect(result).toEqual({ TABLE1: SAMPLE_XX.TABLE1 });
+    const paths = new Set(["/TABLE1", "/TABLE1/0/COL1"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
+    expect(result).toEqual({ TABLE1: SAMPLE_MODEL.TABLE1 });
   });
 
   test("full array for one table does not affect the delta of another", () => {
-    const paths = new Set(["/XX/TABLE1", "/XX/TABLE2/1/VALUE"]);
-    const result = _buildDeltaFromPaths(paths, SAMPLE_XX);
+    const paths = new Set(["/TABLE1", "/TABLE2/1/VALUE"]);
+    const result = _buildDeltaFromPaths(paths, SAMPLE_MODEL);
     expect(result).toEqual({
-      TABLE1: SAMPLE_XX.TABLE1,
+      TABLE1: SAMPLE_MODEL.TABLE1,
       TABLE2: { __delta: { 1: { VALUE: "200" } } },
     });
   });

--- a/node/tests/e2e/roundtrip.spec.js
+++ b/node/tests/e2e/roundtrip.spec.js
@@ -71,10 +71,10 @@ test("returns the backend-built view XML on app start", async ({
 
   const xml = body.S_FRONT.PARAMS?.S_VIEW?.XML;
   expect(xml).toContain("<mvc:View");
-  expect(xml).toContain('value="{/XX/NAME}"');
+  expect(xml).toContain('value="{/NAME}"');
   expect(xml).toContain("BUTTON_POST");
   // the two-way bound attribute is seeded in the model
-  expect(body.MODEL.XX).toHaveProperty("NAME");
+  expect(body.MODEL).toHaveProperty("NAME");
 });
 
 test("applies the model delta before on_event and answers the event", async ({
@@ -93,7 +93,7 @@ test("applies the model delta before on_event and answers the event", async ({
     await request.post("/", {
       data: {
         value: {
-          XX: { NAME: "Roundtrip" },
+          MODEL: { NAME: "Roundtrip" },
           S_FRONT: {
             ORIGIN: "http://localhost:3000",
             PATHNAME: "/",

--- a/node/tests/serverRequestSeq.spec.js
+++ b/node/tests/serverRequestSeq.spec.js
@@ -46,7 +46,7 @@ function load() {
   const controllers = [];
   const appState = {
     getGlobal: (k) => (k === "url" ? "/url" : undefined),
-    state: { xxChangedPaths: new Set() },
+    state: { changedPaths: new Set() },
   };
 
   const { module: Server } = loadModule("core/Server.js", {
@@ -147,25 +147,25 @@ test("dispatching a newer request aborts the older one still in flight", async (
 
 test("a superseded response keeps the pending delta paths so the newest request carries them", async () => {
   const { Server, fetchCalls, successes, appState } = load();
-  // A delta edit is pending (the /XX/ path the first request shipped).
-  appState.state.xxChangedPaths = new Set(["/XX/PRODUCT"]);
-  const pending = appState.state.xxChangedPaths;
+  // A delta edit is pending (the model path the first request shipped).
+  appState.state.changedPaths = new Set(["/PRODUCT"]);
+  const pending = appState.state.changedPaths;
 
-  const pA = Server.readHttp({}); // seq 1 - carried /XX/PRODUCT
+  const pA = Server.readHttp({}); // seq 1 - carried /PRODUCT
   const pB = Server.readHttp({}); // seq 2 - newest (also carried it, rebuilt)
 
   // The older response arrives but is stale: it must NOT clear the delta,
   // otherwise the edit would be lost once the newer request wins.
   fetchCalls[0].resolve(okResponse("A"));
   await flush();
-  expect(appState.state.xxChangedPaths).toBe(pending); // untouched, still pending
+  expect(appState.state.changedPaths).toBe(pending); // untouched, still pending
 
   // Only the newest response commits and clears the accumulated delta.
   fetchCalls[1].resolve(okResponse("B"));
   await Promise.all([pA, pB]);
   expect(successes).toHaveLength(1);
-  expect(appState.state.xxChangedPaths).not.toBe(pending);
-  expect(appState.state.xxChangedPaths.size).toBe(0);
+  expect(appState.state.changedPaths).not.toBe(pending);
+  expect(appState.state.changedPaths.size).toBe(0);
 });
 
 test("the single response commits in the default (non-parallel) case", async () => {

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -115,11 +115,12 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     DATA(lv_root) = COND string( WHEN lo_ajson->exists( `/value` ) = abap_true
                                  THEN `/value` ).
 
-    DATA(lv_model_edit_name) = |/{ z2ui5_if_core_types=>cs_ui5-two_way_model }|.
-    result-o_model = z2ui5_cl_ajson=>create_empty( ).
-    DATA(lo_model) = lo_ajson->slice( lv_root && lv_model_edit_name ).
-    result-o_model->set( iv_path = lv_model_edit_name
-                         iv_val  = lo_model ).
+    " the whole view model is transported back under the MODEL container
+    " (symmetric to the response); the frontend ships only the edited delta
+    result-o_model = lo_ajson->slice( lv_root && `/MODEL` ).
+    IF result-o_model IS NOT BOUND.
+      result-o_model = z2ui5_cl_ajson=>create_empty( ).
+    ENDIF.
 
     lo_ajson = lo_ajson->slice( lv_root && `/S_FRONT` ).
 

--- a/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
@@ -162,19 +162,19 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD test_parse_body_model.
-    " the two-way model (XX) is extracted from the request root and has to
-    " stay reachable under /XX/... for main_json_to_attri
+    " the view model is extracted from the request MODEL container and has to
+    " stay reachable under /... for main_json_to_attri
     DATA lv_payload TYPE string.
     DATA lo_handler TYPE REF TO z2ui5_cl_core_handler.
     DATA ls_request TYPE z2ui5_if_core_types=>ty_s_request.
-    lv_payload = `{"value":{"S_FRONT":{"ID":"ABC123","ORIGIN":"O","PATHNAME":"/p","SEARCH":""},"XX":{"NAME":"test-value"}}}`.
+    lv_payload = `{"value":{"S_FRONT":{"ID":"ABC123","ORIGIN":"O","PATHNAME":"/p","SEARCH":""},"MODEL":{"NAME":"test-value"}}}`.
 
     lo_handler = NEW #( val = lv_payload ).
     ls_request = lo_handler->request_json_to_abap( lv_payload ).
 
     cl_abap_unit_assert=>assert_bound( ls_request-o_model ).
     cl_abap_unit_assert=>assert_equals( exp = `test-value`
-                                        act = ls_request-o_model->get_string( `/XX/NAME` ) ).
+                                        act = ls_request-o_model->get_string( `/NAME` ) ).
   ENDMETHOD.
 
   METHOD test_parse_body_model_no_wrap.
@@ -183,14 +183,14 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
     DATA lv_payload TYPE string.
     DATA lo_handler TYPE REF TO z2ui5_cl_core_handler.
     DATA ls_request TYPE z2ui5_if_core_types=>ty_s_request.
-    lv_payload = `{"S_FRONT":{"ID":"ABC123","ORIGIN":"O","PATHNAME":"/p","SEARCH":""},"XX":{"NAME":"test-value"}}`.
+    lv_payload = `{"S_FRONT":{"ID":"ABC123","ORIGIN":"O","PATHNAME":"/p","SEARCH":""},"MODEL":{"NAME":"test-value"}}`.
 
     lo_handler = NEW #( val = lv_payload ).
     ls_request = lo_handler->request_json_to_abap( lv_payload ).
 
     cl_abap_unit_assert=>assert_bound( ls_request-o_model ).
     cl_abap_unit_assert=>assert_equals( exp = `test-value`
-                                        act = ls_request-o_model->get_string( `/XX/NAME` ) ).
+                                        act = ls_request-o_model->get_string( `/NAME` ) ).
   ENDMETHOD.
 
   METHOD test_parse_body_config.

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -148,9 +148,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
                       sub  = `>`
                       with = ``
                       occ  = 0 ).
-    result = COND #( WHEN mv_type = z2ui5_if_core_types=>cs_bind_type-two_way
-                     THEN |/{ z2ui5_if_core_types=>cs_ui5-two_way_model }| )
-        && |/{ result }|.
+    result = |/{ result }|.
 
   ENDMETHOD.
 
@@ -193,12 +191,6 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
       update_model_attri( ).
     ENDIF.
     result = mr_attri->name_client.
-
-    IF result = |/{ z2ui5_if_core_types=>cs_ui5-two_way_model }|.
-      RAISE EXCEPTION TYPE z2ui5_cx_a2ui5_error
-        EXPORTING val = `<p>Name of variable not allowed - XX is a reserved word - use another name for your attribute`.
-
-    ENDIF.
 
     IF ms_config-switch_default_model = abap_true.
       result = |http>{ result }|.

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
@@ -49,7 +49,7 @@ CLASS ltcl_test_bind DEFINITION FINAL
 
   PRIVATE SECTION.
     METHODS test_one_way           FOR TESTING RAISING cx_static_check.
-    METHODS test_one_way_w_x_error FOR TESTING RAISING cx_static_check.
+    METHODS test_attri_named_xx    FOR TESTING RAISING cx_static_check.
     METHODS test_error_diff        FOR TESTING RAISING cx_static_check.
     METHODS test_two_way           FOR TESTING RAISING cx_static_check.
 
@@ -57,22 +57,21 @@ ENDCLASS.
 
 
 CLASS ltcl_test_bind IMPLEMENTATION.
-  METHOD test_one_way_w_x_error.
+  METHOD test_attri_named_xx.
 
+    " XX used to be a reserved model-node name; now that the two-way data
+    " lives directly on the root, an attribute named XX binds like any other
     DATA(lo_app_client) = NEW ltcl_test_app( ).
     DATA(lo_app) = NEW z2ui5_cl_core_app( ).
     lo_app->mo_app = lo_app_client.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
 
-    TRY.
-        lo_bind->main( val  = REF #( lo_app_client->xx )
-                       type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_bind) = lo_bind->main( val  = REF #( lo_app_client->xx )
+                                   type = z2ui5_if_core_types=>cs_bind_type-two_way ).
 
-        cl_abap_unit_assert=>abort( ).
-
-      CATCH cx_root ##NO_HANDLER.
-    ENDTRY.
+    cl_abap_unit_assert=>assert_equals( exp = `{/XX}`
+                                        act = lv_bind ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
@@ -1189,7 +1189,7 @@ CLASS ltcl_test_attri_refresh IMPLEMENTATION.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
     lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
-    lr->name_client = `/XX/MV_SIMPLE`.
+    lr->name_client = `/MV_SIMPLE`.
     lr->view        = z2ui5_if_client=>cs_view-main.
 
     " Refresh clears and re-dissolves but must restore binding info
@@ -1198,7 +1198,7 @@ CLASS ltcl_test_attri_refresh IMPLEMENTATION.
     DATA(ls_after) = VALUE #( lt_attri[ name = `MV_SIMPLE` ] OPTIONAL ).
     cl_abap_unit_assert=>assert_equals( exp = z2ui5_if_core_types=>cs_bind_type-two_way
                                         act = ls_after-bind_type ).
-    cl_abap_unit_assert=>assert_equals( exp = `/XX/MV_SIMPLE`
+    cl_abap_unit_assert=>assert_equals( exp = `/MV_SIMPLE`
                                         act = ls_after-name_client ).
     cl_abap_unit_assert=>assert_equals( exp = z2ui5_if_client=>cs_view-main
                                         act = ls_after-view ).
@@ -1694,7 +1694,7 @@ CLASS ltcl_test_refresh_ext IMPLEMENTATION.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
     lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
-    lr->name_client = `/XX/MV_SIMPLE`.
+    lr->name_client = `/MV_SIMPLE`.
     lr->view        = z2ui5_if_client=>cs_view-main.
 
     " Now instantiate the previously-null oref and refresh
@@ -1709,7 +1709,7 @@ CLASS ltcl_test_refresh_ext IMPLEMENTATION.
     DATA(ls_simple) = VALUE #( lt_attri[ name = `MV_SIMPLE` ] OPTIONAL ).
     cl_abap_unit_assert=>assert_equals( exp = z2ui5_if_core_types=>cs_bind_type-two_way
                                         act = ls_simple-bind_type ).
-    cl_abap_unit_assert=>assert_equals( exp = `/XX/MV_SIMPLE`
+    cl_abap_unit_assert=>assert_equals( exp = `/MV_SIMPLE`
                                         act = ls_simple-name_client ).
   ENDMETHOD.
 
@@ -1763,25 +1763,25 @@ CLASS ltcl_test_json_types IMPLEMENTATION.
                                                   app   = lo_app ).
     lo_model->dissolve( ).
 
-    " First entry: bind MV_SIMPLE as /XX/MV_SIMPLE
+    " First entry: bind MV_SIMPLE as /MV_SIMPLE
     READ TABLE lt_attri REFERENCE INTO DATA(lr1) WITH KEY name = `MV_SIMPLE`.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
     lr1->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
     lr1->view        = z2ui5_if_client=>cs_view-main.
-    lr1->name_client = `/XX/MV_SIMPLE`.
+    lr1->name_client = `/MV_SIMPLE`.
 
     " Second entry: a copy with a different name_client path, also two-way
     DATA ls_extra TYPE z2ui5_if_core_types=>ty_s_attri.
     ls_extra = lr1->*.
     ls_extra-name        = `MV_SIMPLE_ALIAS`.
-    ls_extra-name_client = `/XX/ALIAS`.
+    ls_extra-name_client = `/ALIAS`.
     INSERT ls_extra INTO TABLE lt_attri.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
     lo_model_json = z2ui5_cl_ajson=>create_empty( ).
-    lo_model_json->set( iv_path = `/XX/MV_SIMPLE`
+    lo_model_json->set( iv_path = `/MV_SIMPLE`
                         iv_val  = `first` ).
 
     lo_model->main_json_to_attri( view  = z2ui5_if_client=>cs_view-main

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -5,7 +5,6 @@ INTERFACE z2ui5_if_core_types
     BEGIN OF cs_ui5,
       event_backend_function  TYPE string VALUE `.eB`,
       event_frontend_function TYPE string VALUE `.eF`,
-      two_way_model           TYPE string VALUE `XX`,
     END OF cs_ui5.
 
   CONSTANTS cs_event_nav_app_leave TYPE string VALUE `___ZZZ_NAL`.

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -81,7 +81,7 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//                     the developer tools)` && |\n| &&
              `//   contextId         stateful session id, header transport (Server)` && |\n| &&
              `//   isBusy            roundtrip in flight (View1.eB / Server)` && |\n| &&
-             `//   xxChangedPaths    Set of edited /XX/ model paths for the delta (View1)` && |\n| &&
+             `//   changedPaths      Set of edited model paths for the delta (View1)` && |\n| &&
              `//   checkNestAfter, checkNestAfter2  nested views rebuilt this roundtrip` && |\n| &&
              `//   search            overrides location.search in S_FRONT; never written` && |\n| &&
              `//                     by the framework itself, set externally (custom JS)` && |\n| &&
@@ -127,7 +127,7 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `      responseData: null,` && |\n| &&
              `      contextId: null,` && |\n| &&
              `      isBusy: false,` && |\n| &&
-             `      xxChangedPaths: new Set(),` && |\n| &&
+             `      changedPaths: new Set(),` && |\n| &&
              `      checkNestAfter: false,` && |\n| &&
              `      checkNestAfter2: false,` && |\n| &&
              `      search: null,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -349,23 +349,23 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Build the delta object sent to the backend. ``paths`` is the set of` && |\n| &&
-             `    // /XX/... paths that the user edited; ``xx`` is the full XX model data.` && |\n| &&
+             `    // model paths that the user edited; ``model`` is the full view model data.` && |\n| &&
              `    // Table edits become (recursively nested) __delta structures, so a cell` && |\n| &&
              `    // edit in a nested/tree table ships only the changed cell instead of` && |\n| &&
              `    // the whole outer table.` && |\n| &&
-             `    function buildDeltaFromPaths(paths, xx) {` && |\n| &&
+             `    function buildDeltaFromPaths(paths, modelData) {` && |\n| &&
              `      const delta = {};` && |\n| &&
              `      for (const path of paths) {` && |\n| &&
-             `        // path looks like "/XX/<attr>" or "/XX/<attr>/<row>/<field>" with` && |\n| &&
+             `        // path looks like "/<attr>" or "/<attr>/<row>/<field>" with` && |\n| &&
              `        // arbitrarily deep <row>/<subtable> repetitions for nested tables` && |\n| &&
-             `        const parts = path.slice(4).split("/");` && |\n| &&
+             `        const parts = path.slice(1).split("/");` && |\n| &&
              `        const attr = parts[0];` && |\n| &&
              `        const steps = parseDeltaSteps(parts.slice(1));` && |\n| &&
              `        if (!steps) {` && |\n| &&
              `          // Scalar or unrecognized shape -> ship the whole attribute. The` && |\n| &&
              `          // full value always wins over any queued delta: both read the` && |\n| &&
              `          // same current model data, so it is a superset of every delta.` && |\n| &&
-             `          delta[attr] = xx[attr];` && |\n| &&
+             `          delta[attr] = modelData[attr];` && |\n| &&
              `          continue;` && |\n| &&
              `        }` && |\n| &&
              `        // A full attribute queued by another path already carries every` && |\n| &&
@@ -374,7 +374,7 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `        if (attr in delta && !delta[attr]?.__delta) continue;` && |\n| &&
              `        if (!delta[attr]?.__delta) delta[attr] = { __delta: {} };` && |\n| &&
              `        let node = delta[attr];` && |\n| &&
-             `        let model = xx[attr];` && |\n| &&
+             `        let model = modelData[attr];` && |\n| &&
              `        for (const { row, field, leaf } of steps) {` && |\n| &&
              `          const rows = node.__delta;` && |\n| &&
              `          if (!rows[row]) rows[row] = {};` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_scrolling_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_scrolling_js.clas.abap
@@ -69,7 +69,7 @@ CLASS z2ui5_cl_app_scrolling_js IMPLEMENTATION.
              `        if (!items) return;` && |\n| &&
              `        try {` && |\n| &&
              `          // Resolve the binding path so we can mark only changed entries` && |\n| &&
-             `          // as dirty in xxChangedPaths.` && |\n| &&
+             `          // as dirty in changedPaths.` && |\n| &&
              `          const bindingInfo = this.getBindingInfo("items");` && |\n| &&
              `          const bindingPath =` && |\n| &&
              `            bindingInfo?.parts?.[0]?.path ?? bindingInfo?.path;` && |\n| &&
@@ -78,7 +78,7 @@ CLASS z2ui5_cl_app_scrolling_js IMPLEMENTATION.
              `            if (item.V !== scrollTop) {` && |\n| &&
              `              item.V = scrollTop;` && |\n| &&
              `              if (bindingPath) {` && |\n| &&
-             `                AppState.state.xxChangedPaths.add(``${bindingPath}/${index}/V``);` && |\n| &&
+             `                AppState.state.changedPaths.add(``${bindingPath}/${index}/V``);` && |\n| &&
              `              }` && |\n| &&
              `            }` && |\n| &&
              `          }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -137,7 +137,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `    // Wire format - request (POST body; VIEWNAME/ARGUMENTS are folded into` && |\n| &&
              `    // S_FRONT before sending, empty fields are removed):` && |\n| &&
              `    //   { "value": {` && |\n| &&
-             `    //       "XX": {                        // two-way model delta` && |\n| &&
+             `    //       "MODEL": {                     // view model delta` && |\n| &&
              `    //         "NAME": "new value",         //   scalar: full attribute` && |\n| &&
              `    //         "TAB": { "__delta": { "0": { "COL1": "new cell" } } }` && |\n| &&
              `    //       },` && |\n| &&
@@ -166,7 +166,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `    //         "SET_NAV_BACK": ""           // browser/history follow-ups` && |\n| &&
              `    //       }` && |\n| &&
              `    //     },` && |\n| &&
-             `    //     "MODEL": { "XX": {...}, ... }    // full JSON view model, becomes` && |\n| &&
+             `    //     "MODEL": { "NAME": ..., ... }    // full JSON view model, becomes` && |\n| &&
              `    //   }                                  // the view's binding model` && |\n| &&
              `    //` && |\n| &&
              `    // Inspect live payloads via the developer tools (Ctrl+F12): "Previous` && |\n| &&
@@ -448,7 +448,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        // and these keys are not present in the JSON sent over the wire.` && |\n| &&
              `        if (!sFront.T_EVENT_ARG?.length) delete sFront.T_EVENT_ARG;` && |\n| &&
              `        if (sFront.SEARCH === "") delete sFront.SEARCH;` && |\n| &&
-             `        if (!oBody.XX) delete oBody.XX;` && |\n| &&
+             `        if (!oBody.MODEL) delete oBody.MODEL;` && |\n| &&
              `` && |\n| &&
              `        this.readHttp(oBody);` && |\n| &&
              `      },` && |\n| &&
@@ -613,7 +613,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `` && |\n| &&
              `          // Step 4: hand the parsed response to the success handler.` && |\n| &&
              `          AppState.state.responseData = responseData;` && |\n| &&
-             `          AppState.state.xxChangedPaths = new Set();` && |\n| &&
+             `          AppState.state.changedPaths = new Set();` && |\n| &&
              `          this.responseSuccess({` && |\n| &&
              `            ID: responseData.S_FRONT.ID,` && |\n| &&
              `            PARAMS: responseData.S_FRONT.PARAMS,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -67,7 +67,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `    return Controller.extend("z2ui5.controller.View1", {` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&
-             `      // Model change tracking - remembers which /XX/ paths the user edited` && |\n| &&
+             `      // Model change tracking - remembers which model paths the user edited` && |\n| &&
              `      // so the next roundtrip only ships the delta.` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&
              `      _trackChanges(oModel) {` && |\n| &&
@@ -82,8 +82,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          // Resolve relative paths against the binding context.` && |\n| &&
              `          const changedPath =` && |\n| &&
              `            ctx && !raw.startsWith("/") ? ``${ctx.getPath()}/${raw}`` : raw;` && |\n| &&
-             `          if (changedPath.startsWith("/XX/")) {` && |\n| &&
-             `            AppState.state.xxChangedPaths.add(changedPath);` && |\n| &&
+             `          if (changedPath.startsWith("/")) {` && |\n| &&
+             `            AppState.state.changedPaths.add(changedPath);` && |\n| &&
              `          }` && |\n| &&
              `        });` && |\n| &&
              `        return oModel;` && |\n| &&
@@ -406,20 +406,19 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `        Lib.runCallbacks(AppState.state.onBeforeRoundtrip);` && |\n| &&
              `` && |\n| &&
-             `        // If the user edited /XX/ paths, send only the delta to keep the` && |\n| &&
+             `        // If the user edited model paths, send only the delta to keep the` && |\n| &&
              `        // payload small.` && |\n| &&
-             `        if (oModel && AppState.state.xxChangedPaths.size > 0) {` && |\n| &&
+             `        if (oModel && AppState.state.changedPaths.size > 0) {` && |\n| &&
              `          const data = oModel.getData();` && |\n| &&
-             `          const xx = data?.XX;` && |\n| &&
-             `          if (xx) {` && |\n| &&
-             `            oBody.XX = Lib.buildDeltaFromPaths(` && |\n| &&
-             `              AppState.state.xxChangedPaths,` && |\n| &&
-             `              xx,` && |\n| &&
+             `          if (data) {` && |\n| &&
+             `            oBody.MODEL = Lib.buildDeltaFromPaths(` && |\n| &&
+             `              AppState.state.changedPaths,` && |\n| &&
+             `              data,` && |\n| &&
              `            );` && |\n| &&
              `          }` && |\n| &&
-             `        }` && |\n|.
+             `        }` && |\n| &&
+             `` && |\n|.
     result = result &&
-             `` && |\n| &&
              `        oBody.ID = AppState.state.oResponse?.ID;` && |\n| &&
              `        // Arguments travel as raw JSON values - the request body is` && |\n| &&
              `        // serialized exactly once in Server.readHttp. Object arguments are` && |\n| &&


### PR DESCRIPTION
## Description

This PR removes the `/XX/` prefix convention from model paths throughout the framework, simplifying the data binding API. Previously, two-way bound attributes were accessed via paths like `/XX/NAME`; now they use `/NAME` directly at the model root.

### Key Changes

**Frontend (JavaScript):**
- Updated `buildDeltaFromPaths()` to parse paths starting with `/` instead of `/XX/`
- Renamed `xxChangedPaths` to `changedPaths` in AppState
- Changed request body to send model delta under `MODEL` key instead of `XX`
- Updated path tracking to accept any root-level path, not just `/XX/` prefixed ones

**Backend (ABAP):**
- Removed `XX` constant from `cs_ui5` in `z2ui5_if_core_types`
- Simplified `z2ui5_cl_core_srv_bind` to generate paths without the `/XX/` prefix
- Removed validation that rejected attributes named `XX` (no longer a reserved word)
- Updated request handler to extract model directly from `MODEL` container instead of wrapping it under `/XX/`

**Documentation & Tests:**
- Updated all test cases to use new path format (`/NAME` instead of `/XX/NAME`)
- Updated AGENTS.md to reflect the simplified binding API
- Renamed test data constants (`SAMPLE_XX` → `SAMPLE_MODEL`, `TREE_XX` → `TREE_MODEL`)
- Updated test method names and comments to remove XX references

### API Impact

The `_bind()` method now generates paths directly at the model root:
- **Before:** `{/XX/attribute}` 
- **After:** `{/attribute}`

This is a **breaking change** for applications using the old path format, but the binding method signature remains unchanged.

## How to test

1. Run the existing test suites:
   - `npm test` (Node.js tests including `buildDeltaFromPaths.spec.js`, `serverRequestSeq.spec.js`, `e2e/roundtrip.spec.js`)
   - ABAP unit tests in `.testclasses.abap` files

2. Verify a simple two-way binding scenario:
   - Create an app with `client->_bind(name)` 
   - Confirm the generated XML uses `{/NAME}` not `{/XX/NAME}`
   - Edit the field and verify the delta is sent correctly

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests updated (test data renamed, path assertions updated)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes are generated from source)
- [x] Public API in `src/02/` unchanged (binding method signature stable)
- [x] Changes made via abapGit: no (direct source edits)

https://claude.ai/code/session_01BRbBrfS2hPi9EFQqjjgfHX