### PR TITLE
Add support for SplitApp/SplitContainer and QuickView methods

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -80,6 +80,12 @@ sap.ui.define(
     const CONTROL_METHODS = {
       to: ["controlId", "string"], // target page + optional transitionName
       back: [],
+      toDetail: ["controlId"], // sap.m.SplitApp/SplitContainer: show a detail page
+      toMaster: ["controlId"], // sap.m.SplitApp/SplitContainer: show a master page
+      backDetail: [], // sap.m.SplitApp/SplitContainer: back in the detail stack
+      backMaster: [], // sap.m.SplitApp/SplitContainer: back in the master stack
+      setMode: ["string"], // sap.m.SplitApp/SplitContainer: SplitAppMode
+      navigateBack: [], // sap.m.QuickView/QuickViewCard: navigate one page back
       focus: [],
       scrollToIndex: ["int"],
       scrollTo: ["int", "int"],

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -372,6 +372,52 @@ test.describe("CONTROL_BY_ID", () => {
       ["toggle", "myClass"],
     ]);
   });
+
+  test("toDetail/toMaster resolve their page control (SplitApp/SplitContainer)", () => {
+    const { FrontendAction, calls, controls } = load();
+    const detail = { id: "detailDetail" };
+    const master = { id: "master2" };
+    controls.detailDetail = detail;
+    controls.master2 = master;
+    controls.split = {
+      toDetail: (p) => calls.push(["toDetail", p]),
+      toMaster: (p) => calls.push(["toMaster", p]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "split", "", "toDetail", "detailDetail"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "split", "", "toMaster", "master2"]);
+    expect(calls).toEqual([
+      ["toDetail", detail],
+      ["toMaster", master],
+    ]);
+  });
+
+  test("backDetail/backMaster stay no-arg calls (SplitApp/SplitContainer)", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.split = {
+      backDetail: (...a) => calls.push(["backDetail", a.length]),
+      backMaster: (...a) => calls.push(["backMaster", a.length]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "split", "", "backDetail"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "split", "", "backMaster"]);
+    expect(calls).toEqual([
+      ["backDetail", 0],
+      ["backMaster", 0],
+    ]);
+  });
+
+  test("setMode passes the SplitAppMode string through", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.split = { setMode: (m) => calls.push(["setMode", m]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "split", "", "setMode", "StretchCompressMode"]);
+    expect(calls).toEqual([["setMode", "StretchCompressMode"]]);
+  });
+
+  test("navigateBack stays a no-arg call (QuickView/QuickViewCard)", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.qv = { navigateBack: (...a) => calls.push(["navigateBack", a.length]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "qv", "", "navigateBack"]);
+    expect(calls).toEqual([["navigateBack", 0]]);
+  });
 });
 
 test.describe("BINDING_CALL", () => {

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -100,6 +100,12 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    const CONTROL_METHODS = {` && |\n| &&
              `      to: ["controlId", "string"], // target page + optional transitionName` && |\n| &&
              `      back: [],` && |\n| &&
+             `      toDetail: ["controlId"], // sap.m.SplitApp/SplitContainer: show a detail page` && |\n| &&
+             `      toMaster: ["controlId"], // sap.m.SplitApp/SplitContainer: show a master page` && |\n| &&
+             `      backDetail: [], // sap.m.SplitApp/SplitContainer: back in the detail stack` && |\n| &&
+             `      backMaster: [], // sap.m.SplitApp/SplitContainer: back in the master stack` && |\n| &&
+             `      setMode: ["string"], // sap.m.SplitApp/SplitContainer: SplitAppMode` && |\n| &&
+             `      navigateBack: [], // sap.m.QuickView/QuickViewCard: navigate one page back` && |\n| &&
              `      focus: [],` && |\n| &&
              `      scrollToIndex: ["int"],` && |\n| &&
              `      scrollTo: ["int", "int"],` && |\n| &&


### PR DESCRIPTION
# Description

This PR adds support for additional control methods in the FrontendAction framework:

**SplitApp/SplitContainer methods:**
- `toDetail(controlId)` - Navigate to a detail page
- `toMaster(controlId)` - Navigate to a master page
- `backDetail()` - Navigate back in the detail stack
- `backMaster()` - Navigate back in the master stack
- `setMode(mode)` - Set the SplitAppMode

**QuickView/QuickViewCard methods:**
- `navigateBack()` - Navigate one page back

These methods are now properly registered in the `CONTROL_METHODS` configuration with their correct parameter signatures, allowing the framework to resolve control references and pass arguments appropriately.

## How to test

The change includes comprehensive unit tests covering:
- `toDetail` and `toMaster` resolving their page control references
- `backDetail` and `backMaster` being called with no arguments
- `setMode` passing the SplitAppMode string through
- `navigateBack` being called with no arguments

Run: `npm test -- frontendAction.spec.js` to verify all tests pass.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (node/tests/frontendAction.spec.js)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01Mbzqx3Hvgpe7DxSY6DyrMy