### PR TITLE
Add view parameter to follow_up_action / _event_client

### DIFF
--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -47,6 +47,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
     IF val IS NOT INITIAL
         AND val CO `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_`.
       lv_js = mo_srv_event->get_event_client( val   = val
+                                              view  = view
                                               t_arg = t_arg ).
     ENDIF.
 
@@ -408,8 +409,9 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~_event_client.
 
-    result = mo_srv_event->get_event_client( val = val
-                                       t_arg     = t_arg ).
+    result = mo_srv_event->get_event_client( val   = val
+                                             view  = view
+                                             t_arg = t_arg ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -412,13 +412,17 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
     " the whitelisted control calls are plain follow-up events - t_arg is
     " positional: control_global = object, method, params; control_by_id =
-    " id, view (`` keeps the slot), method, params
+    " id, method, params (the view is the separate view parameter, default
+    " cs_view-main -> empty slot; a concrete view fills the slot)
     li_client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_global
                                  t_arg = VALUE #( ( `MESSAGE_TOAST` ) ( `show` ) ( `Hello` ) ) ).
     li_client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
-                                 t_arg = VALUE #( ( `demoPanel` ) ( `` ) ( `setExpanded` ) ( `X` ) ) ).
+                                 t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ).
+    li_client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
+                                 view  = z2ui5_if_client=>cs_view-popover
+                                 t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ).
 
-    cl_abap_unit_assert=>assert_equals( exp = 2
+    cl_abap_unit_assert=>assert_equals( exp = 3
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
     cl_abap_unit_assert=>assert_equals(
         exp = `.eF('CONTROL_GLOBAL', 'MESSAGE_TOAST', 'show', 'Hello')`
@@ -426,6 +430,9 @@ CLASS ltcl_test_client IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = `.eF('CONTROL_BY_ID', 'demoPanel', '', 'setExpanded', 'X')`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'demoPanel', 'POPOVER', 'setExpanded', 'X')`
+        act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 3 ] ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -13,6 +13,7 @@ CLASS z2ui5_cl_core_srv_event DEFINITION PUBLIC FINAL.
     METHODS get_event_client
       IMPORTING
         val           TYPE clike
+        view          TYPE clike        DEFAULT z2ui5_if_client=>cs_view-main
         t_arg         TYPE string_table OPTIONAL
       RETURNING
         VALUE(result) TYPE string.
@@ -69,6 +70,16 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
                         ( `to` )
                         ( VALUE #( t_arg[ 2 ] OPTIONAL ) ) ).
       lv_val = z2ui5_if_client=>cs_event-control_by_id.
+    ELSEIF lv_val = z2ui5_if_client=>cs_event-control_by_id.
+      " the view is passed as its own parameter now, not as a positional
+      " t_arg slot; inject it at position 2 so the frontend still reads
+      " args = id, view, method, ... . cs_view-main maps to the empty slot,
+      " keeping the unchanged default where the id resolves across all open
+      " views (resolveById); a concrete view scopes the lookup to that slot.
+      DATA(lv_view_slot) = COND string( WHEN view = z2ui5_if_client=>cs_view-main THEN ``
+                                        ELSE CONV string( view ) ).
+      lt_arg = t_arg.
+      INSERT lv_view_slot INTO lt_arg INDEX 2.
     ENDIF.
 
     result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ lv_val }'{ get_t_arg( lt_arg ) }|.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
@@ -11,6 +11,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS event_empty_arg   FOR TESTING.
     METHODS event_empty_middle_arg FOR TESTING.
     METHODS event_trailing_empty_arg FOR TESTING.
+    METHODS event_view_param FOR TESTING.
     METHODS event_multi_req   FOR TESTING.
     METHODS event_client_args FOR TESTING.
     METHODS event_nav_container FOR TESTING.
@@ -197,14 +198,15 @@ CLASS ltcl_test IMPLEMENTATION.
     DATA lo_event TYPE REF TO z2ui5_cl_core_srv_event.
     lo_event = NEW #( ).
 
-    " an empty argument BETWEEN filled ones keeps its position - dropping
-    " it would shift every following argument into the wrong slot (a
-    " CONTROL_BY_ID action without a view lost its method name this way,
-    " live find in beta samples 448/449)
+    " for control_by_id the view is injected as the empty slot at position 2
+    " (default cs_view-main), so an empty argument BETWEEN filled ones keeps
+    " its position - dropping it would shift every following argument into the
+    " wrong slot (a CONTROL_BY_ID action without a view lost its method name
+    " this way, live find in beta samples 448/449)
     cl_abap_unit_assert=>assert_equals(
         exp = `.eF('CONTROL_BY_ID', 'demoPanel', '', 'setExpanded', 'X')`
         act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-control_by_id
-                                          t_arg = VALUE #( ( `demoPanel` ) ( `` ) ( `setExpanded` ) ( `X` ) ) ) ).
+                                          t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ) ).
 
   ENDMETHOD.
 
@@ -214,11 +216,35 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_event = NEW #( ).
 
     " trailing empties still disappear - an ABAP false boolean param
-    " serializes to `` and simply ends the argument list
+    " serializes to `` and simply ends the argument list, while the injected
+    " main-view empty slot at position 2 stays
     cl_abap_unit_assert=>assert_equals(
         exp = `.eF('CONTROL_BY_ID', 'demoPanel', '', 'setExpanded')`
         act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-control_by_id
-                                          t_arg = VALUE #( ( `demoPanel` ) ( `` ) ( `setExpanded` ) ( `` ) ) ) ).
+                                          t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD event_view_param.
+
+    DATA lo_event TYPE REF TO z2ui5_cl_core_srv_event.
+    lo_event = NEW #( ).
+
+    " a concrete view is injected as the (filled) slot at position 2, scoping
+    " the id lookup to that view slot on the frontend
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'demoPanel', 'POPOVER', 'setExpanded', 'X')`
+        act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-control_by_id
+                                          view  = z2ui5_if_client=>cs_view-popover
+                                          t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ) ).
+
+    " the default view (cs_view-main) maps to the empty slot, preserving the
+    " unchanged cross-view resolveById default
+    cl_abap_unit_assert=>assert_equals(
+        exp = `.eF('CONTROL_BY_ID', 'demoPanel', '', 'setExpanded', 'X')`
+        act = lo_event->get_event_client( val   = z2ui5_if_client=>cs_event-control_by_id
+                                          view  = z2ui5_if_client=>cs_view-main
+                                          t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ) ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -215,6 +215,7 @@ INTERFACE z2ui5_if_client
   METHODS _event_client
     IMPORTING
       val           TYPE clike
+      view          TYPE clike        DEFAULT cs_view-main
       t_arg         TYPE string_table OPTIONAL
     RETURNING
       VALUE(result) TYPE string.
@@ -259,7 +260,9 @@ INTERFACE z2ui5_if_client
   "! The whitelisted control/binding calls are frontend events too; their t_arg
   "! is positional (an empty argument between filled ones keeps its slot as ``):
   "! cs_event-control_by_id - call a whitelisted method on a control resolved
-  "! by id: t_arg = id, view (`` = global lookup), method, params.
+  "! by id: t_arg = id, method, params. The view is passed as the separate
+  "! view parameter (default cs_view-main resolves the id across all open
+  "! views; pass cs_view-popup/popover/... to scope the lookup to that view).
   "! cs_event-control_global - call a whitelisted method on a global object
   "! (MESSAGE_TOAST, MESSAGE_BOX, BUSY_INDICATOR, THEMING):
   "! t_arg = object, method, params.
@@ -270,10 +273,11 @@ INTERFACE z2ui5_if_client
   "! operator, value1, value2 (empty values clear the filter); method `sort`:
   "! params = path, descending, group (abap_bool as `X`/``).
   "! Each of these events also works roundtrip-free when wired in the view via
-  "! _event_client with the same t_arg.
+  "! _event_client with the same t_arg (and view).
   METHODS follow_up_action
     IMPORTING
       val   TYPE string
+      view  TYPE clike        DEFAULT cs_view-main
       t_arg TYPE string_table OPTIONAL.
 
   METHODS check_on_event


### PR DESCRIPTION
Pull the view out of the positional control_by_id t_arg into its own
`view` importing parameter on follow_up_action and _event_client
(default cs_view-main). The view can now be omitted for a main-view
control and passed explicitly (view = cs_view-popup/popover/...) for a
popup/popover-hosted control, instead of being an empty/named slot in
t_arg.

get_event_client injects the view at t_arg position 2 only for the
control_by_id family; cs_view-main maps to the empty slot so the
existing cross-view resolveById default is preserved, while a concrete
view scopes the frontend lookup to that slot. control_global and
binding_call (whose position 2 is not a view) are untouched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ar8FTqFRTaZ9r5jcje9J9n