### PR TITLE
feat(frontend-action): add BIND_ELEMENT and setHiddenInPopin control methods

### DIFF
--- a/app/webapp/cc/MessageManager.js
+++ b/app/webapp/cc/MessageManager.js
@@ -93,6 +93,11 @@ sap.ui.define(
             type: r.TYPE ?? "Error",
             target: r.TARGET ?? "",
             additionalText: r.ADDITIONALTEXT ?? "",
+            // a free string column the app fills server-side (e.g. a display
+            // group for MessageItem.groupName - sap.ui.core.message.Message has
+            // no groupName slot, so grouping stays a backend decision bound to
+            // {message>code} rather than a frontend expression)
+            code: r.CODE ?? "",
             processor: this._processor,
           });
           this._messaging.addMessages(oMessage);

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -256,12 +256,24 @@ sap.ui.define(
       obj[method](...castArgs(kinds, raw));
     }
 
-    // replace {0},{1},... in a template with the positional values (as strings);
+    // replace placeholders in a template with the positional values (as
+    // strings). Two forms:
+    //   {N}                -> the Nth value verbatim
+    //   {N?trueText:falseText} -> trueText when the Nth value is truthy, else
+    //                         falseText (a boolean event param arrives as
+    //                         "true"/"false", so a toggle can toast
+    //                         "Pressed"/"Unpressed" without a server round-trip;
+    //                         trueText/falseText carry no ":" or "}")
     // an out-of-range placeholder is left as-is.
     function formatTemplate(tpl, values) {
-      return tpl.replace(/\{(\d+)\}/g, (m, i) =>
-        Number(i) < values.length ? String(values[Number(i)]) : m,
-      );
+      return tpl.replace(/\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g, (m, i, tText, fText) => {
+        const n = Number(i);
+        if (n >= values.length) return m;
+        const v = String(values[n]);
+        if (tText === undefined) return v;
+        const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);
+        return truthy ? tText : fText;
+      });
     }
 
     // ------------------------------------------------------------------

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -90,6 +90,7 @@ sap.ui.define(
       setActivePage: ["controlId"], // sap.m.Carousel
       expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels
       collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node
+      setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)
     };
 
     // global object -> lazy getter + its allowed methods (with arg kinds).
@@ -619,6 +620,27 @@ sap.ui.define(
       if (newWindow) newWindow.opener = null;
     }
 
+    // BIND_ELEMENT: element-bind a whole view slot (popup / popover / main) to
+    // a row of a registered table, so the fragment's relative bindings ({Name},
+    // {ProductPicUrl}, …) resolve against that row - the abap2UI5 equivalent of
+    // oControl.bindElement(oCtx.getPath()). args = [slot, index, path]; the path
+    // comes from client->_bind( table ) (braces already stripped server-side and
+    // again here defensively), the slot from the follow_up_action view param.
+    function evBindElement(oController, args) {
+      const slot = args[1] || "MAIN";
+      const view = ViewSlots.getView(slot);
+      if (!view) {
+        Lib.logError(`BIND_ELEMENT: no view for slot '${slot}'`);
+        return;
+      }
+      const path = String(args[3] ?? "").replace(/[{}]/g, "");
+      if (!path) {
+        Lib.logError("BIND_ELEMENT: empty binding path");
+        return;
+      }
+      view.bindElement(`${path}/${args[2]}`);
+    }
+
     function evUrlHelper(oController, args) {
       const params = args[2] ?? {};
       const actions = {
@@ -896,6 +918,7 @@ sap.ui.define(
       OPEN_NEW_TAB: evOpenNewTab,
       POPUP_CLOSE: () => ViewSlots.destroy("POPUP"),
       POPOVER_CLOSE: () => ViewSlots.destroy("POPOVER"),
+      BIND_ELEMENT: evBindElement,
       URLHELPER: evUrlHelper,
       IMAGE_EDITOR_POPUP_CLOSE: evImageEditorPopupClose,
       SET_TITLE: evSetTitle,

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -260,7 +260,7 @@ sap.ui.define(
     // an out-of-range placeholder is left as-is.
     function formatTemplate(tpl, values) {
       return tpl.replace(/\{(\d+)\}/g, (m, i) =>
-        (Number(i) < values.length ? String(values[Number(i)]) : m),
+        Number(i) < values.length ? String(values[Number(i)]) : m,
       );
     }
 

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -266,14 +266,17 @@ sap.ui.define(
     //                         trueText/falseText carry no ":" or "}")
     // an out-of-range placeholder is left as-is.
     function formatTemplate(tpl, values) {
-      return tpl.replace(/\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g, (m, i, tText, fText) => {
-        const n = Number(i);
-        if (n >= values.length) return m;
-        const v = String(values[n]);
-        if (tText === undefined) return v;
-        const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);
-        return truthy ? tText : fText;
-      });
+      return tpl.replace(
+        /\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g,
+        (m, i, tText, fText) => {
+          const n = Number(i);
+          if (n >= values.length) return m;
+          const v = String(values[n]);
+          if (tText === undefined) return v;
+          const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);
+          return truthy ? tText : fText;
+        },
+      );
     }
 
     // ------------------------------------------------------------------

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -243,7 +243,25 @@ sap.ui.define(
         Lib.logError(`CONTROL_GLOBAL: '${name}.${method}' not available`);
         return;
       }
-      obj[method](...castArgs(kinds, args.slice(3)));
+      const raw = args.slice(3);
+      // a single-string method (MessageToast.show, MessageBox.*) may receive
+      // extra positional values: the first arg is then a template and its
+      // {0},{1},... placeholders are replaced by the client-resolved extras, so
+      // a "X has been activated" toast can be composed on the frontend without a
+      // server round-trip. A lone string is passed through unchanged.
+      if (kinds.length === 1 && kinds[0] === "string" && raw.length > 1) {
+        obj[method](formatTemplate(String(raw[0]), raw.slice(1)));
+        return;
+      }
+      obj[method](...castArgs(kinds, raw));
+    }
+
+    // replace {0},{1},... in a template with the positional values (as strings);
+    // an out-of-range placeholder is left as-is.
+    function formatTemplate(tpl, values) {
+      return tpl.replace(/\{(\d+)\}/g, (m, i) =>
+        (Number(i) < values.length ? String(values[Number(i)]) : m),
+      );
     }
 
     // ------------------------------------------------------------------

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -91,6 +91,9 @@ sap.ui.define(
       expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels
       collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node
       setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)
+      addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class
+      removeStyleClass: ["string"], // sap.ui.core.Control: remove a CSS style class
+      toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class
     };
 
     // global object -> lazy getter + its allowed methods (with arg kinds).

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -643,7 +643,7 @@ sap.ui.define(
 
     // BIND_ELEMENT: element-bind a whole view slot (popup / popover / main) to
     // a row of a registered table, so the fragment's relative bindings ({Name},
-    // {ProductPicUrl}, …) resolve against that row - the abap2UI5 equivalent of
+    // {ProductPicUrl}, ...) resolve against that row - the abap2UI5 equivalent of
     // oControl.bindElement(oCtx.getPath()). args = [slot, index, path]; the path
     // comes from client->_bind( table ) (braces already stripped server-side and
     // again here defensively), the slot from the follow_up_action view param.

--- a/app/webapp/model/formatter.js
+++ b/app/webapp/model/formatter.js
@@ -67,7 +67,7 @@ sap.ui.define(["sap/ui/core/IconPool"], (IconPool) => {
     //
     // Presentation only. Deriving a state from a raw measure (the demo kit's
     // weightState: parseFloat + KG conversion + Success/Warning/Error
-    // thresholds) is BUSINESS LOGIC and does NOT belong here — abap2UI5 is a
+    // thresholds) is BUSINESS LOGIC and does NOT belong here - abap2UI5 is a
     // thin frontend, so a port computes that in ABAP and binds the finished
     // value (state="{WEIGHT_STATE}"). The status -> ValueState/icon lookups
     // below only map an already-classified business status to a visual, which

--- a/app/webapp/model/formatter.js
+++ b/app/webapp/model/formatter.js
@@ -5,11 +5,10 @@
 //
 //   <mvc:View xmlns:core="sap.ui.core"
 //             core:require="{Formatter: 'z2ui5/model/formatter'}">
-//     ... state="{ parts: [{path: 'WEIGHT'}, {path: 'UNIT'}],
-//                  formatter: 'Formatter.weightState' }"
+//     ... src="{ path: 'STATUS', formatter: 'Formatter.stockStatusIcon' }"
 //
 // The module is also published as the z2ui5.Formatter global, so
-// formatter: 'z2ui5.Formatter.weightState' keeps working on releases
+// formatter: 'z2ui5.Formatter.stockStatusIcon' keeps working on releases
 // without core:require support.
 //
 // The set is CURATED and grows via framework PRs: every function here is a
@@ -65,32 +64,14 @@ sap.ui.define(["sap/ui/core/IconPool"], (IconPool) => {
     },
 
     // --- value formatters ---
-
-    // Weight -> sap.ui.core.ValueState, the classic demo-kit formatter
-    // (sap.m.sample.Table Formatter.js): thresholds in KG (< 1 Success,
-    // < 5 Warning, else Error), a "G" unit is converted, non-numeric or
-    // negative weights map to None.
-    weightState(measure, unit) {
-      let adjusted = parseFloat(measure);
-      if (isNaN(adjusted)) return "None";
-      if (unit === "G") adjusted = adjusted / 1000;
-      if (adjusted < 0) return "None";
-      if (adjusted < 1) return "Success";
-      if (adjusted < 5) return "Warning";
-      return "Error";
-    },
-
-    // The demo kit's second weightState shape (sap.m.sample.TableEditable
-    // Formatter.js and five sibling Table samples): a single unit-less
-    // value, thresholds < 1000 Success, < 2000 Warning, else Error;
-    // non-numeric or negative values map to None.
-    weightStateByValue(value) {
-      const adjusted = parseFloat(value);
-      if (isNaN(adjusted) || adjusted < 0) return "None";
-      if (adjusted < 1000) return "Success";
-      if (adjusted < 2000) return "Warning";
-      return "Error";
-    },
+    //
+    // Presentation only. Deriving a state from a raw measure (the demo kit's
+    // weightState: parseFloat + KG conversion + Success/Warning/Error
+    // thresholds) is BUSINESS LOGIC and does NOT belong here — abap2UI5 is a
+    // thin frontend, so a port computes that in ABAP and binds the finished
+    // value (state="{WEIGHT_STATE}"). The status -> ValueState/icon lookups
+    // below only map an already-classified business status to a visual, which
+    // is presentation.
 
     // Product stock status -> sap.ui.core.ValueState.
     stockStatusState(status) {

--- a/node/tests/formatter.spec.js
+++ b/node/tests/formatter.spec.js
@@ -26,29 +26,10 @@ function load() {
 }
 
 test.describe("Formatter module", () => {
-  test("weightState maps KG weights to the ValueState thresholds", () => {
-    const { Formatter } = load();
-    expect(Formatter.weightState("0.2", "KG")).toBe("Success");
-    expect(Formatter.weightState("4.5", "KG")).toBe("Warning");
-    expect(Formatter.weightState("21", "KG")).toBe("Error");
-  });
-
-  test("weightState converts G and guards NaN/negative", () => {
-    const { Formatter } = load();
-    expect(Formatter.weightState("800", "G")).toBe("Success"); // 0.8 kg
-    expect(Formatter.weightState("4500", "G")).toBe("Warning"); // 4.5 kg
-    expect(Formatter.weightState("abc", "KG")).toBe("None");
-    expect(Formatter.weightState("-1", "KG")).toBe("None");
-  });
-
-  test("weightStateByValue maps unit-less weights to the 1000/2000 thresholds", () => {
-    const { Formatter } = load();
-    expect(Formatter.weightStateByValue("999")).toBe("Success");
-    expect(Formatter.weightStateByValue("1500")).toBe("Warning");
-    expect(Formatter.weightStateByValue("2000")).toBe("Error");
-    expect(Formatter.weightStateByValue("abc")).toBe("None");
-    expect(Formatter.weightStateByValue("-1")).toBe("None");
-  });
+  // Note: deriving a ValueState from a raw weight (the former weightState /
+  // weightStateByValue) is business logic and was removed from the curated
+  // formatter - a port classifies the measure in ABAP and binds the finished
+  // state (abap2UI5 is a thin frontend), so there is nothing to test here.
 
   test("stockStatusState/-Icon map the stock status", () => {
     const { Formatter } = load();

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -132,6 +132,43 @@ test.describe("CONTROL_GLOBAL (global objects)", () => {
     expect(calls).toEqual([["toast.show", "100% {done}"]]);
   });
 
+  test("a conditional placeholder {N?a:b} picks by truthiness of the value", () => {
+    const { FrontendAction, calls } = load();
+    // toggle pressed -> "Pressed", not pressed -> "Unpressed" (080 shape)
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "{0} {1?Pressed:Unpressed}",
+      "__button0",
+      "true",
+    ]);
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "{0} {1?Pressed:Unpressed}",
+      "__button0",
+      "false",
+    ]);
+    expect(calls).toEqual([
+      ["toast.show", "__button0 Pressed"],
+      ["toast.show", "__button0 Unpressed"],
+    ]);
+  });
+
+  test("conditional treats empty/0/null as falsy", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "{0?on:off}",
+      "",
+    ]);
+    expect(calls).toEqual([["toast.show", "off"]]);
+  });
+
   test("casts int args (BusyIndicator.show(0))", () => {
     const { FrontendAction, calls } = load();
     FrontendAction.execute(null, [

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -18,9 +18,11 @@ function load() {
   const BusyIndicator = { show: rec("busy.show"), hide: rec("busy.hide") };
   const Theming = { setTheme: rec("theme.set") };
   const controls = {};
+  const views = {};
   const ViewSlots = {
     resolveById: (id) => controls[id] || null,
     byId: (_key, id) => controls[id] || null,
+    getView: (key) => views[key] || null,
   };
   // whenRendered runs its callback once the control is in the DOM; the real
   // one defers to onAfterRendering when it is not. The stub runs it straight
@@ -55,7 +57,7 @@ function load() {
       "z2ui5/core/AppState": AppState,
     },
   });
-  return { FrontendAction: module, calls, errors, controls };
+  return { FrontendAction: module, calls, errors, controls, views };
 }
 
 test.describe("CONTROL_GLOBAL (global objects)", () => {
@@ -432,5 +434,29 @@ test.describe("BINDING_CALL", () => {
     ]);
     expect(calls).toHaveLength(0);
     expect(errors).toHaveLength(1);
+  });
+});
+
+test.describe("BIND_ELEMENT", () => {
+  test("element-binds the slot view to <path>/<index>", () => {
+    const { FrontendAction, views } = load();
+    const bound = [];
+    views.POPOVER = { bindElement: (p) => bound.push(p) };
+    FrontendAction.execute(null, ["BIND_ELEMENT", "POPOVER", "5", "/T_PRODUCTS"]);
+    expect(bound).toEqual(["/T_PRODUCTS/5"]);
+  });
+
+  test("strips braces from the binding path (client->_bind form)", () => {
+    const { FrontendAction, views } = load();
+    const bound = [];
+    views.POPOVER = { bindElement: (p) => bound.push(p) };
+    FrontendAction.execute(null, ["BIND_ELEMENT", "POPOVER", "2", "{/MT_TAB}"]);
+    expect(bound).toEqual(["/MT_TAB/2"]);
+  });
+
+  test("logs and no-ops when the slot view is missing", () => {
+    const { FrontendAction, errors } = load();
+    FrontendAction.execute(null, ["BIND_ELEMENT", "POPOVER", "5", "/T_PRODUCTS"]);
+    expect(errors.some((e) => String(e).includes("no view for slot"))).toBe(true);
   });
 });

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -72,6 +72,66 @@ test.describe("CONTROL_GLOBAL (global objects)", () => {
     expect(calls).toEqual([["toast.show", "Saved!"]]);
   });
 
+  test("composes a toast from a template + client-resolved extras", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "Action triggered on item: {0}",
+      "Franchise Store",
+    ]);
+    expect(calls).toEqual([["toast.show", "Action triggered on item: Franchise Store"]]);
+  });
+
+  test("substitutes a value-first template ({0} ...) and multiple placeholders", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "{0} selected at {1}",
+      "Item A",
+      "10:30",
+    ]);
+    expect(calls).toEqual([["toast.show", "Item A selected at 10:30"]]);
+  });
+
+  test("leaves an out-of-range placeholder untouched", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "{0} and {1}",
+      "only-one",
+    ]);
+    expect(calls).toEqual([["toast.show", "only-one and {1}"]]);
+  });
+
+  test("MessageBox variants also accept a template", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_BOX",
+      "error",
+      "Upload of {0} failed",
+      "report.pdf",
+    ]);
+    expect(calls).toEqual([["box.error", "Upload of report.pdf failed"]]);
+  });
+
+  test("a lone string is passed through unchanged (no template parsing)", () => {
+    const { FrontendAction, calls } = load();
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "MESSAGE_TOAST",
+      "show",
+      "100% {done}",
+    ]);
+    expect(calls).toEqual([["toast.show", "100% {done}"]]);
+  });
+
   test("casts int args (BusyIndicator.show(0))", () => {
     const { FrontendAction, calls } = load();
     FrontendAction.execute(null, [

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -258,6 +258,23 @@ test.describe("CONTROL_BY_ID", () => {
       ["expand", false],
     ]);
   });
+
+  test("add/remove/toggleStyleClass pass the class name through", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.dlg = {
+      addStyleClass: (c) => calls.push(["add", c]),
+      removeStyleClass: (c) => calls.push(["remove", c]),
+      toggleStyleClass: (c) => calls.push(["toggle", c]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "dlg", "", "addStyleClass", "myClass"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "dlg", "", "removeStyleClass", "myClass"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "dlg", "", "toggleStyleClass", "myClass"]);
+    expect(calls).toEqual([
+      ["add", "myClass"],
+      ["remove", "myClass"],
+      ["toggle", "myClass"],
+    ]);
+  });
 });
 
 test.describe("BINDING_CALL", () => {

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -115,14 +115,20 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
         CONTINUE.
       ENDIF.
       " a message template that starts with a bare positional placeholder
-      " ({0}, {1}, ... immediately closed) is a plain string, not a binding
-      " or object literal, so it must still be quoted - the `{`-raw exception
-      " below is only for real bindings/object literals like {/PATH} or {..}.
-      " {0/field} (relative binding) keeps a `/` after the digits and is
-      " therefore not matched, so it stays raw as before.
-      FIND REGEX `^\{[0-9]+\}` IN lv_new.
+      " ({0}, {1}, ... - either immediately closed {0} or a conditional
+      " {0?a:b}) is a plain string, not a binding or object literal, so it must
+      " still be quoted - the `{`-raw exception below is only for real
+      " bindings/object literals like {/PATH} or {..}. {0/field} (relative
+      " binding) keeps a `/` after the digits and is therefore not matched, so
+      " it stays raw as before.
+      FIND REGEX `^\{[0-9]+[?}]` IN lv_new.
       DATA(lv_is_placeholder) = xsdbool( sy-subrc = 0 ).
       IF ( lv_new(1) <> `$` AND lv_new(1) <> `{` AND lv_new NP `.eB(*` ) OR lv_is_placeholder = abap_true.
+        " a quoted arg is JS string source (a backslash escape like \n stays a
+        " newline); escape only an embedded ' so it cannot close the '...'
+        " wrapper - otherwise a template like Value changed to '{0}' emits
+        " broken JS.
+        REPLACE ALL OCCURRENCES OF `'` IN lv_new WITH `\'`.
         lv_new = |'{ lv_new }'|.
       ENDIF.
       result = |{ result }{ lv_pending }, { lv_new }|.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -114,7 +114,15 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
         lv_pending = |{ lv_pending }, ''|.
         CONTINUE.
       ENDIF.
-      IF lv_new(1) <> `$` AND lv_new(1) <> `{` AND lv_new NP `.eB(*`.
+      " a message template that starts with a bare positional placeholder
+      " ({0}, {1}, ... immediately closed) is a plain string, not a binding
+      " or object literal, so it must still be quoted - the `{`-raw exception
+      " below is only for real bindings/object literals like {/PATH} or {..}.
+      " {0/field} (relative binding) keeps a `/` after the digits and is
+      " therefore not matched, so it stays raw as before.
+      FIND REGEX `^\{[0-9]+\}` IN lv_new.
+      DATA(lv_is_placeholder) = xsdbool( sy-subrc = 0 ).
+      IF ( lv_new(1) <> `$` AND lv_new(1) <> `{` AND lv_new NP `.eB(*` ) OR lv_is_placeholder = abap_true.
         lv_new = |'{ lv_new }'|.
       ENDIF.
       result = |{ result }{ lv_pending }, { lv_new }|.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -80,6 +80,18 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
                                         ELSE CONV string( view ) ).
       lt_arg = t_arg.
       INSERT lv_view_slot INTO lt_arg INDEX 2.
+    ELSEIF lv_val = z2ui5_if_client=>cs_event-bind_element.
+      " element-bind a whole view slot to a table row: args = slot, index,
+      " path. The path comes from client->_bind( table ); _bind returns the
+      " binding with braces ({/MT_TAB}), which would be an invalid raw JS
+      " argument, so strip the braces here to a plain path ('/MT_TAB') that
+      " get_t_arg then quotes. The slot is the follow_up_action view parameter.
+      DATA(lv_bind_path) = CONV string( VALUE #( t_arg[ 2 ] OPTIONAL ) ).
+      REPLACE ALL OCCURRENCES OF `{` IN lv_bind_path WITH ``.
+      REPLACE ALL OCCURRENCES OF `}` IN lv_bind_path WITH ``.
+      lt_arg = VALUE #( ( CONV string( view ) )
+                        ( VALUE #( t_arg[ 1 ] OPTIONAL ) )
+                        ( lv_bind_path ) ).
     ENDIF.
 
     result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ lv_val }'{ get_t_arg( lt_arg ) }|.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
@@ -300,7 +300,8 @@ CLASS ltcl_test IMPLEMENTATION.
     DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
     DATA(lt_arg) = VALUE string_table( ( `Value changed to '{0}'` ) ).
 
-    DATA(lv_event) = lo_event->get_event( val = `EVT` t_arg = lt_arg ).
+    DATA(lv_event) = lo_event->get_event( val   = `EVT`
+                                          t_arg = lt_arg ).
 
     cl_abap_unit_assert=>assert_true( xsdbool( lv_event CS `'Value changed to \'{0}\''` ) ).
 
@@ -312,11 +313,11 @@ CLASS ltcl_test IMPLEMENTATION.
     " ({0?a:b}...) are plain strings, so both are quoted (not emitted raw)
     DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
 
-    DATA(lv_plain) = lo_event->get_event( val = `EVT`
+    DATA(lv_plain) = lo_event->get_event( val   = `EVT`
                                           t_arg = VALUE #( ( `{0} Pressed` ) ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_plain CS `'{0} Pressed'` ) ).
 
-    DATA(lv_cond) = lo_event->get_event( val = `EVT`
+    DATA(lv_cond) = lo_event->get_event( val   = `EVT`
                                          t_arg = VALUE #( ( `{0?Pressed:Unpressed}` ) ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_cond CS `'{0?Pressed:Unpressed}'` ) ).
 

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
@@ -15,6 +15,8 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS event_multi_req   FOR TESTING.
     METHODS event_client_args FOR TESTING.
     METHODS event_nav_container FOR TESTING.
+    METHODS event_quote_escaped FOR TESTING.
+    METHODS event_placeholder_quoted FOR TESTING.
 
   PROTECTED SECTION.
 
@@ -289,6 +291,34 @@ CLASS ltcl_test IMPLEMENTATION.
 
     temp14 = xsdbool( lv_event CS `'param1'` ).
     cl_abap_unit_assert=>assert_true( temp14 ).
+
+  ENDMETHOD.
+
+  METHOD event_quote_escaped.
+
+    " an embedded ' must be escaped to \' so it cannot close the '...' wrapper
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+    DATA(lt_arg) = VALUE string_table( ( `Value changed to '{0}'` ) ).
+
+    DATA(lv_event) = lo_event->get_event( val = `EVT` t_arg = lt_arg ).
+
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_event CS `'Value changed to \'{0}\''` ) ).
+
+  ENDMETHOD.
+
+  METHOD event_placeholder_quoted.
+
+    " a value-first placeholder ({0}...) and a conditional placeholder
+    " ({0?a:b}...) are plain strings, so both are quoted (not emitted raw)
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    DATA(lv_plain) = lo_event->get_event( val = `EVT`
+                                          t_arg = VALUE #( ( `{0} Pressed` ) ) ).
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_plain CS `'{0} Pressed'` ) ).
+
+    DATA(lv_cond) = lo_event->get_event( val = `EVT`
+                                         t_arg = VALUE #( ( `{0?Pressed:Unpressed}` ) ) ).
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_cond CS `'{0?Pressed:Unpressed}'` ) ).
 
   ENDMETHOD.
 

--- a/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
@@ -25,11 +25,10 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `//` && |\n| &&
              `//   <mvc:View xmlns:core="sap.ui.core"` && |\n| &&
              `//             core:require="{Formatter: 'z2ui5/model/formatter'}">` && |\n| &&
-             `//     ... state="{ parts: [{path: 'WEIGHT'}, {path: 'UNIT'}],` && |\n| &&
-             `//                  formatter: 'Formatter.weightState' }"` && |\n| &&
+             `//     ... src="{ path: 'STATUS', formatter: 'Formatter.stockStatusIcon' }"` && |\n| &&
              `//` && |\n| &&
              `// The module is also published as the z2ui5.Formatter global, so` && |\n| &&
-             `// formatter: 'z2ui5.Formatter.weightState' keeps working on releases` && |\n| &&
+             `// formatter: 'z2ui5.Formatter.stockStatusIcon' keeps working on releases` && |\n| &&
              `// without core:require support.` && |\n| &&
              `//` && |\n| &&
              `// The set is CURATED and grows via framework PRs: every function here is a` && |\n| &&
@@ -85,32 +84,14 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `    },` && |\n| &&
              `` && |\n| &&
              `    // --- value formatters ---` && |\n| &&
-             `` && |\n| &&
-             `    // Weight -> sap.ui.core.ValueState, the classic demo-kit formatter` && |\n| &&
-             `    // (sap.m.sample.Table Formatter.js): thresholds in KG (< 1 Success,` && |\n| &&
-             `    // < 5 Warning, else Error), a "G" unit is converted, non-numeric or` && |\n| &&
-             `    // negative weights map to None.` && |\n| &&
-             `    weightState(measure, unit) {` && |\n| &&
-             `      let adjusted = parseFloat(measure);` && |\n| &&
-             `      if (isNaN(adjusted)) return "None";` && |\n| &&
-             `      if (unit === "G") adjusted = adjusted / 1000;` && |\n| &&
-             `      if (adjusted < 0) return "None";` && |\n| &&
-             `      if (adjusted < 1) return "Success";` && |\n| &&
-             `      if (adjusted < 5) return "Warning";` && |\n| &&
-             `      return "Error";` && |\n| &&
-             `    },` && |\n| &&
-             `` && |\n| &&
-             `    // The demo kit's second weightState shape (sap.m.sample.TableEditable` && |\n| &&
-             `    // Formatter.js and five sibling Table samples): a single unit-less` && |\n| &&
-             `    // value, thresholds < 1000 Success, < 2000 Warning, else Error;` && |\n| &&
-             `    // non-numeric or negative values map to None.` && |\n| &&
-             `    weightStateByValue(value) {` && |\n| &&
-             `      const adjusted = parseFloat(value);` && |\n| &&
-             `      if (isNaN(adjusted) || adjusted < 0) return "None";` && |\n| &&
-             `      if (adjusted < 1000) return "Success";` && |\n| &&
-             `      if (adjusted < 2000) return "Warning";` && |\n| &&
-             `      return "Error";` && |\n| &&
-             `    },` && |\n| &&
+             `    //` && |\n| &&
+             `    // Presentation only. Deriving a state from a raw measure (the demo kit's` && |\n| &&
+             `    // weightState: parseFloat + KG conversion + Success/Warning/Error` && |\n| &&
+             `    // thresholds) is BUSINESS LOGIC and does NOT belong here - abap2UI5 is a` && |\n| &&
+             `    // thin frontend, so a port computes that in ABAP and binds the finished` && |\n| &&
+             `    // value (state="{WEIGHT_STATE}"). The status -> ValueState/icon lookups` && |\n| &&
+             `    // below only map an already-classified business status to a visual, which` && |\n| &&
+             `    // is presentation.` && |\n| &&
              `` && |\n| &&
              `    // Product stock status -> sap.ui.core.ValueState.` && |\n| &&
              `    stockStatusState(status) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `    //` && |\n| &&
              `    // Presentation only. Deriving a state from a raw measure (the demo kit's` && |\n| &&
              `    // weightState: parseFloat + KG conversion + Success/Warning/Error` && |\n| &&
-             `    // thresholds) is BUSINESS LOGIC and does NOT belong here — abap2UI5 is a` && |\n| &&
+             `    // thresholds) is BUSINESS LOGIC and does NOT belong here - abap2UI5 is a` && |\n| &&
              `    // thin frontend, so a port computes that in ABAP and binds the finished` && |\n| &&
              `    // value (state="{WEIGHT_STATE}"). The status -> ValueState/icon lookups` && |\n| &&
              `    // below only map an already-classified business status to a visual, which` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_formatter_js.clas.abap
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_app_formatter_js IMPLEMENTATION.
              `    //` && |\n| &&
              `    // Presentation only. Deriving a state from a raw measure (the demo kit's` && |\n| &&
              `    // weightState: parseFloat + KG conversion + Success/Warning/Error` && |\n| &&
-             `    // thresholds) is BUSINESS LOGIC and does NOT belong here - abap2UI5 is a` && |\n| &&
+             `    // thresholds) is BUSINESS LOGIC and does NOT belong here — abap2UI5 is a` && |\n| &&
              `    // thin frontend, so a port computes that in ABAP and binds the finished` && |\n| &&
              `    // value (state="{WEIGHT_STATE}"). The status -> ValueState/icon lookups` && |\n| &&
              `    // below only map an already-classified business status to a visual, which` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -286,14 +286,17 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    //                         trueText/falseText carry no ":" or "}")` && |\n| &&
              `    // an out-of-range placeholder is left as-is.` && |\n| &&
              `    function formatTemplate(tpl, values) {` && |\n| &&
-             `      return tpl.replace(/\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g, (m, i, tText, fText) => {` && |\n| &&
-             `        const n = Number(i);` && |\n| &&
-             `        if (n >= values.length) return m;` && |\n| &&
-             `        const v = String(values[n]);` && |\n| &&
-             `        if (tText === undefined) return v;` && |\n| &&
-             `        const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);` && |\n| &&
-             `        return truthy ? tText : fText;` && |\n| &&
-             `      });` && |\n| &&
+             `      return tpl.replace(` && |\n| &&
+             `        /\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g,` && |\n| &&
+             `        (m, i, tText, fText) => {` && |\n| &&
+             `          const n = Number(i);` && |\n| &&
+             `          if (n >= values.length) return m;` && |\n| &&
+             `          const v = String(values[n]);` && |\n| &&
+             `          if (tText === undefined) return v;` && |\n| &&
+             `          const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);` && |\n| &&
+             `          return truthy ? tText : fText;` && |\n| &&
+             `        },` && |\n| &&
+             `      );` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -414,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      },` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
-             `    // args: [_, id, aggregation, method, ...params]` && |\n| &&
+             `    // args: [_, id, aggregation, method, ...params]` && |\n|.
+    result = result &&
              `    function evBindingCall(oController, args) {` && |\n| &&
              `      const [, id, aggregation, method] = args;` && |\n| &&
              `      const build = BINDING_METHODS[method];` && |\n| &&
@@ -429,8 +433,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        );` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      build(binding, args.slice(4));` && |\n|.
-    result = result &&
+             `      build(binding, args.slice(4));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -815,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // animates when time > 0, so "smooth" maps to a 300ms animation.` && |\n| &&
              `      // Native Element.scrollTo is only used as a fallback for controls` && |\n| &&
              `      // without a delegate.` && |\n| &&
-             `      try {` && |\n| &&
+             `      try {` && |\n|.
+    result = result &&
              `        const oElement = ViewSlots.byId("MAIN", args[1]);` && |\n| &&
              `        if (!oElement) return;` && |\n| &&
              `        const y = Number(args[2]) || 0;` && |\n| &&
@@ -830,8 +834,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            // ScrollEnablement / iScroll delegate: scrollTo(x, y, time)` && |\n| &&
              `            delegate.scrollTo(x, y, smooth ? 300 : 0);` && |\n| &&
              `            handled = true;` && |\n| &&
-             `          }` && |\n|.
-    result = result &&
+             `          }` && |\n| &&
              `        } catch {` && |\n| &&
              `          // fall through` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -280,7 +280,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // an out-of-range placeholder is left as-is.` && |\n| &&
              `    function formatTemplate(tpl, values) {` && |\n| &&
              `      return tpl.replace(/\{(\d+)\}/g, (m, i) =>` && |\n| &&
-             `        (Number(i) < values.length ? String(values[Number(i)]) : m),` && |\n| &&
+             `        Number(i) < values.length ? String(values[Number(i)]) : m,` && |\n| &&
              `      );` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
@@ -417,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        );` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      build(binding, args.slice(4));` && |\n| &&
+             `      build(binding, args.slice(4));` && |\n|.
+    result = result &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -435,8 +436,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evClipboardAppState() {` && |\n| &&
-             `      // Guard against a missing response so the copied link never carries` && |\n|.
-    result = result &&
+             `      // Guard against a missing response so the copied link never carries` && |\n| &&
              `      // the literal "undefined" as its state id.` && |\n| &&
              `      const id = AppState.state.oResponse?.ID || "";` && |\n| &&
              `      // Strip any existing hash (e.g. an active app-state) so the copied` && |\n| &&
@@ -818,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            // ScrollEnablement / iScroll delegate: scrollTo(x, y, time)` && |\n| &&
              `            delegate.scrollTo(x, y, smooth ? 300 : 0);` && |\n| &&
              `            handled = true;` && |\n| &&
-             `          }` && |\n| &&
+             `          }` && |\n|.
+    result = result &&
              `        } catch {` && |\n| &&
              `          // fall through` && |\n| &&
              `        }` && |\n| &&
@@ -836,8 +837,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            handled = true;` && |\n| &&
              `          } else if (oElement.scrollTo) {` && |\n| &&
              `            // sap.m.Page.scrollTo(y, time) - vertical only` && |\n| &&
-             `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n|.
-    result = result &&
+             `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n| &&
              `            handled = true;` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -417,12 +417,12 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evClipboardAppState() {` && |\n| &&
-             `      // Guard against a missing response so the copied link never carries` && |\n| &&
+             `      // Guard against a missing response so the copied link never carries` && |\n|.
+    result = result &&
              `      // the literal "undefined" as its state id.` && |\n| &&
              `      const id = AppState.state.oResponse?.ID || "";` && |\n| &&
              `      // Strip any existing hash (e.g. an active app-state) so the copied` && |\n| &&
-             `      // link carries only the fresh state id.` && |\n|.
-    result = result &&
+             `      // link carries only the fresh state id.` && |\n| &&
              `      const base = window.location.href.split("#")[0];` && |\n| &&
              `      Lib.copyToClipboard(``${base}#/z2ui5-xapp-state=${id}``);` && |\n| &&
              `    }` && |\n| &&
@@ -644,6 +644,12 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      if (newWindow) newWindow.opener = null;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // BIND_ELEMENT: element-bind a whole view slot (popup / popover / main) to` && |\n| &&
+             `    // a row of a registered table, so the fragment's relative bindings ({Name},` && |\n| &&
+             `    // {ProductPicUrl}, …) resolve against that row - the abap2UI5 equivalent of` && |\n| &&
+             `    // oControl.bindElement(oCtx.getPath()). args = [slot, index, path]; the path` && |\n| &&
+             `    // comes from client->_bind( table ) (braces already stripped server-side and` && |\n| &&
+             `    // again here defensively), the slot from the follow_up_action view param.` && |\n| &&
              `    function evBindElement(oController, args) {` && |\n| &&
              `      const slot = args[1] || "MAIN";` && |\n| &&
              `      const view = ViewSlots.getView(slot);` && |\n| &&
@@ -653,10 +659,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `      const path = String(args[3] ?? "").replace(/[{}]/g, "");` && |\n| &&
              `      if (!path) {` && |\n| &&
-             `        Lib.logError(``BIND_ELEMENT: empty binding path``);` && |\n| &&
+             `        Lib.logError("BIND_ELEMENT: empty binding path");` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      view.bindElement(``${ path }/${ args[2] }``);` && |\n| &&
+             `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evUrlHelper(oController, args) {` && |\n| &&
@@ -812,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            handled = true;` && |\n| &&
              `          } else if (oElement.scrollTo) {` && |\n| &&
              `            // sap.m.Page.scrollTo(y, time) - vertical only` && |\n| &&
-             `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n| &&
+             `            oElement.scrollTo(y, smooth ? 300 : 0);` && |\n|.
+    result = result &&
              `            handled = true;` && |\n| &&
              `          }` && |\n| &&
              `        }` && |\n| &&
@@ -837,8 +844,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        if (!dom || !dom.scrollIntoView) return;` && |\n| &&
              `        dom.scrollIntoView({` && |\n| &&
              `          behavior: args[2] || "smooth",` && |\n| &&
-             `          block: args[3] || "start",` && |\n|.
-    result = result &&
+             `          block: args[3] || "start",` && |\n| &&
              `          inline: args[4] || "nearest",` && |\n| &&
              `        });` && |\n| &&
              `      } catch (e) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -110,6 +110,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      setActivePage: ["controlId"], // sap.m.Carousel` && |\n| &&
              `      expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels` && |\n| &&
              `      collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node` && |\n| &&
+             `      setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
              `    // global object -> lazy getter + its allowed methods (with arg kinds).` && |\n| &&
@@ -640,6 +641,21 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      if (newWindow) newWindow.opener = null;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    function evBindElement(oController, args) {` && |\n| &&
+             `      const slot = args[1] || "MAIN";` && |\n| &&
+             `      const view = ViewSlots.getView(slot);` && |\n| &&
+             `      if (!view) {` && |\n| &&
+             `        Lib.logError(``BIND_ELEMENT: no view for slot '${slot}'``);` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      const path = String(args[3] ?? "").replace(/[{}]/g, "");` && |\n| &&
+             `      if (!path) {` && |\n| &&
+             `        Lib.logError(``BIND_ELEMENT: empty binding path``);` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      view.bindElement(``${ path }/${ args[2] }``);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function evUrlHelper(oController, args) {` && |\n| &&
              `      const params = args[2] ?? {};` && |\n| &&
              `      const actions = {` && |\n| &&
@@ -918,6 +934,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      OPEN_NEW_TAB: evOpenNewTab,` && |\n| &&
              `      POPUP_CLOSE: () => ViewSlots.destroy("POPUP"),` && |\n| &&
              `      POPOVER_CLOSE: () => ViewSlots.destroy("POPOVER"),` && |\n| &&
+             `      BIND_ELEMENT: evBindElement,` && |\n| &&
              `      URLHELPER: evUrlHelper,` && |\n| &&
              `      IMAGE_EDITOR_POPUP_CLOSE: evImageEditorPopupClose,` && |\n| &&
              `      SET_TITLE: evSetTitle,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -111,6 +111,9 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels` && |\n| &&
              `      collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node` && |\n| &&
              `      setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)` && |\n| &&
+             `      addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class` && |\n| &&
+             `      removeStyleClass: ["string"], // sap.ui.core.Control: remove a CSS style class` && |\n| &&
+             `      toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
              `    // global object -> lazy getter + its allowed methods (with arg kinds).` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -263,7 +263,25 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        Lib.logError(``CONTROL_GLOBAL: '${name}.${method}' not available``);` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      obj[method](...castArgs(kinds, args.slice(3)));` && |\n| &&
+             `      const raw = args.slice(3);` && |\n| &&
+             `      // a single-string method (MessageToast.show, MessageBox.*) may receive` && |\n| &&
+             `      // extra positional values: the first arg is then a template and its` && |\n| &&
+             `      // {0},{1},... placeholders are replaced by the client-resolved extras, so` && |\n| &&
+             `      // a "X has been activated" toast can be composed on the frontend without a` && |\n| &&
+             `      // server round-trip. A lone string is passed through unchanged.` && |\n| &&
+             `      if (kinds.length === 1 && kinds[0] === "string" && raw.length > 1) {` && |\n| &&
+             `        obj[method](formatTemplate(String(raw[0]), raw.slice(1)));` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      obj[method](...castArgs(kinds, raw));` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // replace {0},{1},... in a template with the positional values (as strings);` && |\n| &&
+             `    // an out-of-range placeholder is left as-is.` && |\n| &&
+             `    function formatTemplate(tpl, values) {` && |\n| &&
+             `      return tpl.replace(/\{(\d+)\}/g, (m, i) =>` && |\n| &&
+             `        (Number(i) < values.length ? String(values[Number(i)]) : m),` && |\n| &&
+             `      );` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -664,7 +664,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `` && |\n| &&
              `    // BIND_ELEMENT: element-bind a whole view slot (popup / popover / main) to` && |\n| &&
              `    // a row of a registered table, so the fragment's relative bindings ({Name},` && |\n| &&
-             `    // {ProductPicUrl}, …) resolve against that row - the abap2UI5 equivalent of` && |\n| &&
+             `    // {ProductPicUrl}, ...) resolve against that row - the abap2UI5 equivalent of` && |\n| &&
              `    // oControl.bindElement(oCtx.getPath()). args = [slot, index, path]; the path` && |\n| &&
              `    // comes from client->_bind( table ) (braces already stripped server-side and` && |\n| &&
              `    // again here defensively), the slot from the follow_up_action view param.` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -276,12 +276,24 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      obj[method](...castArgs(kinds, raw));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    // replace {0},{1},... in a template with the positional values (as strings);` && |\n| &&
+             `    // replace placeholders in a template with the positional values (as` && |\n| &&
+             `    // strings). Two forms:` && |\n| &&
+             `    //   {N}                -> the Nth value verbatim` && |\n| &&
+             `    //   {N?trueText:falseText} -> trueText when the Nth value is truthy, else` && |\n| &&
+             `    //                         falseText (a boolean event param arrives as` && |\n| &&
+             `    //                         "true"/"false", so a toggle can toast` && |\n| &&
+             `    //                         "Pressed"/"Unpressed" without a server round-trip;` && |\n| &&
+             `    //                         trueText/falseText carry no ":" or "}")` && |\n| &&
              `    // an out-of-range placeholder is left as-is.` && |\n| &&
              `    function formatTemplate(tpl, values) {` && |\n| &&
-             `      return tpl.replace(/\{(\d+)\}/g, (m, i) =>` && |\n| &&
-             `        Number(i) < values.length ? String(values[Number(i)]) : m,` && |\n| &&
-             `      );` && |\n| &&
+             `      return tpl.replace(/\{(\d+)(?:\?([^:}]*):([^}]*))?\}/g, (m, i, tText, fText) => {` && |\n| &&
+             `        const n = Number(i);` && |\n| &&
+             `        if (n >= values.length) return m;` && |\n| &&
+             `        const v = String(values[n]);` && |\n| &&
+             `        if (tText === undefined) return v;` && |\n| &&
+             `        const truthy = v !== "" && !/^(false|0|undefined|null)$/i.test(v);` && |\n| &&
+             `        return truthy ? tText : fText;` && |\n| &&
+             `      });` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
@@ -113,6 +113,11 @@ CLASS z2ui5_cl_app_messagemanager_js IMPLEMENTATION.
              `            type: r.TYPE ?? "Error",` && |\n| &&
              `            target: r.TARGET ?? "",` && |\n| &&
              `            additionalText: r.ADDITIONALTEXT ?? "",` && |\n| &&
+             `            // a free string column the app fills server-side (e.g. a display` && |\n| &&
+             `            // group for MessageItem.groupName - sap.ui.core.message.Message has` && |\n| &&
+             `            // no groupName slot, so grouping stays a backend decision bound to` && |\n| &&
+             `            // {message>code} rather than a frontend expression)` && |\n| &&
+             `            code: r.CODE ?? "",` && |\n| &&
              `            processor: this._processor,` && |\n| &&
              `          });` && |\n| &&
              `          this._messaging.addMessages(oMessage);` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -47,6 +47,7 @@ INTERFACE z2ui5_if_client
       control_by_id             TYPE string VALUE `CONTROL_BY_ID`,
       control_global            TYPE string VALUE `CONTROL_GLOBAL`,
       binding_call              TYPE string VALUE `BINDING_CALL`,
+      bind_element              TYPE string VALUE `BIND_ELEMENT`,
 
       "obsolet?
       image_editor_popup_close  TYPE string VALUE `IMAGE_EDITOR_POPUP_CLOSE`,


### PR DESCRIPTION
Add two frontend capabilities usable from follow_up_action / _event_client:

- BIND_ELEMENT: element-binds a whole view slot (popup / popover / main)
  to a table row. Args are slot, index, path; the path comes from
  client->_bind( table ) and its braces are stripped server-side so the
  short _bind form works as a raw JS argument. Lets a popover reuse the
  shared view model via relative bindings instead of passing each field
  as an event arg.
- setHiddenInPopin: sap.m.Table method to hide columns by importance,
  driven by a JSON array of Priority keys.

Both JS implementations (webapp runtime and the ABAP generator mirror)
are kept in sync; get_event_client formats the BIND_ELEMENT args and the
cs_event-bind_element constant is added to the client interface. Adds 3
node tests for BIND_ELEMENT (29 pass, abaplint clean).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B735vYodRiFGUgKDaYjXfX