### PR TITLE
Add enablePostButton support and improve openBy handling

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -103,6 +103,7 @@ sap.ui.define(
       expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels
       collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node
       setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)
+      enablePostButton: ["bool"], // sap.m.FeedInput: toggle the Post button independent of `enabled`
       addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class
       removeStyleClass: ["string"], // sap.ui.core.Control: remove a CSS style class
       toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class
@@ -265,16 +266,33 @@ sap.ui.define(
         });
         return;
       }
+      // openBy is handled BEFORE the generic callable check: a control
+      // without an own openBy (sap.ui.unified.Menu) still supports the
+      // anchored open via its open(bWithKeyboard, opener, my, at, of)
+      // signature - the anchor doubles as opener and dock reference.
+      if (method === "openBy") {
+        if (
+          !control ||
+          (typeof control.openBy !== "function" &&
+            typeof control.open !== "function")
+        ) {
+          Lib.logError(
+            `CONTROL_BY_ID: 'openBy' not callable on control '${id}'`,
+          );
+          return;
+        }
+        const anchor = castArgs(kinds, args.slice(4), view)[0];
+        // Same reason as toggleBy: wait for the anchor to render.
+        whenAnchorRendered(anchor, oController, () => {
+          if (typeof control.openBy === "function") control.openBy(anchor);
+          else control.open(false, anchor, "begin top", "begin bottom", anchor);
+        });
+        return;
+      }
       if (!control || typeof control[method] !== "function") {
         Lib.logError(
           `CONTROL_BY_ID: '${method}' not callable on control '${id}'`,
         );
-        return;
-      }
-      if (method === "openBy") {
-        const anchor = castArgs(kinds, args.slice(4), view)[0];
-        // Same reason as toggleBy: wait for the anchor to render.
-        whenAnchorRendered(anchor, oController, () => control.openBy(anchor));
         return;
       }
       control[method](...castArgs(kinds, args.slice(4), view));

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -123,6 +123,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      expandToLevel: ["int"], // sap.m.Tree / sap.ui.table.TreeTable: expand to N levels` && |\n| &&
              `      collapseAll: [], // sap.m.Tree / sap.ui.table.TreeTable: collapse every node` && |\n| &&
              `      setHiddenInPopin: ["object"], // sap.m.Table: hide columns by importance (JSON array of Priority keys)` && |\n| &&
+             `      enablePostButton: ["bool"], // sap.m.FeedInput: toggle the Post button independent of ``enabled``` && |\n| &&
              `      addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class` && |\n| &&
              `      removeStyleClass: ["string"], // sap.ui.core.Control: remove a CSS style class` && |\n| &&
              `      toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class` && |\n| &&
@@ -285,16 +286,33 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        });` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
+             `      // openBy is handled BEFORE the generic callable check: a control` && |\n| &&
+             `      // without an own openBy (sap.ui.unified.Menu) still supports the` && |\n| &&
+             `      // anchored open via its open(bWithKeyboard, opener, my, at, of)` && |\n| &&
+             `      // signature - the anchor doubles as opener and dock reference.` && |\n| &&
+             `      if (method === "openBy") {` && |\n| &&
+             `        if (` && |\n| &&
+             `          !control ||` && |\n| &&
+             `          (typeof control.openBy !== "function" &&` && |\n| &&
+             `            typeof control.open !== "function")` && |\n| &&
+             `        ) {` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``CONTROL_BY_ID: 'openBy' not callable on control '${id}'``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        const anchor = castArgs(kinds, args.slice(4), view)[0];` && |\n| &&
+             `        // Same reason as toggleBy: wait for the anchor to render.` && |\n| &&
+             `        whenAnchorRendered(anchor, oController, () => {` && |\n| &&
+             `          if (typeof control.openBy === "function") control.openBy(anchor);` && |\n| &&
+             `          else control.open(false, anchor, "begin top", "begin bottom", anchor);` && |\n| &&
+             `        });` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
              `      if (!control || typeof control[method] !== "function") {` && |\n| &&
              `        Lib.logError(` && |\n| &&
              `          ``CONTROL_BY_ID: '${method}' not callable on control '${id}'``,` && |\n| &&
              `        );` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
-             `      if (method === "openBy") {` && |\n| &&
-             `        const anchor = castArgs(kinds, args.slice(4), view)[0];` && |\n| &&
-             `        // Same reason as toggleBy: wait for the anchor to render.` && |\n| &&
-             `        whenAnchorRendered(anchor, oController, () => control.openBy(anchor));` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
              `      control[method](...castArgs(kinds, args.slice(4), view));` && |\n| &&
@@ -399,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        groups = JSON.parse(json);` && |\n| &&
              `      } catch {` && |\n| &&
              `        Lib.logError("BINDING_CALL: malformed filter groups JSON");` && |\n| &&
-             `        return;` && |\n| &&
+             `        return;` && |\n|.
+    result = result &&
              `      }` && |\n| &&
              `      if (!Array.isArray(groups)) {` && |\n| &&
              `        Lib.logError("BINDING_CALL: filter groups must be an array");` && |\n| &&
@@ -417,8 +436,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          const [path, operator, value1, value2] = Array.isArray(row)` && |\n| &&
              `            ? row` && |\n| &&
              `            : [];` && |\n| &&
-             `          if (typeof path !== "string" || !FILTER_OPERATORS.has(operator)) {` && |\n|.
-    result = result &&
+             `          if (typeof path !== "string" || !FILTER_OPERATORS.has(operator)) {` && |\n| &&
              `            Lib.logError(` && |\n| &&
              `              ``BINDING_CALL: bad filter row (path '${path}' / operator '${operator}')``,` && |\n| &&
              `            );` && |\n| &&
@@ -800,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const editor = ViewSlots.byId("POPUP", "imageEditor");` && |\n| &&
              `        if (editor) image = editor.getImagePngDataURL();` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n| &&
+             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n|.
+    result = result &&
              `      }` && |\n| &&
              `      ViewSlots.destroy("POPUP");` && |\n| &&
              `      oController.eB(["SAVE"], image);` && |\n| &&
@@ -818,8 +837,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      clearTimeout(timers[timerKey]);` && |\n| &&
              `      timers[timerKey] = setTimeout(() => {` && |\n| &&
              `        delete timers[timerKey];` && |\n| &&
-             `        oController.eB([callbackEvent]);` && |\n|.
-    result = result &&
+             `        oController.eB([callbackEvent]);` && |\n| &&
              `      }, delay);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&


### PR DESCRIPTION
# Description

This PR makes two key improvements to the FrontendAction functionality:

1. **Add `enablePostButton` method support**: Adds support for the `enablePostButton` method on `sap.m.FeedInput` controls, allowing independent toggling of the Post button state regardless of the control's `enabled` property.

2. **Improve `openBy` method handling**: Refactors the `openBy` method logic to be checked **before** the generic callable check. This allows controls like `sap.ui.unified.Menu` that don't have their own `openBy` method to still support anchored opening via their `open(bWithKeyboard, opener, my, at, of)` signature. The implementation now:
   - Validates that the control has either `openBy` or `open` methods
   - Properly handles both control types with dedicated `openBy` and those using the generic `open` method
   - Maintains the anchor rendering wait behavior for both cases

## How to test

- Verify `enablePostButton` can be called on FeedInput controls to toggle the Post button state
- Test that `openBy` works correctly with:
  - Controls that have a dedicated `openBy` method
  - `sap.ui.unified.Menu` and similar controls that use the `open` method with anchor parameters

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01XedzkbSu1nuj9T1Yo5mtYr