### PR TITLE
Simplify binding model: remove explicit bind type parameter

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -365,7 +365,6 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
   METHOD z2ui5_if_client~_bind.
 
     result = mo_srv_bind->main( val = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( val )
-                            type    = z2ui5_if_core_types=>cs_bind_type-two_way
                             config  = VALUE #( path_only           = path
                                               custom_filter        = custom_filter
 *                                              custom_filter_back   = custom_filter_back
@@ -375,22 +374,12 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
                                               tab_index            = tab_index
                                               switch_default_model = switch_default_model ) ).
 
-*    result = mo_srv_bind->main( val = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( val )
-*                            type    = z2ui5_if_core_types=>cs_bind_type-one_way
-*                            config  = VALUE #( path_only           = path
-*                                              custom_filter        = custom_filter
-*                                              custom_mapper        = custom_mapper
-*                                              tab                  = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( tab )
-*                                              tab_index            = tab_index
-*                                              switch_default_model = switch_default_model ) ).
-
   ENDMETHOD.
 
 
   METHOD z2ui5_if_client~_bind_edit.
 
     result = mo_srv_bind->main( val = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( val )
-                            type    = z2ui5_if_core_types=>cs_bind_type-two_way
                             config  = VALUE #(
                                               path_only            = path
                                               custom_filter        = custom_filter

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -4,7 +4,6 @@ CLASS z2ui5_cl_core_srv_bind DEFINITION PUBLIC FINAL.
     DATA mo_app    TYPE REF TO z2ui5_cl_core_app.
     DATA mr_attri  TYPE REF TO z2ui5_if_core_types=>ty_s_attri.
     DATA ms_config TYPE z2ui5_if_core_types=>ty_s_bind_config.
-    DATA mv_type   TYPE string.
 
     METHODS constructor
       IMPORTING
@@ -13,7 +12,6 @@ CLASS z2ui5_cl_core_srv_bind DEFINITION PUBLIC FINAL.
     METHODS main
       IMPORTING
         val           TYPE REF TO data
-        type          TYPE string
         config        TYPE z2ui5_if_core_types=>ty_s_bind_config OPTIONAL
       RETURNING
         VALUE(result) TYPE string.
@@ -21,7 +19,6 @@ CLASS z2ui5_cl_core_srv_bind DEFINITION PUBLIC FINAL.
     METHODS main_cell
       IMPORTING
         val           TYPE data
-        type          TYPE string
         config        TYPE z2ui5_if_core_types=>ty_s_bind_config OPTIONAL
       RETURNING
         VALUE(result) TYPE string.
@@ -92,11 +89,6 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
 
   METHOD check_raise_existing.
 
-    IF mr_attri->bind_type <> mv_type.
-      RAISE EXCEPTION TYPE z2ui5_cx_a2ui5_error
-        EXPORTING val = |<p>Binding Error - Two different binding types for same attribute used ({ mr_attri->name }).|.
-    ENDIF.
-
     IF mr_attri->custom_mapper IS BOUND AND ms_config-custom_mapper IS BOUND
         AND z2ui5_cl_a2ui5_context=>rtti_get_classname_by_ref( mr_attri->custom_mapper )
          <> z2ui5_cl_a2ui5_context=>rtti_get_classname_by_ref( ms_config-custom_mapper ).
@@ -157,14 +149,12 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     IF z2ui5_cl_a2ui5_context=>check_bound_a_not_initial( config-tab ).
 
       result = main_cell( val    = val
-                          type   = type
                           config = config ).
 
       RETURN.
     ENDIF.
 
     ms_config = config.
-    mv_type   = type.
 
     DATA(lo_model) = NEW z2ui5_cl_core_srv_model( attri = mo_app->mt_attri
                                                   app   = mo_app->mo_app ).
@@ -184,7 +174,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
       mr_attri = lr_ref_attri.
     ENDIF.
 
-    IF mr_attri->bind_type IS NOT INITIAL.
+    IF mr_attri->bind = abap_true.
       check_raise_existing( ).
     ELSE.
       check_raise_new( ).
@@ -208,7 +198,6 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
 
     DATA(lo_bind) = NEW z2ui5_cl_core_srv_bind( mo_app ).
     result = lo_bind->main( val    = config-tab
-                            type   = type
                             config = VALUE #( path_only = abap_true ) ).
 
     result = bind_tab_cell( iv_name = result
@@ -222,7 +211,7 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
 
   METHOD update_model_attri.
 
-    mr_attri->bind_type          = mv_type.
+    mr_attri->bind               = abap_true.
     mr_attri->custom_filter      = ms_config-custom_filter.
     mr_attri->custom_filter_back = ms_config-custom_filter_back.
     mr_attri->custom_mapper      = ms_config-custom_mapper.

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.testclasses.abap
@@ -48,10 +48,9 @@ CLASS ltcl_test_bind DEFINITION FINAL
   PROTECTED SECTION.
 
   PRIVATE SECTION.
-    METHODS test_one_way           FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_path         FOR TESTING RAISING cx_static_check.
     METHODS test_attri_named_xx    FOR TESTING RAISING cx_static_check.
-    METHODS test_error_diff        FOR TESTING RAISING cx_static_check.
-    METHODS test_two_way           FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_idempotent   FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -67,15 +66,14 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
 
-    DATA(lv_bind) = lo_bind->main( val  = REF #( lo_app_client->xx )
-                                   type = z2ui5_if_core_types=>cs_bind_type-two_way ).
+    DATA(lv_bind) = lo_bind->main( REF #( lo_app_client->xx ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/XX}`
                                         act = lv_bind ).
 
   ENDMETHOD.
 
-  METHOD test_one_way.
+  METHOD test_bind_path.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -87,42 +85,14 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
     DATA(lo_bind) = NEW z2ui5_cl_core_srv_bind( lo_app ).
 
-    DATA(lv_bind) = lo_bind->main( val  = REF #( lo_app_client->mv_value )
-                                   type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_bind) = lo_bind->main( REF #( lo_app_client->mv_value ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MV_VALUE}`
                                         act = lv_bind ).
 
   ENDMETHOD.
 
-  METHOD test_error_diff.
-
-    IF sy-sysid = `ABC`.
-      RETURN.
-    ENDIF.
-
-
-    DATA(lo_app_client) = NEW ltcl_test_app( ).
-    DATA(lo_app) = NEW z2ui5_cl_core_app( ).
-    lo_app->mo_app = lo_app_client.
-
-    DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-
-    lo_bind->main( val  = REF #( lo_app_client->mv_value )
-                   type = z2ui5_if_core_types=>cs_bind_type-one_way ).
-
-    TRY.
-        lo_bind->main( val  = REF #( lo_app_client->mv_value )
-                       type = z2ui5_if_core_types=>cs_bind_type-two_way ).
-
-        cl_abap_unit_assert=>abort( ).
-
-      CATCH cx_root ##NO_HANDLER.
-    ENDTRY.
-
-  ENDMETHOD.
-
-  METHOD test_two_way.
+  METHOD test_bind_idempotent.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -134,11 +104,9 @@ CLASS ltcl_test_bind IMPLEMENTATION.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
 
-    DATA(lv_bind) = lo_bind->main( val  = REF #( lo_app_client->mv_value )
-                                   type = z2ui5_if_core_types=>cs_bind_type-two_way ).
+    DATA(lv_bind) = lo_bind->main( REF #( lo_app_client->mv_value ) ).
 
-    DATA(lv_bind2) = lo_bind->main( val  = REF #( lo_app_client->mv_value )
-                                    type = z2ui5_if_core_types=>cs_bind_type-two_way ).
+    DATA(lv_bind2) = lo_bind->main( REF #( lo_app_client->mv_value ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = lv_bind2
                                         act = lv_bind ).
@@ -173,16 +141,16 @@ CLASS ltcl_test_main_structure DEFINITION FINAL
 
   PRIVATE SECTION.
 
-    METHODS test_one_way_lev1           FOR TESTING RAISING cx_static_check.
-    METHODS test_one_way_lev2           FOR TESTING RAISING cx_static_check.
-    METHODS test_one_way_lev3           FOR TESTING RAISING cx_static_check.
-    METHODS test_one_way_lev4_long_name FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_lev1           FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_lev2           FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_lev3           FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_lev4_long_name FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
 
 CLASS ltcl_test_main_structure IMPLEMENTATION.
-  METHOD test_one_way_lev1.
+  METHOD test_bind_lev1.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -194,22 +162,20 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->ms_struc-input )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->ms_struc-input ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MS_STRUC/INPUT}`
                                         act = lv_result ).
 
     lv_result = lo_bind->main( val    = REF #( lo_test_app->ms_struc-input )
-                               config = VALUE #( path_only = abap_true )
-                               type   = z2ui5_if_core_types=>cs_bind_type-one_way ).
+                               config = VALUE #( path_only = abap_true ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `/MS_STRUC/INPUT`
                                         act = lv_result ).
 
   ENDMETHOD.
 
-  METHOD test_one_way_lev2.
+  METHOD test_bind_lev2.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -221,15 +187,14 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->ms_struc-s_02-input )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->ms_struc-s_02-input ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MS_STRUC/S_02/INPUT}`
                                         act = lv_result ).
 
   ENDMETHOD.
 
-  METHOD test_one_way_lev3.
+  METHOD test_bind_lev3.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -240,15 +205,14 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->ms_struc-s_02-s_03-input )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->ms_struc-s_02-s_03-input ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MS_STRUC/S_02/S_03/INPUT}`
                                         act = lv_result ).
 
   ENDMETHOD.
 
-  METHOD test_one_way_lev4_long_name.
+  METHOD test_bind_lev4_long_name.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -259,8 +223,7 @@ CLASS ltcl_test_main_structure IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->ms_struc-s_02-s_03-s_04-input )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->ms_struc-s_02-s_03-s_04-input ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MS_STRUC/S_02/S_03/S_04/INPUT}`
                                         act = lv_result ).
@@ -295,15 +258,15 @@ CLASS ltcl_test_main_object DEFINITION FINAL
 
   PRIVATE SECTION.
 
-    METHODS test_one_way_value FOR TESTING RAISING cx_static_check.
-    METHODS test_one_way_struc FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_value FOR TESTING RAISING cx_static_check.
+    METHODS test_bind_struc FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
 
 CLASS ltcl_test_main_object IMPLEMENTATION.
 
-  METHOD test_one_way_value.
+  METHOD test_bind_value.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -317,15 +280,14 @@ CLASS ltcl_test_main_object IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->mo_obj->mv_value )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->mo_obj->mv_value ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MO_OBJ/MV_VALUE}`
                                         act = lv_result ).
 
   ENDMETHOD.
 
-  METHOD test_one_way_struc.
+  METHOD test_bind_struc.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -337,8 +299,7 @@ CLASS ltcl_test_main_object IMPLEMENTATION.
     lo_app->mo_app = lo_test_app.
 
     DATA(lo_bind)  = NEW z2ui5_cl_core_srv_bind( lo_app ).
-    DATA(lv_result) = lo_bind->main( val  = REF #( lo_test_app->mo_obj->ms_struc-input )
-                                     type = z2ui5_if_core_types=>cs_bind_type-one_way ).
+    DATA(lv_result) = lo_bind->main( REF #( lo_test_app->mo_obj->ms_struc-input ) ).
 
     cl_abap_unit_assert=>assert_equals( exp = `{/MO_OBJ/MS_STRUC/INPUT}`
                                         act = lv_result ).

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -129,7 +129,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
   METHOD main_json_to_attri.
 
     LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri)
-         WHERE bind_type = z2ui5_if_core_types=>cs_bind_type-two_way. "#EC CI_SORTSEQ
+         WHERE bind = abap_true.                        "#EC CI_SORTSEQ
       TRY.
 
           DATA(lo_val_front) = model->slice( lr_attri->name_client ).
@@ -185,7 +185,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
         DATA lt_mapper_cache TYPE STANDARD TABLE OF ty_s_mapper_cache WITH EMPTY KEY.
 
         LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri) "#EC CI_SORTSEQ
-             WHERE bind_type <> ``
+             WHERE bind = abap_true
                    AND type_kind <> z2ui5_cl_a2ui5_context=>cv_typedescr_typekind_dref
                    AND type_kind <> z2ui5_cl_a2ui5_context=>cv_typedescr_typekind_oref.
 
@@ -759,7 +759,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
   METHOD main_attri_refresh.
 
     DATA(lt_attri) = mt_attri->*.
-    DELETE lt_attri WHERE bind_type IS INITIAL.         "#EC CI_SORTSEQ
+    DELETE lt_attri WHERE bind = abap_false.            "#EC CI_SORTSEQ
     CLEAR mt_attri->*.
 
     dissolve( ).
@@ -767,7 +767,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri).
       READ TABLE lt_attri REFERENCE INTO DATA(lr_old) WITH KEY name = lr_attri->name. "#EC CI_SORTSEQ
       IF sy-subrc = 0.
-        lr_attri->bind_type   = lr_old->bind_type.
+        lr_attri->bind        = lr_old->bind.
         lr_attri->name_client = lr_old->name_client.
       ENDIF.
     ENDLOOP.

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.testclasses.abap
@@ -1047,7 +1047,7 @@ CLASS ltcl_test_json_stringify IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr_simple->bind_type   = z2ui5_if_core_types=>cs_bind_type-one_way.
+    lr_simple->bind        = abap_true.
     lr_simple->name_client = `/MV_SIMPLE`.
 
     DATA(lv_json) = lo_model->main_json_stringify( ).
@@ -1063,7 +1063,7 @@ CLASS ltcl_test_json_stringify IMPLEMENTATION.
                                                   app   = lo_app ).
     lo_model->dissolve( ).
 
-    " No bind_type set on any attribute - stringify produces empty JSON object
+    " No binding set on any attribute - stringify produces empty JSON object
     DATA(lv_json) = lo_model->main_json_stringify( ).
     cl_abap_unit_assert=>assert_equals( exp = `{}`
                                         act = lv_json ).
@@ -1075,13 +1075,13 @@ ENDCLASS.
 CLASS ltcl_test_json_to_attri DEFINITION FINAL
   FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
   PRIVATE SECTION.
-    METHODS test_updates_two_way FOR TESTING RAISING cx_static_check.
-    METHODS test_skips_one_way   FOR TESTING RAISING cx_static_check.
+    METHODS test_updates_bound   FOR TESTING RAISING cx_static_check.
+    METHODS test_skips_unbound   FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS ltcl_test_json_to_attri IMPLEMENTATION.
 
-  METHOD test_updates_two_way.
+  METHOD test_updates_bound.
     DATA(lo_app) = NEW ltcl_app_complex( ).
     DATA lt_attri TYPE z2ui5_if_core_types=>ty_t_attri.
     DATA(lo_model) = NEW z2ui5_cl_core_srv_model( attri = REF #( lt_attri )
@@ -1092,7 +1092,7 @@ CLASS ltcl_test_json_to_attri IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr->bind        = abap_true.
     lr->name_client = `/MV_SIMPLE`.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
@@ -1106,7 +1106,7 @@ CLASS ltcl_test_json_to_attri IMPLEMENTATION.
                                         act = lo_app->mv_simple ).
   ENDMETHOD.
 
-  METHOD test_skips_one_way.
+  METHOD test_skips_unbound.
     DATA(lo_app) = NEW ltcl_app_complex( ).
     DATA lt_attri TYPE z2ui5_if_core_types=>ty_t_attri.
     DATA(lo_model) = NEW z2ui5_cl_core_srv_model( attri = REF #( lt_attri )
@@ -1117,7 +1117,7 @@ CLASS ltcl_test_json_to_attri IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-one_way.
+    lr->bind        = abap_false.
     lr->name_client = `/MV_SIMPLE`.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
@@ -1127,7 +1127,7 @@ CLASS ltcl_test_json_to_attri IMPLEMENTATION.
 
     lo_model->main_json_to_attri( lo_model_json ).
 
-    " ONE_WAY binding - value must not be written back from frontend
+    " unbound attribute - value must not be written back from frontend
     cl_abap_unit_assert=>assert_equals( exp = ``
                                         act = lo_app->mv_simple ).
   ENDMETHOD.
@@ -1155,15 +1155,15 @@ CLASS ltcl_test_attri_refresh IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr->bind        = abap_true.
     lr->name_client = `/MV_SIMPLE`.
 
     " Refresh clears and re-dissolves but must restore binding info
     lo_model->main_attri_refresh( ).
 
     DATA(ls_after) = VALUE #( lt_attri[ name = `MV_SIMPLE` ] OPTIONAL ).
-    cl_abap_unit_assert=>assert_equals( exp = z2ui5_if_core_types=>cs_bind_type-two_way
-                                        act = ls_after-bind_type ).
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = ls_after-bind ).
     cl_abap_unit_assert=>assert_equals( exp = `/MV_SIMPLE`
                                         act = ls_after-name_client ).
   ENDMETHOD.
@@ -1581,7 +1581,7 @@ CLASS ltcl_test_deep_nesting IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr->bind        = abap_true.
     lr->name_client = `/MS_NESTED-INNER-DEEP1`.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
@@ -1613,7 +1613,7 @@ CLASS ltcl_test_deep_nesting IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr_inner->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr_inner->bind        = abap_true.
     lr_inner->name_client = `/MO_MID-MO_INNER-MV_INNER`.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
@@ -1653,7 +1653,7 @@ CLASS ltcl_test_refresh_ext IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr->bind        = abap_true.
     lr->name_client = `/MV_SIMPLE`.
 
     " Now instantiate the previously-null oref and refresh
@@ -1666,8 +1666,8 @@ CLASS ltcl_test_refresh_ext IMPLEMENTATION.
 
     " The pre-existing MV_SIMPLE binding must be preserved
     DATA(ls_simple) = VALUE #( lt_attri[ name = `MV_SIMPLE` ] OPTIONAL ).
-    cl_abap_unit_assert=>assert_equals( exp = z2ui5_if_core_types=>cs_bind_type-two_way
-                                        act = ls_simple-bind_type ).
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = ls_simple-bind ).
     cl_abap_unit_assert=>assert_equals( exp = `/MV_SIMPLE`
                                         act = ls_simple-name_client ).
   ENDMETHOD.
@@ -1696,7 +1696,7 @@ CLASS ltcl_test_json_types IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr->bind        = abap_true.
     lr->name_client = `/MV_INT`.
 
     DATA lo_model_json TYPE REF TO z2ui5_if_ajson.
@@ -1725,7 +1725,7 @@ CLASS ltcl_test_json_types IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>abort( ).
     ENDIF.
-    lr1->bind_type   = z2ui5_if_core_types=>cs_bind_type-two_way.
+    lr1->bind        = abap_true.
     lr1->name_client = `/MV_SIMPLE`.
 
     " Second entry: a copy with a different name_client path, also two-way

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -9,12 +9,6 @@ INTERFACE z2ui5_if_core_types
 
   CONSTANTS cs_event_nav_app_leave TYPE string VALUE `___ZZZ_NAL`.
 
-  CONSTANTS:
-    BEGIN OF cs_bind_type,
-      one_way  TYPE string VALUE `ONE_WAY`,
-      two_way  TYPE string VALUE `TWO_WAY`,
-    END OF cs_bind_type.
-
   " single source of truth for the five view slots in ty_s_next_frontend -
   " consumers SPLIT at the comma and access the components dynamically
   CONSTANTS cs_view_slot_list TYPE string VALUE `S_VIEW,S_VIEW_NEST,S_VIEW_NEST2,S_POPUP,S_POPOVER`.
@@ -49,7 +43,7 @@ INTERFACE z2ui5_if_core_types
       name_client        TYPE string,
       name_parent        TYPE string,
       name_ref           TYPE string,
-      bind_type          TYPE string,
+      bind               TYPE abap_bool,
       srtti_data         TYPE string,
       check_dissolved    TYPE abap_bool,
       custom_filter      TYPE REF TO z2ui5_if_ajson_filter,


### PR DESCRIPTION
# Description

This PR simplifies the data binding model by removing the explicit `type` parameter (ONE_WAY/TWO_WAY) from binding operations. The binding system now uses a single implicit binding mode where:

- All bindings are now treated uniformly (previously TWO_WAY)
- The `bind_type` attribute is replaced with a simple boolean `bind` flag
- The `type` parameter is removed from `main()` and `main_cell()` methods
- Validation that prevented mixing different binding types on the same attribute is removed

**Key changes:**
- Removed `cs_bind_type` constants (ONE_WAY, TWO_WAY) from `z2ui5_if_core_types`
- Changed `ty_s_attri.bind_type` (string) to `ty_s_attri.bind` (abap_bool)
- Simplified `z2ui5_cl_core_srv_bind` by removing `mv_type` field and `type` parameter
- Updated all test methods to use the new simplified binding API
- Updated model serialization/deserialization to check `bind = abap_true` instead of bind_type values
- Removed cross-binding-type validation in `check_raise_existing()`

This reduces API complexity while maintaining the same functional behavior for the common two-way binding use case.

## How to test

The existing unit tests have been updated to verify the simplified binding behavior:
- `ltcl_test_bind`: Tests basic binding path generation
- `ltcl_test_bind_idempotent`: Verifies binding is idempotent (same result on repeated calls)
- `ltcl_test_main_structure`: Tests binding at various nesting levels
- `ltcl_test_main_object`: Tests binding to object attributes
- `ltcl_test_json_stringify`: Verifies JSON serialization with bound attributes
- `ltcl_test_json_to_attri`: Tests bidirectional updates for bound attributes

All tests pass with the new simplified model.

## Checklist

- [x] Unit tests updated to reflect simplified binding model
- [x] No changes to generated code in `src/00/` or `src/01/03/`
- [x] Public API changes are in `src/01/02/` (internal implementation)
- [x] Changes made via abapGit: yes

https://claude.ai/code/session_01KqBW8H2hTSwczTto13WbUY