### PR TITLE
fix(frontend): route popover render errors through the friendly UI5 popup

### DIFF
--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -229,6 +229,33 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     }
   }
 
+  // showFriendlyDialog only succeeds when sap.m.Dialog/Button/Text are already
+  // loaded, because it resolves them with the synchronous sap.ui.require (which
+  // returns undefined for a not-yet-loaded module). This kicks off the async
+  // require for those three controls and retries the friendly popup once they
+  // arrive, so a fatal error raised before any Dialog was used - most notably a
+  // popover fragment that fails to render on the first roundtrip - still lands
+  // in the friendly UI5 popup instead of the raw-DOM overlay. Returns true when
+  // the async load was started (the caller must then NOT also show the raw
+  // overlay); false when async loading is unavailable, so the caller falls back
+  // right away. If the modules cannot be loaded (broken core) or still cannot
+  // render, the errback / retry paths show the raw overlay so the error is
+  // never swallowed.
+  function loadFriendlyDialogAsync(title, details, options) {
+    try {
+      const require = sap?.ui?.require;
+      if (typeof require !== "function") return false;
+      require(["sap/m/Dialog", "sap/m/Button", "sap/m/Text"], () => {
+        if (!showFriendlyDialog(title, details)) {
+          showRawOverlay(title, details, options);
+        }
+      }, () => showRawOverlay(title, details, options));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   // `response` may be a string or an Error object; `title` overrides the
   // default header text; `options.onRetry` adds a Retry action that removes
   // the overlay and re-runs the failed request (offered by Server.readHttp
@@ -251,11 +278,21 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
       onRetry: typeof options.onRetry === "function" ? options.onRetry : null,
     };
 
-    // Prefer a friendly UI5 dialog ("an unexpected error occurred" + Details
-    // / Restart). Only when UI5 cannot render it (broken core, missing
-    // module) do we fall back to the raw-DOM overlay below.
+    // Prefer a friendly UI5 dialog (the error text + Details / Restart).
     if (showFriendlyDialog(title, errorMessage)) return;
 
+    // Its modules were not loaded yet: load them asynchronously and retry, so
+    // the error still lands in the friendly popup first (see
+    // loadFriendlyDialogAsync). Only when async loading is unavailable do we
+    // fall through to the raw-DOM overlay immediately.
+    if (loadFriendlyDialogAsync(title, errorMessage, options)) return;
+
+    showRawOverlay(title, errorMessage, options);
+  }
+
+  // The raw-DOM fatal overlay - the last-resort error display, built without
+  // UI5 so it still works when the core cannot render the friendly dialog.
+  function showRawOverlay(title, errorMessage, options = {}) {
     const errorContainer = createContainer();
 
     // Announce the overlay to assistive technology: without a dialog role

--- a/node/tests/errorView.spec.js
+++ b/node/tests/errorView.spec.js
@@ -58,7 +58,21 @@ function load({ ui5 = true } = {}) {
       return inst;
     };
 
-  const modules = ui5
+  // ui5 === true    -> the controls are already loaded: the synchronous
+  //                    (string) require resolves them, so the friendly dialog
+  //                    renders on the first try.
+  // ui5 === "async" -> the controls are NOT loaded yet: the synchronous require
+  //                    returns undefined (friendly dialog skipped), but the
+  //                    asynchronous (array) require loads them and the retry
+  //                    renders the dialog. This models the first fatal error of
+  //                    a session, e.g. a popover fragment that fails to render
+  //                    before any Dialog was used.
+  // ui5 === false   -> the controls can never be loaded (broken core): both the
+  //                    sync require and the async errback fail, so the raw-DOM
+  //                    overlay is the only display.
+  const haveModules = ui5 !== false;
+  const asyncOnly = ui5 === "async";
+  const modules = haveModules
     ? {
         "sap/m/Dialog": makeCtor("Dialog"),
         "sap/m/Button": makeCtor("Button"),
@@ -66,8 +80,27 @@ function load({ ui5 = true } = {}) {
       }
     : {};
   // Augment the loader-provided sap.ui (which already carries define) with a
-  // require that resolves the lazily-required controls to the stubs above.
-  sandbox.sap.ui.require = (name) => modules[name];
+  // require that resolves the lazily-required controls to the stubs above. It
+  // emulates the two sap.ui.require signatures: the synchronous string form
+  // (returns the module or undefined) and the asynchronous array form (invokes
+  // the callback with the resolved modules, or the errback when unavailable).
+  // Loaded synchronously from the start only when the controls are already
+  // present (ui5 === true). In asyncOnly mode the sync require sees them as
+  // not-yet-loaded until the async (array) require pulls them in - after which
+  // the sync require resolves them, exactly like the real UI5 loader.
+  let loaded = haveModules && !asyncOnly;
+  sandbox.sap.ui.require = (name, callback, errback) => {
+    if (Array.isArray(name)) {
+      if (haveModules) {
+        loaded = true;
+        callback?.(...name.map((n) => modules[n]));
+      } else {
+        errback?.(new Error("module not loaded"));
+      }
+      return undefined;
+    }
+    return loaded ? modules[name] : undefined;
+  };
   return { ErrorView: module, state, reloads, created };
 }
 
@@ -190,10 +223,27 @@ test.describe("ErrorView friendly dialog", () => {
     expect(created.dialogs[1].open_called).toBe(true);
   });
 
+  test("loads the dialog modules asynchronously and still shows the popup", () => {
+    // ui5:"async" -> the synchronous require returns undefined (Dialog not
+    // loaded yet, e.g. a popover fragment that fails to render on the first
+    // roundtrip), but the async require loads the controls and the retry
+    // renders the friendly popup - it must NOT drop to the raw-DOM overlay.
+    const { ErrorView, created } = load({ ui5: "async" });
+    ErrorView.show(
+      "popover dump",
+      "Unexpected Error Occurred - App Terminated",
+    );
+    expect(created.dialogs).toHaveLength(1);
+    expect(created.dialogs[0].open_called).toBe(true);
+    expect(created.dialogs[0].settings.content[0].settings.text).toBe(
+      "popover dump",
+    );
+  });
+
   test("falls back to the raw overlay when UI5 cannot render a dialog", () => {
-    // ui5:false -> sap.ui.require returns undefined for the controls -> the
-    // friendly dialog is skipped and the raw-DOM overlay path runs without
-    // throwing (records lastError either way).
+    // ui5:false -> sap.ui.require returns undefined for the controls (sync) and
+    // the async errback fires -> the friendly dialog is skipped and the raw-DOM
+    // overlay path runs without throwing (records lastError either way).
     const { ErrorView, state, created } = load({ ui5: false });
     expect(() => ErrorView.show("dump", "T")).not.toThrow();
     expect(created.dialogs).toHaveLength(0);

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -249,6 +249,33 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    }` && |\n| &&
              `  }` && |\n| &&
              `` && |\n| &&
+             `  // showFriendlyDialog only succeeds when sap.m.Dialog/Button/Text are already` && |\n| &&
+             `  // loaded, because it resolves them with the synchronous sap.ui.require (which` && |\n| &&
+             `  // returns undefined for a not-yet-loaded module). This kicks off the async` && |\n| &&
+             `  // require for those three controls and retries the friendly popup once they` && |\n| &&
+             `  // arrive, so a fatal error raised before any Dialog was used - most notably a` && |\n| &&
+             `  // popover fragment that fails to render on the first roundtrip - still lands` && |\n| &&
+             `  // in the friendly UI5 popup instead of the raw-DOM overlay. Returns true when` && |\n| &&
+             `  // the async load was started (the caller must then NOT also show the raw` && |\n| &&
+             `  // overlay); false when async loading is unavailable, so the caller falls back` && |\n| &&
+             `  // right away. If the modules cannot be loaded (broken core) or still cannot` && |\n| &&
+             `  // render, the errback / retry paths show the raw overlay so the error is` && |\n| &&
+             `  // never swallowed.` && |\n| &&
+             `  function loadFriendlyDialogAsync(title, details, options) {` && |\n| &&
+             `    try {` && |\n| &&
+             `      const require = sap?.ui?.require;` && |\n| &&
+             `      if (typeof require !== "function") return false;` && |\n| &&
+             `      require(["sap/m/Dialog", "sap/m/Button", "sap/m/Text"], () => {` && |\n| &&
+             `        if (!showFriendlyDialog(title, details)) {` && |\n| &&
+             `          showRawOverlay(title, details, options);` && |\n| &&
+             `        }` && |\n| &&
+             `      }, () => showRawOverlay(title, details, options));` && |\n| &&
+             `      return true;` && |\n| &&
+             `    } catch {` && |\n| &&
+             `      return false;` && |\n| &&
+             `    }` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
              `  // ``response`` may be a string or an Error object; ``title`` overrides the` && |\n| &&
              `  // default header text; ``options.onRetry`` adds a Retry action that removes` && |\n| &&
              `  // the overlay and re-runs the failed request (offered by Server.readHttp` && |\n| &&
@@ -271,11 +298,21 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `      onRetry: typeof options.onRetry === "function" ? options.onRetry : null,` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
-             `    // Prefer a friendly UI5 dialog ("an unexpected error occurred" + Details` && |\n| &&
-             `    // / Restart). Only when UI5 cannot render it (broken core, missing` && |\n| &&
-             `    // module) do we fall back to the raw-DOM overlay below.` && |\n| &&
+             `    // Prefer a friendly UI5 dialog (the error text + Details / Restart).` && |\n| &&
              `    if (showFriendlyDialog(title, errorMessage)) return;` && |\n| &&
              `` && |\n| &&
+             `    // Its modules were not loaded yet: load them asynchronously and retry, so` && |\n| &&
+             `    // the error still lands in the friendly popup first (see` && |\n| &&
+             `    // loadFriendlyDialogAsync). Only when async loading is unavailable do we` && |\n| &&
+             `    // fall through to the raw-DOM overlay immediately.` && |\n| &&
+             `    if (loadFriendlyDialogAsync(title, errorMessage, options)) return;` && |\n| &&
+             `` && |\n| &&
+             `    showRawOverlay(title, errorMessage, options);` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
+             `  // The raw-DOM fatal overlay - the last-resort error display, built without` && |\n| &&
+             `  // UI5 so it still works when the core cannot render the friendly dialog.` && |\n| &&
+             `  function showRawOverlay(title, errorMessage, options = {}) {` && |\n| &&
              `    const errorContainer = createContainer();` && |\n| &&
              `` && |\n| &&
              `    // Announce the overlay to assistive technology: without a dialog role` && |\n| &&
@@ -380,7 +417,8 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    // the primary action instead of the broken page behind the overlay.` && |\n| &&
              `    const firstButton = actionsDiv.querySelector("button");` && |\n| &&
              `    if (firstButton) firstButton.focus();` && |\n| &&
-             `  }` && |\n| &&
+             `  }` && |\n|.
+    result = result &&
              `` && |\n| &&
              `  return { show, handleLogout, reopenErrorDialog };` && |\n| &&
              `});` && |\n| &&


### PR DESCRIPTION
A fatal error surfaced before any sap.m.Dialog had been used - most
notably a popover fragment that fails to render on the first roundtrip
(e.g. an unparseable binding in htmlText) - skipped the friendly UI5
error popup and jumped straight to the raw-DOM "App Terminated" overlay.

The cause: ErrorView.showFriendlyDialog resolves sap.m.Dialog/Button/Text
with the synchronous sap.ui.require, which returns undefined for a
module that has not been loaded yet. On the first error of a session
those controls are usually not loaded, so the friendly popup was
silently skipped.

ErrorView.show now asynchronously requires those three controls and
retries the friendly popup before falling back, so every fatal error
lands in the friendly UI5 popup first. Only a genuinely broken core
(the require errors out, or the retry still cannot render) reaches the
raw-DOM overlay. The raw overlay body is extracted into showRawOverlay
so both the immediate and the errback/retry paths can reuse it.

Adds a unit-test scenario (ui5:"async") that models the popover case:
the sync require reports the controls as not-yet-loaded, the async
require loads them, and the retry renders the friendly dialog.

Regenerates the embedded z2ui5_cl_app_errorview_js ABAP class.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PMuicY4wncbcthigz7gh4s