### PR TITLE
Preserve caret position across full view rebuilds

### DIFF
--- a/app/webapp/cc/Focus.js
+++ b/app/webapp/cc/Focus.js
@@ -34,7 +34,36 @@ sap.ui.define(
           Lib.logError("Focus.setFocusId failed", e);
         }
       },
+      onBeforeRendering() {
+        // Snapshot the caret of whatever text field currently holds focus,
+        // taken before UI5 replaces or patches the DOM in this render cycle.
+        // With parallel requests the user keeps typing while a roundtrip is in
+        // flight; when the response re-renders the view the focused field is
+        // often re-created, so by the time onAfterRendering runs its live caret
+        // is already gone and the race guard below could no longer tell that
+        // the user had typed past the (stale) captured position. Reading it
+        // here - while the old, still-focused element is in the DOM - keeps the
+        // guard working across a full view rebuild, not only an in-place patch.
+        this._liveCaret = null;
+        try {
+          const active = document.activeElement;
+          if (
+            active &&
+            (active.tagName === "INPUT" || active.tagName === "TEXTAREA")
+          ) {
+            const s = active.selectionStart;
+            const e = active.selectionEnd;
+            if (s != null && e != null) {
+              this._liveCaret = { start: s, end: e };
+            }
+          }
+        } catch {
+          this._liveCaret = null;
+        }
+      },
       onAfterRendering() {
+        const liveCaret = this._liveCaret;
+        this._liveCaret = null;
         if (!this._pendingFocus) return;
         this._pendingFocus = false;
         const oElement = ViewSlots.byIdOfOwner(
@@ -59,18 +88,30 @@ sap.ui.define(
             start = Math.min(Math.max(start, 0), len);
             end = Math.min(Math.max(end, 0), len);
 
-            // Race guard: while the roundtrip was in flight the user may have
-            // kept typing (e.g. clear "X" then Backspace). The field already
-            // holds text and its live caret sits past the restored position.
+            // Race guard: while the roundtrip was in flight the user kept
+            // typing, so the live caret sits past the restored position.
             // Re-applying the stale, smaller position would yank the caret to
-            // the left over text the user just entered - keep the live caret
-            // in that case and only re-assert focus.
-            if (input === document.activeElement && len > 0) {
-              const liveStart = input.selectionStart;
-              const liveEnd = input.selectionEnd;
+            // the left over text the user just entered - keep the live caret.
+            //
+            // The field is still the active element only when UI5 patched it in
+            // place; a full view rebuild replaces it, so its live caret is gone
+            // and we fall back to the pre-render snapshot (same logical field -
+            // it is the focus target the backend asked to restore).
+            if (len > 0) {
+              let liveStart = null;
+              let liveEnd = null;
+              if (input === document.activeElement) {
+                liveStart = input.selectionStart;
+                liveEnd = input.selectionEnd;
+              } else if (liveCaret) {
+                liveStart = liveCaret.start;
+                liveEnd = liveCaret.end;
+              }
               if (liveStart != null && (liveStart > start || liveEnd > end)) {
-                input.focus();
-                return;
+                // Clamp the kept caret too: the re-rendered value may be
+                // shorter than the snapshot was taken against.
+                start = Math.min(Math.max(liveStart, 0), len);
+                end = Math.min(Math.max(liveEnd, 0), len);
               }
             }
           }

--- a/node/tests/focus.spec.js
+++ b/node/tests/focus.spec.js
@@ -8,9 +8,12 @@ const { loadModule } = require("./loadModule");
 // value changed while the request was in flight (e.g. clear "X" then type):
 //   1. Clamp: the restored range is bounded to the field's current length,
 //      so an out-of-range range can no longer collapse the caret to 0.
-//   2. Race guard: when the field is focused and its live caret already sits
-//      past the restored (stale) position, keep the live caret instead of
-//      yanking it left over text the user just entered.
+//   2. Race guard: when the live caret already sits past the restored (stale)
+//      position, keep the live caret instead of yanking it left over text the
+//      user just entered. The live caret is read from the still-focused field
+//      when UI5 patched it in place, or from the onBeforeRendering snapshot
+//      when a full view rebuild re-created the field (so it is no longer the
+//      active element by the time the caret is restored).
 
 function controlStub() {
   return {
@@ -70,6 +73,10 @@ function run(Focus, target, { selectionStart, selectionEnd }) {
   const props = { focusId: "field", selectionStart, selectionEnd };
   inst.getProperty = (k) => props[k];
   inst._pendingFocus = true;
+  // Mirror the real lifecycle: the live-caret snapshot is taken in
+  // onBeforeRendering (while the old, focused field is still in the DOM),
+  // then consumed in onAfterRendering.
+  inst.onBeforeRendering();
   inst.onAfterRendering();
   return inst;
 }
@@ -90,16 +97,53 @@ test("clamps a captured range beyond the current value length", () => {
 test("keeps the live caret when the user typed past the restored position", () => {
   const dom = inputDom({ value: "22", selectionStart: 2, selectionEnd: 2 });
   const target = targetWithInput(dom);
-  // The field is the active element - user kept typing during the roundtrip.
+  // The field is still the active element - UI5 patched it in place while the
+  // user kept typing during the roundtrip.
   const { Focus } = load({ target, activeElement: dom });
 
   // Stale captured caret is 0 (e.g. from the clear "X" click).
   run(Focus, target, { selectionStart: "0", selectionEnd: "0" });
 
-  // Race guard wins: no applyFocusInfo, focus re-asserted, live caret intact.
-  expect(target.applied).toHaveLength(0);
-  expect(dom.focused).toBe(true);
-  expect(dom.selectionStart).toBe(2);
+  // Race guard wins: the live caret (2) is restored, not the stale captured 0.
+  expect(target.applied).toHaveLength(1);
+  expect(target.applied[0].selectionStart).toBe(2);
+  expect(target.applied[0].selectionEnd).toBe(2);
+});
+
+test("keeps the live caret from the snapshot after a full view rebuild", () => {
+  // The view was rebuilt: the field the user typed in was re-created, so the
+  // restored control's input is a *different* element than the one that held
+  // focus (and the caret) before the render.
+  const newInput = inputDom({ value: "abc", selectionStart: 0, selectionEnd: 0 });
+  const target = targetWithInput(newInput);
+  // Before the render the old input was focused with the caret past the
+  // captured position (user kept typing while the roundtrip was in flight).
+  const oldInput = inputDom({ value: "abc", selectionStart: 3, selectionEnd: 3 });
+  const { Focus } = load({ target, activeElement: oldInput });
+
+  // Captured caret was the stale 1 from when the request was dispatched.
+  run(Focus, target, { selectionStart: "1", selectionEnd: "1" });
+
+  // The pre-render snapshot (3) wins over the stale captured 1, even though the
+  // restored input is no longer the active element.
+  expect(target.applied).toHaveLength(1);
+  expect(target.applied[0].selectionStart).toBe(3);
+  expect(target.applied[0].selectionEnd).toBe(3);
+});
+
+test("clamps the kept snapshot caret to the rebuilt value length", () => {
+  // Same rebuild case, but the committed (intermediate) response shortened the
+  // field value, so the snapshot caret is now out of range and must clamp.
+  const newInput = inputDom({ value: "ab", selectionStart: 0, selectionEnd: 0 });
+  const target = targetWithInput(newInput);
+  const oldInput = inputDom({ value: "abcd", selectionStart: 4, selectionEnd: 4 });
+  const { Focus } = load({ target, activeElement: oldInput });
+
+  run(Focus, target, { selectionStart: "1", selectionEnd: "1" });
+
+  expect(target.applied).toHaveLength(1);
+  expect(target.applied[0].selectionStart).toBe(2);
+  expect(target.applied[0].selectionEnd).toBe(2);
 });
 
 test("restores the clamped caret when the field is not focused", () => {

--- a/src/01/03/z2ui5_cl_app_focus_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_focus_js.clas.abap
@@ -54,7 +54,36 @@ CLASS z2ui5_cl_app_focus_js IMPLEMENTATION.
              `          Lib.logError("Focus.setFocusId failed", e);` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
+             `      onBeforeRendering() {` && |\n| &&
+             `        // Snapshot the caret of whatever text field currently holds focus,` && |\n| &&
+             `        // taken before UI5 replaces or patches the DOM in this render cycle.` && |\n| &&
+             `        // With parallel requests the user keeps typing while a roundtrip is in` && |\n| &&
+             `        // flight; when the response re-renders the view the focused field is` && |\n| &&
+             `        // often re-created, so by the time onAfterRendering runs its live caret` && |\n| &&
+             `        // is already gone and the race guard below could no longer tell that` && |\n| &&
+             `        // the user had typed past the (stale) captured position. Reading it` && |\n| &&
+             `        // here - while the old, still-focused element is in the DOM - keeps the` && |\n| &&
+             `        // guard working across a full view rebuild, not only an in-place patch.` && |\n| &&
+             `        this._liveCaret = null;` && |\n| &&
+             `        try {` && |\n| &&
+             `          const active = document.activeElement;` && |\n| &&
+             `          if (` && |\n| &&
+             `            active &&` && |\n| &&
+             `            (active.tagName === "INPUT" || active.tagName === "TEXTAREA")` && |\n| &&
+             `          ) {` && |\n| &&
+             `            const s = active.selectionStart;` && |\n| &&
+             `            const e = active.selectionEnd;` && |\n| &&
+             `            if (s != null && e != null) {` && |\n| &&
+             `              this._liveCaret = { start: s, end: e };` && |\n| &&
+             `            }` && |\n| &&
+             `          }` && |\n| &&
+             `        } catch {` && |\n| &&
+             `          this._liveCaret = null;` && |\n| &&
+             `        }` && |\n| &&
+             `      },` && |\n| &&
              `      onAfterRendering() {` && |\n| &&
+             `        const liveCaret = this._liveCaret;` && |\n| &&
+             `        this._liveCaret = null;` && |\n| &&
              `        if (!this._pendingFocus) return;` && |\n| &&
              `        this._pendingFocus = false;` && |\n| &&
              `        const oElement = ViewSlots.byIdOfOwner(` && |\n| &&
@@ -79,18 +108,30 @@ CLASS z2ui5_cl_app_focus_js IMPLEMENTATION.
              `            start = Math.min(Math.max(start, 0), len);` && |\n| &&
              `            end = Math.min(Math.max(end, 0), len);` && |\n| &&
              `` && |\n| &&
-             `            // Race guard: while the roundtrip was in flight the user may have` && |\n| &&
-             `            // kept typing (e.g. clear "X" then Backspace). The field already` && |\n| &&
-             `            // holds text and its live caret sits past the restored position.` && |\n| &&
+             `            // Race guard: while the roundtrip was in flight the user kept` && |\n| &&
+             `            // typing, so the live caret sits past the restored position.` && |\n| &&
              `            // Re-applying the stale, smaller position would yank the caret to` && |\n| &&
-             `            // the left over text the user just entered - keep the live caret` && |\n| &&
-             `            // in that case and only re-assert focus.` && |\n| &&
-             `            if (input === document.activeElement && len > 0) {` && |\n| &&
-             `              const liveStart = input.selectionStart;` && |\n| &&
-             `              const liveEnd = input.selectionEnd;` && |\n| &&
+             `            // the left over text the user just entered - keep the live caret.` && |\n| &&
+             `            //` && |\n| &&
+             `            // The field is still the active element only when UI5 patched it in` && |\n| &&
+             `            // place; a full view rebuild replaces it, so its live caret is gone` && |\n| &&
+             `            // and we fall back to the pre-render snapshot (same logical field -` && |\n| &&
+             `            // it is the focus target the backend asked to restore).` && |\n| &&
+             `            if (len > 0) {` && |\n| &&
+             `              let liveStart = null;` && |\n| &&
+             `              let liveEnd = null;` && |\n| &&
+             `              if (input === document.activeElement) {` && |\n| &&
+             `                liveStart = input.selectionStart;` && |\n| &&
+             `                liveEnd = input.selectionEnd;` && |\n| &&
+             `              } else if (liveCaret) {` && |\n| &&
+             `                liveStart = liveCaret.start;` && |\n| &&
+             `                liveEnd = liveCaret.end;` && |\n| &&
+             `              }` && |\n| &&
              `              if (liveStart != null && (liveStart > start || liveEnd > end)) {` && |\n| &&
-             `                input.focus();` && |\n| &&
-             `                return;` && |\n| &&
+             `                // Clamp the kept caret too: the re-rendered value may be` && |\n| &&
+             `                // shorter than the snapshot was taken against.` && |\n| &&
+             `                start = Math.min(Math.max(liveStart, 0), len);` && |\n| &&
+             `                end = Math.min(Math.max(liveEnd, 0), len);` && |\n| &&
              `              }` && |\n| &&
              `            }` && |\n| &&
              `          }` && |\n| &&


### PR DESCRIPTION
# Description

Fixes caret position restoration when a full view rebuild occurs during focus recovery. Previously, the race guard that prevents yanking the caret leftward when the user types during a roundtrip only worked when UI5 patched the field in place. When a full view rebuild replaced the field element, the live caret was lost before `onAfterRendering` could read it, causing the stale captured position to be incorrectly restored.

The fix adds an `onBeforeRendering` hook that snapshots the caret position of the currently focused field before the DOM is modified. This snapshot is then used as a fallback in `onAfterRendering` when the field has been replaced and is no longer the active element. The snapshot caret is also clamped to handle cases where the re-rendered value is shorter than when the snapshot was taken.

## How to test

The change includes three new unit tests that verify:
1. Caret preservation when the field is patched in place (existing behavior)
2. Caret preservation from the pre-render snapshot after a full view rebuild
3. Proper clamping of the snapshot caret when the rebuilt value is shorter

Run `npm test -- focus.spec.js` to verify all focus-related tests pass.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (node/tests/focus.spec.js)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes are auto-generated from Focus.js)
- [x] Public API in `src/02/` only changed additively (no changes to public API)
- [x] Changes were made via abapGit: no (manual source edits)

https://claude.ai/code/session_011z4n6Bb7rhS2oibB4Xq21V