### PR TITLE
Add Copy button to error dialog and ABAP source to exports

### DIFF
--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -328,7 +328,9 @@ sap.ui.define(
       // skipped. Every source is guarded (a throwing one can never blank the
       // whole export) and each section is capped, because the SYSTEM global can
       // serialize to several MB - a value that large blanks a sap.m.TextArea.
-      buildExport() {
+      // `abapSource` is the running app's ABAP class source, fetched
+      // asynchronously by onExport (empty when it could not be retrieved).
+      buildExport(abapSource) {
         // Max characters per section; long ones (mainly SYSTEM) are truncated
         // so the popup's TextArea still renders.
         const MAX_SECTION = 100000;
@@ -366,6 +368,10 @@ sap.ui.define(
 
         if (AppState.state.lastError) push("ERROR", text(formatLastError));
         push("LOG", text(formatErrorLog));
+        // The running app's ABAP class source (fetched by onExport). Placed
+        // high up because it is usually the most useful context when sharing
+        // an error - a reader can see the class that produced it.
+        push("ABAP SOURCE", abapSource);
         push(
           "RESPONSE",
           json(() => jsonSources.PLAIN()),
@@ -432,12 +438,36 @@ sap.ui.define(
         return sections.join("\n\n") || "(nothing to export)";
       },
 
+      // Fetch the running app's ABAP class source via the ADT REST endpoint,
+      // so the export can include the class that produced the current state.
+      // Returns the raw source text, or "" when the class name is unknown or
+      // the request fails (the endpoint needs an authenticated, ADT-enabled
+      // session, which is not always available - the export must still work
+      // without it). Never throws: the export must succeed regardless.
+      async fetchAbapSource() {
+        const url = this.getAbapSourceUrl();
+        if (!url) return "";
+        try {
+          const response = await fetch(url, {
+            headers: { Accept: "text/plain" },
+            credentials: "same-origin",
+          });
+          if (!response.ok) return "";
+          return await response.text();
+        } catch {
+          return "";
+        }
+      },
+
       // Show the whole export in a stretched popup with a read-through TextArea
-      // (selectable for manual copy) and a one-click "Copy to Clipboard".
-      onExport() {
+      // (selectable for manual copy) and a one-click "Copy to Clipboard". The
+      // ABAP class source is fetched first (asynchronously) so it can be part
+      // of the exported / copied blob.
+      async onExport() {
         let text;
         try {
-          text = this.buildExport();
+          const abapSource = await this.fetchAbapSource();
+          text = this.buildExport(abapSource);
         } catch (e) {
           text = `(export failed: ${e?.message || e})`;
         }

--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -85,6 +85,36 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
       : preview;
   }
 
+  // Copy text to the clipboard, working both in a secure (HTTPS) context and
+  // over plain HTTP - the latter is common for on-premise ABAP systems, where
+  // the async navigator.clipboard API is unavailable. A hidden <textarea> plus
+  // the classic execCommand("copy") works everywhere, so try it first and only
+  // fall back to the async API when it did not copy. Returns nothing - copying
+  // is best-effort and must never throw out of a fatal-error dialog.
+  function copyToClipboard(text) {
+    const value = String(text == null ? "" : text);
+    let copied;
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    // Keep it out of view and out of the layout flow while it is selected.
+    textarea.style.cssText =
+      "position:fixed;top:-9999px;left:-9999px;opacity:0;";
+    textarea.setAttribute("readonly", "");
+    document.body.appendChild(textarea);
+    try {
+      textarea.focus();
+      textarea.select();
+      textarea.setSelectionRange(0, value.length);
+      copied = document.execCommand("copy");
+    } catch {
+      copied = false;
+    }
+    textarea.remove();
+    if (!copied && navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(value).catch(() => {});
+    }
+  }
+
   function createContainer() {
     // Always start from a fresh element: reusing a previous overlay would
     // keep its keydown focus-trap listener alive and stack a duplicate on
@@ -174,6 +204,22 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
         type: "Emphasized",
         press: () => window.location.reload(),
       });
+      // Copy the full error text (not just the shown preview) to the clipboard
+      // so the user can paste it into a ticket or chat. Briefly flip the label
+      // to "Copied" as feedback, then restore it (guarding against a dialog
+      // that was closed in the meantime).
+      const copyButton = new Button({
+        text: "Copy",
+        press: () => {
+          copyToClipboard(details);
+          copyButton.setText("Copied");
+          setTimeout(() => {
+            if (!copyButton.bIsDestroyed) copyButton.setText("Copy");
+          }, 1500);
+        },
+      });
+      // sap.m.Dialog does not allow more than one begin/end button, so use the
+      // `buttons` aggregation to line up Details / Copy / Restart in the footer.
       const dialog = new Dialog({
         title: title || "Application Error",
         type: "Message",
@@ -181,17 +227,20 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
         icon: "sap-icon://message-error",
         // Escape must not dismiss the fatal-error popup: rejecting the escape
         // promise keeps it open, so the only ways out are the explicit
-        // Details / Restart actions below.
+        // Details / Copy / Restart actions below.
         escapeHandler: (oPromise) => oPromise.reject(),
         content: [new Text({ text: message })],
-        beginButton: new Button({
-          text: "Details",
-          press: () => {
-            dialog.close();
-            openDeveloperTools();
-          },
-        }),
-        endButton: restartButton,
+        buttons: [
+          new Button({
+            text: "Details",
+            press: () => {
+              dialog.close();
+              openDeveloperTools();
+            },
+          }),
+          copyButton,
+          restartButton,
+        ],
         initialFocus: restartButton,
         afterClose: () => {
           if (friendlyDialog === dialog) friendlyDialog = null;

--- a/node/tests/developerTools.spec.js
+++ b/node/tests/developerTools.spec.js
@@ -290,6 +290,19 @@ test.describe("Export", () => {
     expect(out).not.toContain("===== ERROR =====");
     expect(out).toContain("===== LOG =====");
   });
+
+  test("includes the ABAP SOURCE section when a class source is passed", () => {
+    const { DeveloperTools } = loadDeveloperTools();
+    const out = DeveloperTools.buildExport("CLASS zcl_demo DEFINITION.");
+    expect(out).toContain("===== ABAP SOURCE =====");
+    expect(out).toContain("CLASS zcl_demo DEFINITION.");
+  });
+
+  test("omits the ABAP SOURCE section when the source could not be fetched", () => {
+    const { DeveloperTools } = loadDeveloperTools();
+    const out = DeveloperTools.buildExport("");
+    expect(out).not.toContain("===== ABAP SOURCE =====");
+  });
 });
 
 test.describe("Close / Escape returns to the error popup", () => {

--- a/node/tests/errorView.spec.js
+++ b/node/tests/errorView.spec.js
@@ -14,6 +14,9 @@ function load({ ui5 = true } = {}) {
   const AppState = { state };
   const reloads = [];
   const created = { dialogs: [] };
+  // Records the text passed to the async clipboard fallback so the Copy
+  // button test can assert what would be copied.
+  const clipboardWrites = [];
   // Minimal DOM so the raw-overlay fallback path does not throw when it runs.
   const el = () => ({
     id: "",
@@ -39,6 +42,19 @@ function load({ ui5 = true } = {}) {
     sandbox: {
       document,
       window: { location: { reload: () => reloads.push(true) } },
+      // The stubbed DOM has no execCommand, so copyToClipboard falls back to
+      // the async clipboard API - capture what it would write.
+      navigator: {
+        clipboard: {
+          writeText: (v) => {
+            clipboardWrites.push(v);
+            return Promise.resolve();
+          },
+        },
+      },
+      // The Copy button restores its label on a timer; keep it a no-op so the
+      // "Copied" feedback state stays observable in the test.
+      setTimeout: () => 0,
     },
   });
 
@@ -54,6 +70,9 @@ function load({ ui5 = true } = {}) {
       };
       inst.destroy = () => (inst.destroyed = true);
       inst.focus = () => {};
+      // The Copy button flips its label via setText; mirror it into settings so
+      // tests can observe the "Copied" feedback.
+      inst.setText = (t) => (inst.settings.text = t);
       if (kind === "Dialog") created.dialogs.push(inst);
       return inst;
     };
@@ -101,7 +120,7 @@ function load({ ui5 = true } = {}) {
     }
     return loaded ? modules[name] : undefined;
   };
-  return { ErrorView: module, state, reloads, created };
+  return { ErrorView: module, state, reloads, created, clipboardWrites };
 }
 
 test.describe("ErrorView friendly dialog", () => {
@@ -114,19 +133,35 @@ test.describe("ErrorView friendly dialog", () => {
     expect(state.lastError.onRetry).toBe(onRetry);
   });
 
-  test("shows a dialog with Details + Restart and only the error text", () => {
+  test("shows a dialog with Details + Copy + Restart and only the error text", () => {
     const { ErrorView, created } = load();
     ErrorView.show("some backend dump");
     expect(created.dialogs).toHaveLength(1);
     const dlg = created.dialogs[0].settings;
     // No "An unexpected error occurred" prefix - just the error text.
     expect(dlg.content[0].settings.text).toBe("some backend dump");
-    expect(dlg.beginButton.settings.text).toBe("Details");
-    expect(dlg.endButton.settings.text).toBe("Restart");
+    // The footer uses the `buttons` aggregation: Details / Copy / Restart.
+    const [detailsButton, copyButton, restartButton] = dlg.buttons;
+    expect(detailsButton.settings.text).toBe("Details");
+    expect(copyButton.settings.text).toBe("Copy");
+    expect(restartButton.settings.text).toBe("Restart");
     // Restart is emphasized and gets the initial focus.
-    expect(dlg.endButton.settings.type).toBe("Emphasized");
-    expect(dlg.initialFocus).toBe(dlg.endButton);
+    expect(restartButton.settings.type).toBe("Emphasized");
+    expect(dlg.initialFocus).toBe(restartButton);
     expect(created.dialogs[0].open_called).toBe(true);
+  });
+
+  test("Copy copies the full error text to the clipboard", () => {
+    const { ErrorView, created, clipboardWrites } = load();
+    ErrorView.show("full backend dump");
+    const copyButton = created.dialogs[0].settings.buttons[1];
+    expect(copyButton.settings.text).toBe("Copy");
+    copyButton.settings.press();
+    // execCommand is unavailable in the stubbed DOM, so it falls back to the
+    // async clipboard API with the full (untruncated) error text.
+    expect(clipboardWrites).toEqual(["full backend dump"]);
+    // The label flips to "Copied" as feedback.
+    expect(copyButton.settings.text).toBe("Copied");
   });
 
   test("Escape does not dismiss the fatal-error popup", () => {
@@ -185,7 +220,7 @@ test.describe("ErrorView friendly dialog", () => {
     state.developerTools = { show: (tab) => showCalls.push(tab) };
     ErrorView.show("dump");
     const dialog = created.dialogs[0];
-    dialog.settings.beginButton.settings.press();
+    dialog.settings.buttons[0].settings.press(); // Details
     expect(dialog.open_called).toBe(false); // dialog was closed
     expect(state.developerTools.reopenErrorOnClose).toBe(true);
     expect(showCalls).toEqual(["ERROR"]);
@@ -194,7 +229,7 @@ test.describe("ErrorView friendly dialog", () => {
   test("Restart reloads the page", () => {
     const { ErrorView, reloads, created } = load();
     ErrorView.show("dump");
-    created.dialogs[0].settings.endButton.settings.press();
+    created.dialogs[0].settings.buttons[2].settings.press(); // Restart
     expect(reloads).toEqual([true]);
   });
 

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -348,7 +348,9 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `      // skipped. Every source is guarded (a throwing one can never blank the` && |\n| &&
              `      // whole export) and each section is capped, because the SYSTEM global can` && |\n| &&
              `      // serialize to several MB - a value that large blanks a sap.m.TextArea.` && |\n| &&
-             `      buildExport() {` && |\n| &&
+             `      // ``abapSource`` is the running app's ABAP class source, fetched` && |\n| &&
+             `      // asynchronously by onExport (empty when it could not be retrieved).` && |\n| &&
+             `      buildExport(abapSource) {` && |\n| &&
              `        // Max characters per section; long ones (mainly SYSTEM) are truncated` && |\n| &&
              `        // so the popup's TextArea still renders.` && |\n| &&
              `        const MAX_SECTION = 100000;` && |\n| &&
@@ -386,6 +388,10 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `` && |\n| &&
              `        if (AppState.state.lastError) push("ERROR", text(formatLastError));` && |\n| &&
              `        push("LOG", text(formatErrorLog));` && |\n| &&
+             `        // The running app's ABAP class source (fetched by onExport). Placed` && |\n| &&
+             `        // high up because it is usually the most useful context when sharing` && |\n| &&
+             `        // an error - a reader can see the class that produced it.` && |\n| &&
+             `        push("ABAP SOURCE", abapSource);` && |\n| &&
              `        push(` && |\n| &&
              `          "RESPONSE",` && |\n| &&
              `          json(() => jsonSources.PLAIN()),` && |\n| &&
@@ -411,14 +417,14 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `            "POPUP MODEL",` && |\n| &&
              `            json(() => jsonSources.POPUP_MODEL()),` && |\n| &&
              `          );` && |\n| &&
-             `        }` && |\n| &&
+             `        }` && |\n|.
+    result = result &&
              `        if (getResponseXml("S_POPOVER")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "POPOVER",` && |\n| &&
              `            xml(() => xmlSources.POPOVER().xml),` && |\n| &&
              `          );` && |\n| &&
-             `          push(` && |\n|.
-    result = result &&
+             `          push(` && |\n| &&
              `            "POPOVER MODEL",` && |\n| &&
              `            json(() => jsonSources.POPOVER_MODEL()),` && |\n| &&
              `          );` && |\n| &&
@@ -453,12 +459,36 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `        return sections.join("\n\n") || "(nothing to export)";` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
+             `      // Fetch the running app's ABAP class source via the ADT REST endpoint,` && |\n| &&
+             `      // so the export can include the class that produced the current state.` && |\n| &&
+             `      // Returns the raw source text, or "" when the class name is unknown or` && |\n| &&
+             `      // the request fails (the endpoint needs an authenticated, ADT-enabled` && |\n| &&
+             `      // session, which is not always available - the export must still work` && |\n| &&
+             `      // without it). Never throws: the export must succeed regardless.` && |\n| &&
+             `      async fetchAbapSource() {` && |\n| &&
+             `        const url = this.getAbapSourceUrl();` && |\n| &&
+             `        if (!url) return "";` && |\n| &&
+             `        try {` && |\n| &&
+             `          const response = await fetch(url, {` && |\n| &&
+             `            headers: { Accept: "text/plain" },` && |\n| &&
+             `            credentials: "same-origin",` && |\n| &&
+             `          });` && |\n| &&
+             `          if (!response.ok) return "";` && |\n| &&
+             `          return await response.text();` && |\n| &&
+             `        } catch {` && |\n| &&
+             `          return "";` && |\n| &&
+             `        }` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
              `      // Show the whole export in a stretched popup with a read-through TextArea` && |\n| &&
-             `      // (selectable for manual copy) and a one-click "Copy to Clipboard".` && |\n| &&
-             `      onExport() {` && |\n| &&
+             `      // (selectable for manual copy) and a one-click "Copy to Clipboard". The` && |\n| &&
+             `      // ABAP class source is fetched first (asynchronously) so it can be part` && |\n| &&
+             `      // of the exported / copied blob.` && |\n| &&
+             `      async onExport() {` && |\n| &&
              `        let text;` && |\n| &&
              `        try {` && |\n| &&
-             `          text = this.buildExport();` && |\n| &&
+             `          const abapSource = await this.fetchAbapSource();` && |\n| &&
+             `          text = this.buildExport(abapSource);` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          text = ``(export failed: ${e?.message || e})``;` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -105,6 +105,36 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `      : preview;` && |\n| &&
              `  }` && |\n| &&
              `` && |\n| &&
+             `  // Copy text to the clipboard, working both in a secure (HTTPS) context and` && |\n| &&
+             `  // over plain HTTP - the latter is common for on-premise ABAP systems, where` && |\n| &&
+             `  // the async navigator.clipboard API is unavailable. A hidden <textarea> plus` && |\n| &&
+             `  // the classic execCommand("copy") works everywhere, so try it first and only` && |\n| &&
+             `  // fall back to the async API when it did not copy. Returns nothing - copying` && |\n| &&
+             `  // is best-effort and must never throw out of a fatal-error dialog.` && |\n| &&
+             `  function copyToClipboard(text) {` && |\n| &&
+             `    const value = String(text == null ? "" : text);` && |\n| &&
+             `    let copied;` && |\n| &&
+             `    const textarea = document.createElement("textarea");` && |\n| &&
+             `    textarea.value = value;` && |\n| &&
+             `    // Keep it out of view and out of the layout flow while it is selected.` && |\n| &&
+             `    textarea.style.cssText =` && |\n| &&
+             `      "position:fixed;top:-9999px;left:-9999px;opacity:0;";` && |\n| &&
+             `    textarea.setAttribute("readonly", "");` && |\n| &&
+             `    document.body.appendChild(textarea);` && |\n| &&
+             `    try {` && |\n| &&
+             `      textarea.focus();` && |\n| &&
+             `      textarea.select();` && |\n| &&
+             `      textarea.setSelectionRange(0, value.length);` && |\n| &&
+             `      copied = document.execCommand("copy");` && |\n| &&
+             `    } catch {` && |\n| &&
+             `      copied = false;` && |\n| &&
+             `    }` && |\n| &&
+             `    textarea.remove();` && |\n| &&
+             `    if (!copied && navigator.clipboard?.writeText) {` && |\n| &&
+             `      navigator.clipboard.writeText(value).catch(() => {});` && |\n| &&
+             `    }` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
              `  function createContainer() {` && |\n| &&
              `    // Always start from a fresh element: reusing a previous overlay would` && |\n| &&
              `    // keep its keydown focus-trap listener alive and stack a duplicate on` && |\n| &&
@@ -194,6 +224,22 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `        type: "Emphasized",` && |\n| &&
              `        press: () => window.location.reload(),` && |\n| &&
              `      });` && |\n| &&
+             `      // Copy the full error text (not just the shown preview) to the clipboard` && |\n| &&
+             `      // so the user can paste it into a ticket or chat. Briefly flip the label` && |\n| &&
+             `      // to "Copied" as feedback, then restore it (guarding against a dialog` && |\n| &&
+             `      // that was closed in the meantime).` && |\n| &&
+             `      const copyButton = new Button({` && |\n| &&
+             `        text: "Copy",` && |\n| &&
+             `        press: () => {` && |\n| &&
+             `          copyToClipboard(details);` && |\n| &&
+             `          copyButton.setText("Copied");` && |\n| &&
+             `          setTimeout(() => {` && |\n| &&
+             `            if (!copyButton.bIsDestroyed) copyButton.setText("Copy");` && |\n| &&
+             `          }, 1500);` && |\n| &&
+             `        },` && |\n| &&
+             `      });` && |\n| &&
+             `      // sap.m.Dialog does not allow more than one begin/end button, so use the` && |\n| &&
+             `      // ``buttons`` aggregation to line up Details / Copy / Restart in the footer.` && |\n| &&
              `      const dialog = new Dialog({` && |\n| &&
              `        title: title || "Application Error",` && |\n| &&
              `        type: "Message",` && |\n| &&
@@ -201,17 +247,20 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `        icon: "sap-icon://message-error",` && |\n| &&
              `        // Escape must not dismiss the fatal-error popup: rejecting the escape` && |\n| &&
              `        // promise keeps it open, so the only ways out are the explicit` && |\n| &&
-             `        // Details / Restart actions below.` && |\n| &&
+             `        // Details / Copy / Restart actions below.` && |\n| &&
              `        escapeHandler: (oPromise) => oPromise.reject(),` && |\n| &&
              `        content: [new Text({ text: message })],` && |\n| &&
-             `        beginButton: new Button({` && |\n| &&
-             `          text: "Details",` && |\n| &&
-             `          press: () => {` && |\n| &&
-             `            dialog.close();` && |\n| &&
-             `            openDeveloperTools();` && |\n| &&
-             `          },` && |\n| &&
-             `        }),` && |\n| &&
-             `        endButton: restartButton,` && |\n| &&
+             `        buttons: [` && |\n| &&
+             `          new Button({` && |\n| &&
+             `            text: "Details",` && |\n| &&
+             `            press: () => {` && |\n| &&
+             `              dialog.close();` && |\n| &&
+             `              openDeveloperTools();` && |\n| &&
+             `            },` && |\n| &&
+             `          }),` && |\n| &&
+             `          copyButton,` && |\n| &&
+             `          restartButton,` && |\n| &&
+             `        ],` && |\n| &&
              `        initialFocus: restartButton,` && |\n| &&
              `        afterClose: () => {` && |\n| &&
              `          if (friendlyDialog === dialog) friendlyDialog = null;` && |\n| &&
@@ -368,7 +417,8 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    errorContainer.appendChild(headerDiv);` && |\n| &&
              `` && |\n| &&
              `    // Keep keyboard focus inside the overlay: Tab cycles through the action` && |\n| &&
-             `    // buttons instead of escaping into the broken page behind it. The button` && |\n| &&
+             `    // buttons instead of escaping into the broken page behind it. The button` && |\n|.
+    result = result &&
              `    // set is complete here (all appended above), so resolve first/last once` && |\n| &&
              `    // rather than re-querying the DOM on every Tab press.` && |\n| &&
              `    const trapButtons = actionsDiv.querySelectorAll("button");` && |\n| &&
@@ -417,8 +467,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    // the primary action instead of the broken page behind the overlay.` && |\n| &&
              `    const firstButton = actionsDiv.querySelector("button");` && |\n| &&
              `    if (firstButton) firstButton.focus();` && |\n| &&
-             `  }` && |\n|.
-    result = result &&
+             `  }` && |\n| &&
              `` && |\n| &&
              `  return { show, handleLogout, reopenErrorDialog };` && |\n| &&
              `});` && |\n| &&


### PR DESCRIPTION
## Description

This PR enhances error handling and debugging capabilities:

1. **Error Dialog Copy Button**: Adds a "Copy" button to the fatal error dialog that copies the full error text to the clipboard. The button provides visual feedback by temporarily changing its label to "Copied". The implementation uses a fallback strategy that works in both HTTPS and HTTP contexts (important for on-premise ABAP systems where the async clipboard API may be unavailable).

2. **ABAP Source in Exports**: The developer tools export now includes the running app's ABAP class source code, fetched asynchronously via the ADT REST endpoint. This provides crucial context when sharing errors. The source is placed high in the export since it's typically the most useful information for debugging.

3. **Dialog Layout Refactor**: Changes the error dialog from using `beginButton`/`endButton` properties to the `buttons` aggregation to accommodate three action buttons (Details, Copy, Restart) in the footer.

## How to test

1. Trigger an application error and verify the dialog shows three buttons: Details, Copy, and Restart
2. Click the Copy button and verify:
   - The button label changes to "Copied" for 1.5 seconds
   - The full error text is copied to the clipboard (paste it to verify)
3. Open the developer tools export and verify:
   - The "ABAP SOURCE" section appears in the export
   - It contains the running app's class source code (when available)
   - The export still works when the source cannot be fetched

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (added Copy button test, updated dialog structure tests, added ABAP SOURCE export tests)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes are generated from source files)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: no (source files modified, ABAP classes auto-generated)

https://claude.ai/code/session_01GVXEubM33DdccejnoaLWEq