### PR TITLE
Fix nested view model sharing and size limit handling

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -41,7 +41,12 @@ sap.ui.define(
 
     function applyStoredSizeLimit(viewKey, oModel) {
       if (!oModel) return;
-      const limit = AppState.state.viewSizeLimits[viewKey];
+      // For the root slots (MAIN/NEST/NEST2) this is the max limit across them,
+      // since they share this one model; popup/popover get their own limit.
+      const limit = Lib.effectiveSizeLimit(
+        AppState.state.viewSizeLimits,
+        viewKey,
+      );
       if (limit !== undefined) oModel.setSizeLimit(limit);
     }
 
@@ -245,19 +250,28 @@ sap.ui.define(
 
       async displayNestedView(xml, slotKey) {
         const paramKey = ViewSlots.paramByKey(slotKey);
-        const oModel = this._createViewModel();
-        applyStoredSizeLimit(slotKey, oModel);
+        // Nested views do NOT create their own model. They are inserted into
+        // the MAIN control tree below and inherit its default JSON model via
+        // UI5 model propagation, so every view binds against the same data with
+        // one change tracker and one refresh per roundtrip - no duplicate
+        // models pointing at the same data. The model passed to the XML
+        // preprocessor here only feeds {template>...} bindings at build time;
+        // it is the MAIN view's JSON model (the named "http" model when
+        // SWITCH_DEFAULT_MODEL_PATH moved OData into the default slot, otherwise
+        // the default model), mirroring displayView's template model.
+        const oMainView = ViewSlots.getView("MAIN");
+        const oTemplateModel =
+          oMainView?.getModel("http") ?? oMainView?.getModel();
         const oView = await XMLView.create({
           definition: xml,
           controller: ViewSlots.getController(slotKey),
-          preprocessors: { xml: { models: { template: oModel } } },
+          preprocessors: { xml: { models: { template: oTemplateModel } } },
         });
 
         if (!Lib.isAlive(AppState.state.oApp)) {
           oView.destroy();
           return;
         }
-        oView.setModel(oModel);
 
         const nestParams = AppState.state.oResponse?.PARAMS?.[paramKey];
         if (!nestParams) {
@@ -424,8 +438,10 @@ sap.ui.define(
           return ViewSlots.getView("MAIN")?.getModel();
         }
 
-        // Non-main slots return their own model so the delta is read from the
-        // view that actually fired the event.
+        // Non-main slots return the model of the view that fired the event.
+        // For the nested slots this resolves - via model propagation - to the
+        // same root model as MAIN, which is exactly right: the data and the
+        // changedPaths delta are shared. Popup/popover return their own model.
         return ViewSlots.getView(slotKey)?.getModel();
       },
 
@@ -454,7 +470,14 @@ sap.ui.define(
           isOurs(oView.getModel()) ?? isOurs(oView.getModel("http"));
         if (tracked) {
           applyStoredSizeLimit(slotKey, tracked);
-          tracked.setData(AppState.state.oResponse?.OVIEWMODEL);
+          // MAIN and its nested views resolve to the SAME root model here, and
+          // the update loop calls this once per slot. setData replaces the
+          // model's data reference with OVIEWMODEL, so once the first root slot
+          // has swapped it in, the others already hold it - skip the redundant
+          // setData (and its full binding refresh) instead of running it once
+          // per shared slot.
+          const data = AppState.state.oResponse?.OVIEWMODEL;
+          if (tracked.getData() !== data) tracked.setData(data);
           return;
         }
 

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -407,7 +407,6 @@ sap.ui.define(
       const hasLimit = args[2] !== undefined && args[2] !== "";
       const viewKey = hasLimit ? args[2] : args[1];
       const limit = hasLimit ? Number(args[1]) : NaN;
-      const model = ViewSlots.getView(viewKey)?.getModel();
 
       const isValidLimit = Number.isFinite(limit) && limit > 0;
       if (isValidLimit) {
@@ -415,9 +414,19 @@ sap.ui.define(
       } else {
         delete AppState.state.viewSizeLimits[viewKey];
       }
+
+      // MAIN and the two nested views share one root model via propagation, so
+      // resolve the model through MAIN for those slots and apply the effective
+      // (largest) limit across them; popup/popover keep their own model/limit.
+      const modelKey = Lib.isRootModelSlot(viewKey) ? "MAIN" : viewKey;
+      const model = ViewSlots.getView(modelKey)?.getModel();
       if (model) {
+        const effective = Lib.effectiveSizeLimit(
+          AppState.state.viewSizeLimits,
+          viewKey,
+        );
         // 100 is the UI5 JSONModel default size limit.
-        model.setSizeLimit(isValidLimit ? limit : 100);
+        model.setSizeLimit(effective ?? 100);
         model.refresh(true);
       }
     }

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -405,6 +405,33 @@ sap.ui.define(
       return _sanitizeEl.innerHTML;
     }
 
+    // The MAIN view and its two nested views (NEST, NEST2) share ONE JSON
+    // model: the nested views are inserted into the MAIN control tree and
+    // inherit its default model through UI5 model propagation instead of each
+    // creating their own. Popup and popover are opened standalone (outside the
+    // MAIN tree) and keep their own model.
+    const ROOT_MODEL_SLOTS = ["MAIN", "NEST", "NEST2"];
+
+    function isRootModelSlot(slotKey) {
+      return ROOT_MODEL_SLOTS.includes(slotKey);
+    }
+
+    // Effective JSONModel size limit for a slot. Because the root slots share a
+    // single model, a per-view limit collapses onto it - the largest requested
+    // limit across MAIN/NEST/NEST2 wins. Popup/popover keep their own limit.
+    // Returns undefined when nothing is stored, so callers keep the UI5 default.
+    function effectiveSizeLimit(viewSizeLimits, slotKey) {
+      if (!isRootModelSlot(slotKey)) return viewSizeLimits[slotKey];
+      let max;
+      for (const key of ROOT_MODEL_SLOTS) {
+        const limit = viewSizeLimits[key];
+        if (limit !== undefined && (max === undefined || limit > max)) {
+          max = limit;
+        }
+      }
+      return max;
+    }
+
     return {
       logError,
       isDestroyed,
@@ -427,6 +454,8 @@ sap.ui.define(
       getElementById,
       getMessaging,
       hasMessagingModule,
+      isRootModelSlot,
+      effectiveSizeLimit,
     };
   },
 );

--- a/node/tests/sizeLimit.spec.js
+++ b/node/tests/sizeLimit.spec.js
@@ -1,0 +1,57 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loadLib } = require("./loadLibModule");
+
+// Tests the shared size-limit helpers in app/webapp/core/Lib.js. They encode
+// the nested-views model architecture: MAIN, NEST and NEST2 share ONE root
+// JSON model (the nested views inherit MAIN's default model via UI5 model
+// propagation), so a per-view size limit collapses onto that single model and
+// the largest requested limit across the three wins. Popup/popover are
+// standalone and keep their own limit.
+
+test.describe("isRootModelSlot", () => {
+  const { Lib } = loadLib();
+
+  test("MAIN and the two nested slots share the root model", () => {
+    expect(Lib.isRootModelSlot("MAIN")).toBe(true);
+    expect(Lib.isRootModelSlot("NEST")).toBe(true);
+    expect(Lib.isRootModelSlot("NEST2")).toBe(true);
+  });
+
+  test("popup and popover do not", () => {
+    expect(Lib.isRootModelSlot("POPUP")).toBe(false);
+    expect(Lib.isRootModelSlot("POPOVER")).toBe(false);
+    expect(Lib.isRootModelSlot("UNKNOWN")).toBe(false);
+  });
+});
+
+test.describe("effectiveSizeLimit", () => {
+  const { Lib } = loadLib();
+
+  test("returns undefined for a root slot when nothing is stored", () => {
+    expect(Lib.effectiveSizeLimit({}, "MAIN")).toBeUndefined();
+    expect(Lib.effectiveSizeLimit({}, "NEST")).toBeUndefined();
+  });
+
+  test("a root slot gets the max limit across MAIN/NEST/NEST2", () => {
+    const limits = { MAIN: 100, NEST: 500, NEST2: 200 };
+    expect(Lib.effectiveSizeLimit(limits, "MAIN")).toBe(500);
+    expect(Lib.effectiveSizeLimit(limits, "NEST")).toBe(500);
+    expect(Lib.effectiveSizeLimit(limits, "NEST2")).toBe(500);
+  });
+
+  test("ignores unset root slots when taking the max", () => {
+    expect(Lib.effectiveSizeLimit({ NEST: 300 }, "MAIN")).toBe(300);
+    expect(Lib.effectiveSizeLimit({ MAIN: 100, NEST2: 50 }, "NEST")).toBe(100);
+  });
+
+  test("a standalone slot keeps its own limit, not the root max", () => {
+    const limits = { MAIN: 999, POPUP: 100, POPOVER: 250 };
+    expect(Lib.effectiveSizeLimit(limits, "POPUP")).toBe(100);
+    expect(Lib.effectiveSizeLimit(limits, "POPOVER")).toBe(250);
+  });
+
+  test("a standalone slot with no stored limit returns undefined", () => {
+    expect(Lib.effectiveSizeLimit({ MAIN: 500 }, "POPUP")).toBeUndefined();
+  });
+});

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -428,7 +428,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const hasLimit = args[2] !== undefined && args[2] !== "";` && |\n| &&
              `      const viewKey = hasLimit ? args[2] : args[1];` && |\n| &&
              `      const limit = hasLimit ? Number(args[1]) : NaN;` && |\n| &&
-             `      const model = ViewSlots.getView(viewKey)?.getModel();` && |\n| &&
              `` && |\n| &&
              `      const isValidLimit = Number.isFinite(limit) && limit > 0;` && |\n| &&
              `      if (isValidLimit) {` && |\n| &&
@@ -436,9 +435,19 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      } else {` && |\n| &&
              `        delete AppState.state.viewSizeLimits[viewKey];` && |\n| &&
              `      }` && |\n| &&
+             `` && |\n| &&
+             `      // MAIN and the two nested views share one root model via propagation, so` && |\n| &&
+             `      // resolve the model through MAIN for those slots and apply the effective` && |\n| &&
+             `      // (largest) limit across them; popup/popover keep their own model/limit.` && |\n| &&
+             `      const modelKey = Lib.isRootModelSlot(viewKey) ? "MAIN" : viewKey;` && |\n| &&
+             `      const model = ViewSlots.getView(modelKey)?.getModel();` && |\n| &&
              `      if (model) {` && |\n| &&
+             `        const effective = Lib.effectiveSizeLimit(` && |\n| &&
+             `          AppState.state.viewSizeLimits,` && |\n| &&
+             `          viewKey,` && |\n| &&
+             `        );` && |\n| &&
              `        // 100 is the UI5 JSONModel default size limit.` && |\n| &&
-             `        model.setSizeLimit(isValidLimit ? limit : 100);` && |\n| &&
+             `        model.setSizeLimit(effective ?? 100);` && |\n| &&
              `        model.refresh(true);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
@@ -809,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `              Lib.logError(` && |\n| &&
              `                "SET_TITLE_LAUNCHPAD: ShellUIService.setTitle failed",` && |\n| &&
              `                e,` && |\n| &&
-             `              ),` && |\n| &&
+             `              ),` && |\n|.
+    result = result &&
              `            );` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&
@@ -818,8 +828,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function evZ2ui5Custom(oController, args) {` && |\n|.
-    result = result &&
+             `    function evZ2ui5Custom(oController, args) {` && |\n| &&
              `      try {` && |\n| &&
              `        // Custom functions are registered by apps on the public z2ui5` && |\n| &&
              `        // global (js_loader popup), so resolve them via the facade.` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -426,6 +426,33 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      return _sanitizeEl.innerHTML;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // The MAIN view and its two nested views (NEST, NEST2) share ONE JSON` && |\n| &&
+             `    // model: the nested views are inserted into the MAIN control tree and` && |\n| &&
+             `    // inherit its default model through UI5 model propagation instead of each` && |\n| &&
+             `    // creating their own. Popup and popover are opened standalone (outside the` && |\n| &&
+             `    // MAIN tree) and keep their own model.` && |\n| &&
+             `    const ROOT_MODEL_SLOTS = ["MAIN", "NEST", "NEST2"];` && |\n| &&
+             `` && |\n| &&
+             `    function isRootModelSlot(slotKey) {` && |\n| &&
+             `      return ROOT_MODEL_SLOTS.includes(slotKey);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // Effective JSONModel size limit for a slot. Because the root slots share a` && |\n| &&
+             `    // single model, a per-view limit collapses onto it - the largest requested` && |\n| &&
+             `    // limit across MAIN/NEST/NEST2 wins. Popup/popover keep their own limit.` && |\n| &&
+             `    // Returns undefined when nothing is stored, so callers keep the UI5 default.` && |\n| &&
+             `    function effectiveSizeLimit(viewSizeLimits, slotKey) {` && |\n| &&
+             `      if (!isRootModelSlot(slotKey)) return viewSizeLimits[slotKey];` && |\n| &&
+             `      let max;` && |\n| &&
+             `      for (const key of ROOT_MODEL_SLOTS) {` && |\n| &&
+             `        const limit = viewSizeLimits[key];` && |\n| &&
+             `        if (limit !== undefined && (max === undefined || limit > max)) {` && |\n| &&
+             `          max = limit;` && |\n| &&
+             `        }` && |\n| &&
+             `      }` && |\n| &&
+             `      return max;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    return {` && |\n| &&
              `      logError,` && |\n| &&
              `      isDestroyed,` && |\n| &&
@@ -448,6 +475,8 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      getElementById,` && |\n| &&
              `      getMessaging,` && |\n| &&
              `      hasMessagingModule,` && |\n| &&
+             `      isRootModelSlot,` && |\n| &&
+             `      effectiveSizeLimit,` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&
              `);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -61,7 +61,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `    function applyStoredSizeLimit(viewKey, oModel) {` && |\n| &&
              `      if (!oModel) return;` && |\n| &&
-             `      const limit = AppState.state.viewSizeLimits[viewKey];` && |\n| &&
+             `      // For the root slots (MAIN/NEST/NEST2) this is the max limit across them,` && |\n| &&
+             `      // since they share this one model; popup/popover get their own limit.` && |\n| &&
+             `      const limit = Lib.effectiveSizeLimit(` && |\n| &&
+             `        AppState.state.viewSizeLimits,` && |\n| &&
+             `        viewKey,` && |\n| &&
+             `      );` && |\n| &&
              `      if (limit !== undefined) oModel.setSizeLimit(limit);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
@@ -265,19 +270,28 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `` && |\n| &&
              `      async displayNestedView(xml, slotKey) {` && |\n| &&
              `        const paramKey = ViewSlots.paramByKey(slotKey);` && |\n| &&
-             `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit(slotKey, oModel);` && |\n| &&
+             `        // Nested views do NOT create their own model. They are inserted into` && |\n| &&
+             `        // the MAIN control tree below and inherit its default JSON model via` && |\n| &&
+             `        // UI5 model propagation, so every view binds against the same data with` && |\n| &&
+             `        // one change tracker and one refresh per roundtrip - no duplicate` && |\n| &&
+             `        // models pointing at the same data. The model passed to the XML` && |\n| &&
+             `        // preprocessor here only feeds {template>...} bindings at build time;` && |\n| &&
+             `        // it is the MAIN view's JSON model (the named "http" model when` && |\n| &&
+             `        // SWITCH_DEFAULT_MODEL_PATH moved OData into the default slot, otherwise` && |\n| &&
+             `        // the default model), mirroring displayView's template model.` && |\n| &&
+             `        const oMainView = ViewSlots.getView("MAIN");` && |\n| &&
+             `        const oTemplateModel =` && |\n| &&
+             `          oMainView?.getModel("http") ?? oMainView?.getModel();` && |\n| &&
              `        const oView = await XMLView.create({` && |\n| &&
              `          definition: xml,` && |\n| &&
              `          controller: ViewSlots.getController(slotKey),` && |\n| &&
-             `          preprocessors: { xml: { models: { template: oModel } } },` && |\n| &&
+             `          preprocessors: { xml: { models: { template: oTemplateModel } } },` && |\n| &&
              `        });` && |\n| &&
              `` && |\n| &&
              `        if (!Lib.isAlive(AppState.state.oApp)) {` && |\n| &&
              `          oView.destroy();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        oView.setModel(oModel);` && |\n| &&
              `` && |\n| &&
              `        const nestParams = AppState.state.oResponse?.PARAMS?.[paramKey];` && |\n| &&
              `        if (!nestParams) {` && |\n| &&
@@ -403,7 +417,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        // mapping is: main app controller -> main view, popup controller ->` && |\n| &&
              `        // popup view, etc.` && |\n| &&
              `        const oModel = this._pickModelForRoundtrip(useMainModel);` && |\n| &&
-             `` && |\n| &&
+             `` && |\n|.
+    result = result &&
              `        Lib.runCallbacks(AppState.state.onBeforeRoundtrip);` && |\n| &&
              `` && |\n| &&
              `        // If the user edited model paths, send only the delta to keep the` && |\n| &&
@@ -417,8 +432,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `            );` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&
-             `` && |\n|.
-    result = result &&
+             `` && |\n| &&
              `        oBody.ID = AppState.state.oResponse?.ID;` && |\n| &&
              `        // Arguments travel as raw JSON values - the request body is` && |\n| &&
              `        // serialized exactly once in Server.readHttp. Object arguments are` && |\n| &&
@@ -445,8 +459,10 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          return ViewSlots.getView("MAIN")?.getModel();` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
-             `        // Non-main slots return their own model so the delta is read from the` && |\n| &&
-             `        // view that actually fired the event.` && |\n| &&
+             `        // Non-main slots return the model of the view that fired the event.` && |\n| &&
+             `        // For the nested slots this resolves - via model propagation - to the` && |\n| &&
+             `        // same root model as MAIN, which is exactly right: the data and the` && |\n| &&
+             `        // changedPaths delta are shared. Popup/popover return their own model.` && |\n| &&
              `        return ViewSlots.getView(slotKey)?.getModel();` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -475,7 +491,14 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          isOurs(oView.getModel()) ?? isOurs(oView.getModel("http"));` && |\n| &&
              `        if (tracked) {` && |\n| &&
              `          applyStoredSizeLimit(slotKey, tracked);` && |\n| &&
-             `          tracked.setData(AppState.state.oResponse?.OVIEWMODEL);` && |\n| &&
+             `          // MAIN and its nested views resolve to the SAME root model here, and` && |\n| &&
+             `          // the update loop calls this once per slot. setData replaces the` && |\n| &&
+             `          // model's data reference with OVIEWMODEL, so once the first root slot` && |\n| &&
+             `          // has swapped it in, the others already hold it - skip the redundant` && |\n| &&
+             `          // setData (and its full binding refresh) instead of running it once` && |\n| &&
+             `          // per shared slot.` && |\n| &&
+             `          const data = AppState.state.oResponse?.OVIEWMODEL;` && |\n| &&
+             `          if (tracked.getData() !== data) tracked.setData(data);` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -102,6 +102,7 @@ INTERFACE z2ui5_if_client
       method_destroy TYPE clike OPTIONAL.
 
   METHODS nest_view_destroy.
+  "! obsolete - main and nested views share one model now, use view_model_update instead
   METHODS nest_view_model_update.
 
   METHODS nest2_view_display
@@ -112,6 +113,7 @@ INTERFACE z2ui5_if_client
       method_destroy TYPE clike OPTIONAL.
 
   METHODS nest2_view_destroy.
+  "! obsolete - main and nested views share one model now, use view_model_update instead
   METHODS nest2_view_model_update.
 
   METHODS popup_display


### PR DESCRIPTION
## Description

This PR fixes the model architecture for nested views (NEST, NEST2) to properly share the root JSON model with MAIN via UI5 model propagation, eliminating duplicate models pointing at the same data.

### Key Changes

1. **Nested View Model Sharing**: Modified `displayNestedView()` to stop creating a separate model for nested views. Instead, nested views now inherit MAIN's default model through UI5 model propagation, ensuring:
   - Single change tracker and one refresh per roundtrip
   - No duplicate models pointing at the same data
   - Template bindings use MAIN's model (the "http" model or default model)

2. **Size Limit Consolidation**: Added `Lib.isRootModelSlot()` and `Lib.effectiveSizeLimit()` helpers to handle the fact that MAIN/NEST/NEST2 share one root model:
   - Per-view size limits collapse onto the shared model
   - The largest requested limit across the three root slots wins
   - Popup/popover keep their own independent limits
   - Updated `applyStoredSizeLimit()` and `evSetSizeLimit()` to use the effective limit

3. **Redundant setData Optimization**: In the update loop, skip redundant `setData()` calls when multiple root slots resolve to the same model instance, preventing unnecessary full binding refreshes.

4. **Documentation**: Added comprehensive comments explaining the nested views model propagation architecture and size limit consolidation logic.

### Files Modified

- `app/webapp/core/Lib.js`: Added `isRootModelSlot()` and `effectiveSizeLimit()` functions
- `app/webapp/controller/View1.controller.js`: Updated nested view creation and model update logic
- `app/webapp/core/FrontendAction.js`: Updated size limit application to use effective limits
- `src/02/z2ui5_if_client.intf.abap`: Marked `nest_view_model_update()` as obsolete
- Corresponding ABAP source files with generated JavaScript

### Testing

- Added comprehensive unit tests in `node/tests/sizeLimit.spec.js` covering:
  - `isRootModelSlot()` behavior for root vs. standalone slots
  - `effectiveSizeLimit()` max calculation across root slots
  - Handling of undefined limits and standalone slot independence

## How to test

1. Run the new unit tests: `npm test -- sizeLimit.spec.js`
2. Verify nested views still display correctly and share data with MAIN
3. Test size limit setting on MAIN/NEST/NEST2 slots - the largest limit should apply to all three
4. Verify popup/popover size limits remain independent

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added (`node/tests/sizeLimit.spec.js`)
- [x] No manual edits under `src/00/` or `src/01/03/` (generated from source)
- [x] Public API in `src/02/` only changed additively (marked method as obsolete)
- [x] Changes made via abapGit: no (direct source edits)

https://claude.ai/code/session_01F4VXychqy741rejPzYwLxy