### PR TITLE
Allow unlisted but safe control methods via denylist

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -106,6 +106,26 @@ sap.ui.define(
       toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class
     };
 
+    // A method LISTED above carries explicit arg kinds (and some, like openBy/
+    // toggleBy, get special handling). A method NOT listed is still callable as
+    // long as it is a public control method that is not framework-hostile - so
+    // ordinary setters/toggles (setVisible, enablePostButton, setLayout, ...) work
+    // without enumerating each one here. The denylist protects abap2UI5's own
+    // invariants: nothing that frees or reparents a tracked control, swaps the
+    // model/binding out from under the framework, tampers with event handlers, or
+    // drives the render lifecycle by hand. (The backend is the trusted driver, so
+    // this is a footgun guard, not a security boundary - and control[method] is
+    // still checked to be a function before the call, so a typo just no-ops.)
+    const CONTROL_METHOD_DENY =
+      /^(_|destroy|bind|unbind|attach|detach|removeAll|addDependent|placeAt|rerender|invalidate|applySettings|clone|setModel|setBindingContext|setParent|setBinding|setAssociation)/;
+    function isSafeControlMethod(method) {
+      return (
+        typeof method === "string" &&
+        method.length > 0 &&
+        !CONTROL_METHOD_DENY.test(method)
+      );
+    }
+
     // global object -> lazy getter + its allowed methods (with arg kinds).
     const GLOBAL_TARGETS = {
       MESSAGE_TOAST: { get: () => MessageToast, methods: { show: ["string"] } },
@@ -172,7 +192,21 @@ sap.ui.define(
       }
     }
 
+    // Infer the type of an argument for a method with no declared kinds (the
+    // generalized-allowlist path). abap2UI5 sends booleans as the ABAP tokens
+    // 'X'/space, so recognize those; everything else passes through as a string
+    // (UI5 coerces numeric strings for index/number setters). A method that needs
+    // a literal 'X'/'true'/'false' string or a JSON object must be declared in
+    // CONTROL_METHODS with an explicit kind, which overrides this inference.
+    function castArgAuto(raw) {
+      if (raw === "X" || raw === "true") return true;
+      if (raw === "" || raw === " " || raw === "false") return false;
+      return raw;
+    }
+
     function castArgs(kinds, rawArgs, view) {
+      // kinds === null: unlisted-but-allowed method, infer each arg's type
+      if (kinds === null) return rawArgs.map((raw) => castArgAuto(raw));
       // only cast args the caller actually sent - padding missing trailing
       // args would turn open() into open(undefined) and ints into NaN
       return kinds
@@ -195,10 +229,15 @@ sap.ui.define(
     // args: [_, id, view, method, ...params]
     function evControlCallById(oController, args) {
       const [, id, view, method] = args;
-      const kinds = CONTROL_METHODS[method];
+      let kinds = CONTROL_METHODS[method];
       if (!kinds) {
-        Lib.logError(`CONTROL_BY_ID: method '${method}' not allowed`);
-        return;
+        // not explicitly listed: allow any public, non-hostile control method
+        // (kinds = null -> arg types are inferred), else fail closed.
+        if (!isSafeControlMethod(method)) {
+          Lib.logError(`CONTROL_BY_ID: method '${method}' not allowed`);
+          return;
+        }
+        kinds = null;
       }
       const control = view
         ? ViewSlots.byId(view.toUpperCase(), id)
@@ -319,8 +358,9 @@ sap.ui.define(
     const isEmpty = (v) => v == null || v === "";
 
     // binding method -> builder that turns the trailing params into the
-    // aggregation-update call. Same declarative-whitelist shape as
-    // CONTROL_METHODS: an unlisted method fails closed at the lookup.
+    // aggregation-update call. A strict whitelist (unlike CONTROL_METHODS,
+    // which now allows any non-denied public control method): an unlisted
+    // binding method fails closed at the lookup.
     //   filter: params = [path, operator, value1, value2?]
     //   sort:   params = [path, descending?, group?] (ABAP bools "X"/"")
     // The backend arg serializer keeps empty args between filled ones as ''

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -212,12 +212,58 @@ test.describe("CONTROL_BY_ID", () => {
     expect(calls).toEqual([["to", page2]]);
   });
 
-  test("rejects a non-whitelisted method", () => {
+  test("rejects a framework-hostile method (destroy is on the denylist)", () => {
     const { FrontendAction, calls, errors, controls } = load();
     controls.x = { destroy: () => calls.push(["destroy"]) };
     FrontendAction.execute(null, ["CONTROL_BY_ID", "x", "", "destroy"]);
     expect(calls).toHaveLength(0);
     expect(errors).toHaveLength(1);
+  });
+
+  test("rejects other denied methods (setModel/setParent/bindProperty/attachPress)", () => {
+    const { FrontendAction, calls, errors, controls } = load();
+    controls.x = {
+      setModel: () => calls.push(["setModel"]),
+      setParent: () => calls.push(["setParent"]),
+      bindProperty: () => calls.push(["bindProperty"]),
+      attachPress: () => calls.push(["attachPress"]),
+    };
+    for (const m of ["setModel", "setParent", "bindProperty", "attachPress"]) {
+      FrontendAction.execute(null, ["CONTROL_BY_ID", "x", "", m]);
+    }
+    expect(calls).toHaveLength(0);
+    expect(errors).toHaveLength(4);
+  });
+
+  test("calls an unlisted but safe public method (generalized allowlist)", () => {
+    const { FrontendAction, calls, controls } = load();
+    // enablePostButton is NOT in CONTROL_METHODS, but it is a public, non-denied
+    // setter on a core control -> callable without whitelisting it (app 236).
+    controls.feed = {
+      enablePostButton: (b) => calls.push(["enablePostButton", b]),
+    };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "feed", "", "enablePostButton", "X"]);
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "feed", "", "enablePostButton", " "]);
+    expect(calls).toEqual([
+      ["enablePostButton", true],
+      ["enablePostButton", false],
+    ]);
+  });
+
+  test("infers arg types for an unlisted method (X/space->bool, else string)", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.c = { setValueState: (...a) => calls.push(["setValueState", ...a]) };
+    // a genuine string arg passes through; only the ABAP bool tokens convert
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "c", "", "setValueState", "Error"]);
+    expect(calls).toEqual([["setValueState", "Error"]]);
+  });
+
+  test("a listed method still wins over inference (explicit kinds)", () => {
+    const { FrontendAction, calls, controls } = load();
+    // setHiddenInPopin is listed as ["object"] -> arg is JSON.parsed, not left a string
+    controls.t = { setHiddenInPopin: (a) => calls.push(["setHiddenInPopin", a]) };
+    FrontendAction.execute(null, ["CONTROL_BY_ID", "t", "", "setHiddenInPopin", '["High"]']);
+    expect(calls).toEqual([["setHiddenInPopin", ["High"]]]);
   });
 
   test("open/close without args stay true no-arg calls (popup-mode PDFViewer, Dialog)", () => {

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -126,6 +126,26 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
+             `    // A method LISTED above carries explicit arg kinds (and some, like openBy/` && |\n| &&
+             `    // toggleBy, get special handling). A method NOT listed is still callable as` && |\n| &&
+             `    // long as it is a public control method that is not framework-hostile - so` && |\n| &&
+             `    // ordinary setters/toggles (setVisible, enablePostButton, setLayout, ...) work` && |\n| &&
+             `    // without enumerating each one here. The denylist protects abap2UI5's own` && |\n| &&
+             `    // invariants: nothing that frees or reparents a tracked control, swaps the` && |\n| &&
+             `    // model/binding out from under the framework, tampers with event handlers, or` && |\n| &&
+             `    // drives the render lifecycle by hand. (The backend is the trusted driver, so` && |\n| &&
+             `    // this is a footgun guard, not a security boundary - and control[method] is` && |\n| &&
+             `    // still checked to be a function before the call, so a typo just no-ops.)` && |\n| &&
+             `    const CONTROL_METHOD_DENY =` && |\n| &&
+             `      /^(_|destroy|bind|unbind|attach|detach|removeAll|addDependent|placeAt|rerender|invalidate|applySettings|clone|setModel|setBindingContext|setParent|setBinding|setAssociation)/;` && |\n| &&
+             `    function isSafeControlMethod(method) {` && |\n| &&
+             `      return (` && |\n| &&
+             `        typeof method === "string" &&` && |\n| &&
+             `        method.length > 0 &&` && |\n| &&
+             `        !CONTROL_METHOD_DENY.test(method)` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // global object -> lazy getter + its allowed methods (with arg kinds).` && |\n| &&
              `    const GLOBAL_TARGETS = {` && |\n| &&
              `      MESSAGE_TOAST: { get: () => MessageToast, methods: { show: ["string"] } },` && |\n| &&
@@ -192,7 +212,21 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // Infer the type of an argument for a method with no declared kinds (the` && |\n| &&
+             `    // generalized-allowlist path). abap2UI5 sends booleans as the ABAP tokens` && |\n| &&
+             `    // 'X'/space, so recognize those; everything else passes through as a string` && |\n| &&
+             `    // (UI5 coerces numeric strings for index/number setters). A method that needs` && |\n| &&
+             `    // a literal 'X'/'true'/'false' string or a JSON object must be declared in` && |\n| &&
+             `    // CONTROL_METHODS with an explicit kind, which overrides this inference.` && |\n| &&
+             `    function castArgAuto(raw) {` && |\n| &&
+             `      if (raw === "X" || raw === "true") return true;` && |\n| &&
+             `      if (raw === "" || raw === " " || raw === "false") return false;` && |\n| &&
+             `      return raw;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function castArgs(kinds, rawArgs, view) {` && |\n| &&
+             `      // kinds === null: unlisted-but-allowed method, infer each arg's type` && |\n| &&
+             `      if (kinds === null) return rawArgs.map((raw) => castArgAuto(raw));` && |\n| &&
              `      // only cast args the caller actually sent - padding missing trailing` && |\n| &&
              `      // args would turn open() into open(undefined) and ints into NaN` && |\n| &&
              `      return kinds` && |\n| &&
@@ -215,10 +249,15 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // args: [_, id, view, method, ...params]` && |\n| &&
              `    function evControlCallById(oController, args) {` && |\n| &&
              `      const [, id, view, method] = args;` && |\n| &&
-             `      const kinds = CONTROL_METHODS[method];` && |\n| &&
+             `      let kinds = CONTROL_METHODS[method];` && |\n| &&
              `      if (!kinds) {` && |\n| &&
-             `        Lib.logError(``CONTROL_BY_ID: method '${method}' not allowed``);` && |\n| &&
-             `        return;` && |\n| &&
+             `        // not explicitly listed: allow any public, non-hostile control method` && |\n| &&
+             `        // (kinds = null -> arg types are inferred), else fail closed.` && |\n| &&
+             `        if (!isSafeControlMethod(method)) {` && |\n| &&
+             `          Lib.logError(``CONTROL_BY_ID: method '${method}' not allowed``);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        kinds = null;` && |\n| &&
              `      }` && |\n| &&
              `      const control = view` && |\n| &&
              `        ? ViewSlots.byId(view.toUpperCase(), id)` && |\n| &&
@@ -339,8 +378,9 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    const isEmpty = (v) => v == null || v === "";` && |\n| &&
              `` && |\n| &&
              `    // binding method -> builder that turns the trailing params into the` && |\n| &&
-             `    // aggregation-update call. Same declarative-whitelist shape as` && |\n| &&
-             `    // CONTROL_METHODS: an unlisted method fails closed at the lookup.` && |\n| &&
+             `    // aggregation-update call. A strict whitelist (unlike CONTROL_METHODS,` && |\n| &&
+             `    // which now allows any non-denied public control method): an unlisted` && |\n| &&
+             `    // binding method fails closed at the lookup.` && |\n| &&
              `    //   filter: params = [path, operator, value1, value2?]` && |\n| &&
              `    //   sort:   params = [path, descending?, group?] (ABAP bools "X"/"")` && |\n| &&
              `    // The backend arg serializer keeps empty args between filled ones as ''` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -417,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            : [];` && |\n| &&
              `          if (typeof path !== "string" || !FILTER_OPERATORS.has(operator)) {` && |\n| &&
              `            Lib.logError(` && |\n| &&
-             `              ``BINDING_CALL: bad filter row (path '${path}' / operator '${operator}')``,` && |\n| &&
+             `              ``BINDING_CALL: bad filter row (path '${path}' / operator '${operator}')``,` && |\n|.
+    result = result &&
              `            );` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
@@ -463,8 +464,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      sort(binding, [path, descending, group]) {` && |\n| &&
              `        binding.sort([` && |\n| &&
              `          new Sorter(path, castArg("bool", descending), castArg("bool", group)),` && |\n| &&
-             `        ]);` && |\n|.
-    result = result &&
+             `        ]);` && |\n| &&
              `      },` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
@@ -818,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          ? dom` && |\n| &&
              `          : dom.querySelector("input, textarea");` && |\n| &&
              `        if (!input) return;` && |\n| &&
-             `        input.setAttribute("inputmode", args[2] || "text");` && |\n| &&
+             `        input.setAttribute("inputmode", args[2] || "text");` && |\n|.
+    result = result &&
              `      } catch (e) {` && |\n| &&
              `        Lib.logError(` && |\n| &&
              `          ``KEYBOARD_SET_MODE: setAttribute failed for '${args[1]}'``,` && |\n| &&
@@ -864,8 +865,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // ScrollContainer etc. expose ScrollEnablement). The delegate knows` && |\n| &&
              `      // the real scroll container, which often is NOT the control's root` && |\n| &&
              `      // DOM element - so native Element.scrollTo on getDomRef() silently` && |\n| &&
-             `      // does nothing on a Page. ScrollEnablement.scrollTo(x, y, time)` && |\n|.
-    result = result &&
+             `      // does nothing on a Page. ScrollEnablement.scrollTo(x, y, time)` && |\n| &&
              `      // animates when time > 0, so "smooth" maps to a 300ms animation.` && |\n| &&
              `      // Native Element.scrollTo is only used as a fallback for controls` && |\n| &&
              `      // without a delegate.` && |\n| &&


### PR DESCRIPTION
# Description

This PR extends the `CONTROL_BY_ID` action to support any public, non-hostile control method without requiring explicit whitelisting in `CONTROL_METHODS`. Previously, only methods declared in the whitelist were callable; now methods are allowed by default unless they match a denylist of framework-hostile operations.

## Changes

- **Added `CONTROL_METHOD_DENY` regex**: Blocks methods that could compromise framework invariants (destroy, bind/unbind, attach/detach, removeAll, addDependent, placeAt, rerender, invalidate, applySettings, clone, setModel, setBindingContext, setParent, setBinding, setAssociation, and private methods starting with `_`).

- **Added `isSafeControlMethod()` function**: Validates that a method name is a non-empty string and does not match the denylist.

- **Added `castArgAuto()` function**: Infers argument types for unlisted methods by converting ABAP boolean tokens (`"X"` → true, `""` or `" "` → false) and passing other values as strings. This allows UI5's built-in coercion to handle numeric strings for index/number setters.

- **Updated `castArgs()` function**: When `kinds === null` (unlisted method), applies automatic type inference to all arguments.

- **Updated `evControlCallById()` logic**: Changed from fail-closed (reject unlisted methods) to fail-closed-on-denylist (allow unlisted methods unless denied). Sets `kinds = null` for unlisted-but-safe methods to trigger inference.

- **Updated binding method comment**: Clarified that binding methods remain a strict whitelist (unlike control methods), maintaining the existing security posture for that code path.

## How to test

The test suite includes four new test cases:
- Verify denied methods (destroy, setModel, setParent, bindProperty, attachPress) are still rejected
- Verify unlisted safe methods (e.g., enablePostButton) are callable with inferred types
- Verify ABAP boolean tokens ("X", space) convert to true/false for unlisted methods
- Verify explicitly listed methods still use their declared kinds (e.g., setHiddenInPopin with ["object"] parses JSON)

All existing tests pass; no breaking changes to the public API.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (node/tests/frontendAction.spec.js)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes auto-generated from JS source)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: no (JS source is the authority)

https://claude.ai/code/session_018bxLc81tdpZtW3sJ73vboJ