### PR TITLE
Restore the calling app as the user left it after nav_app_call

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -213,6 +213,11 @@ sap.ui.define(
                 // latest draft so a later Forward restores the newest state.
                 const route = Lib.routeForApp(app, draftForRoute);
                 if (PARAMS.CHECK_NAV_APP_CALL) {
+                  // repoint the caller's entry first - it borrows the echo
+                  // guard, so restore it to this app before pushing the route
+                  this._repointCallerEntry(PARAMS, draftForRoute);
+                  state.currentApp = app;
+                  state.currentDraftId = draftForRoute;
                   _hashChanger.setHash(route);
                 } else if (_hashChanger.getHash() !== route) {
                   _hashChanger.replaceHash(route);
@@ -242,6 +247,34 @@ sap.ui.define(
         } catch (e) {
           Lib.logError("_updateBrowserHistory: history update failed", e);
         }
+      },
+
+      // Point the CALLING app's history entry at the draft the backend saved
+      // for it during this very nav_app_call (PARAMS.NAV_APP_CALL_PREV_*).
+      // That draft carries every client-side change the user made since the
+      // caller last rendered - two-way bound switches, checkboxes, input - all
+      // of which travelled to the backend with the event that triggered the
+      // navigation. The entry itself still carries the older draft of that
+      // last render, so without this Back restores the caller as it was
+      // RENDERED and silently drops those changes. The entry is still the top
+      // one here (the called app's route is pushed right after), so a
+      // replaceHash updates it in place and leaves the history depth alone.
+      // KEEP mode only - a FRESH route carries no draft and always restarts
+      // the app anyway.
+      _repointCallerEntry(PARAMS, draftForRoute) {
+        const state = AppState.state;
+        const prevApp = PARAMS.NAV_APP_CALL_PREV_APP;
+        const prevDraft = PARAMS.NAV_APP_CALL_PREV_ID;
+        if (!draftForRoute || !prevApp || !prevDraft) return;
+        const prevRoute = Lib.routeForApp(prevApp, prevDraft);
+        if (_hashChanger.getHash() === prevRoute) return;
+        // Server.onHashChange ignores the echo of our own hash writes by
+        // comparing the route's draft id against currentDraftId - adopt the
+        // caller's fresh draft BEFORE replacing, or the write reads as a user
+        // navigation and fires a restore roundtrip. The caller of this method
+        // sets the state back to the called app right afterwards.
+        state.currentDraftId = prevDraft;
+        _hashChanger.replaceHash(prevRoute);
       },
 
       // Execute the follow-up JS snippets stashed by Server.responseSuccess.

--- a/node/tests/view1History.spec.js
+++ b/node/tests/view1History.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loadModule } = require("./loadModule");
+
+// Tests View1._updateBrowserHistory - the half of the hash router that WRITES
+// the URL (Server.onHashChange, which reads it, is covered by
+// serverHashRouter.spec.js). What matters here is which history entry each
+// roundtrip touches:
+//  - a plain roundtrip REPLACES the current entry with the app's latest draft
+//  - a nav_app_call PUSHES the called app's route, and first repoints the
+//    CALLING app's entry at the draft the backend saved for it in that same
+//    roundtrip (NAV_APP_CALL_PREV_APP / _ID) - otherwise Back restores the
+//    caller as it was rendered and drops every client-side change the user
+//    made before navigating away (two-way bound switches, checkboxes, input).
+
+function loadLib() {
+  const { module: Lib } = loadModule("core/Lib.js", {
+    deps: { "z2ui5/core/AppState": { state: {} }, "sap/ui/core/Element": {} },
+  });
+  return Lib;
+}
+
+const CALLER = "Z2UI5_CL_CALLER";
+const CALLEE = "Z2UI5_CL_CALLEE";
+
+function loadController(stateOverrides = {}) {
+  // records every hash write plus the echo guard (currentDraftId) that was in
+  // place at that moment - Server.onHashChange compares against it
+  const writes = [];
+  let hash = "";
+  const hashChanger = {
+    getHash: () => hash,
+    setHash: (h) => { writes.push({ op: "set", hash: h, guard: state.currentDraftId }); hash = h; },
+    replaceHash: (h) => { writes.push({ op: "replace", hash: h, guard: state.currentDraftId }); hash = h; },
+  };
+  const state = {
+    navRouting: true,
+    navMode: "KEEP",
+    currentApp: CALLER,
+    currentDraftId: "D1",
+    navFromHash: false,
+    ...stateOverrides,
+  };
+  const { module: ctrl } = loadModule("controller/View1.controller.js", {
+    deps: {
+      // Controller.extend hands back the plain methods object, so the
+      // controller's own functions can be called directly
+      "sap/ui/core/mvc/Controller": { extend: (name, methods) => methods },
+      "sap/ui/core/routing/HashChanger": { getInstance: () => hashChanger },
+      "z2ui5/core/Lib": loadLib(),
+      "z2ui5/core/AppState": { state },
+    },
+  });
+  return { ctrl, state, writes, setHash: (h) => { hash = h; } };
+}
+
+// the response of the roundtrip that ran client->nav_app_call
+function navCallParams() {
+  return {
+    CHECK_NAV_APP_CALL: true,
+    NAV_APP_CALL_PREV_APP: CALLER,
+    NAV_APP_CALL_PREV_ID: "D2",
+  };
+}
+
+test("a plain roundtrip replaces the current entry with the newest draft", () => {
+  const { ctrl, state, writes } = loadController();
+  state.oResponse = { APP: CALLER };
+
+  ctrl._updateBrowserHistory({}, "D2");
+
+  expect(writes).toEqual([
+    { op: "replace", hash: `/app/${CALLER}/D2`, guard: "D2" },
+  ]);
+});
+
+test("a nav_app_call repoints the caller's entry, then pushes the called app", () => {
+  const { ctrl, state, writes, setHash } = loadController();
+  setHash(`/app/${CALLER}/D1`); // the entry the browser is standing on
+  state.oResponse = { APP: CALLEE };
+
+  ctrl._updateBrowserHistory(navCallParams(), "D9");
+
+  expect(writes).toEqual([
+    // the caller's entry now points at the draft that carries the user's
+    // client-side changes ...
+    { op: "replace", hash: `/app/${CALLER}/D2`, guard: "D2" },
+    // ... and the called app gets a NEW entry, so Back returns to it
+    { op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" },
+  ]);
+  // the state ends up on the called app (the repoint must not leak)
+  expect(state.currentApp).toBe(CALLEE);
+  expect(state.currentDraftId).toBe("D9");
+});
+
+test("the repoint is skipped when the caller's entry is already current", () => {
+  const { ctrl, state, writes, setHash } = loadController();
+  setHash(`/app/${CALLER}/D2`);
+  state.oResponse = { APP: CALLEE };
+
+  ctrl._updateBrowserHistory(navCallParams(), "D9");
+
+  expect(writes).toEqual([{ op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" }]);
+});
+
+test("a nav_app_call without the caller info only pushes (older backend)", () => {
+  const { ctrl, state, writes } = loadController();
+  state.oResponse = { APP: CALLEE };
+
+  ctrl._updateBrowserHistory({ CHECK_NAV_APP_CALL: true }, "D9");
+
+  expect(writes).toEqual([{ op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" }]);
+});
+
+test("FRESH mode routes by class only and never repoints", () => {
+  const { ctrl, state, writes } = loadController({ navMode: "FRESH", currentDraftId: null });
+  state.oResponse = { APP: CALLEE };
+
+  ctrl._updateBrowserHistory(navCallParams(), "D9");
+
+  expect(writes).toEqual([{ op: "set", hash: `/app/${CALLEE}`, guard: null }]);
+});
+
+test("a render caused by browser Back/Forward writes no hash at all", () => {
+  const { ctrl, state, writes } = loadController({ navFromHash: true });
+  state.oResponse = { APP: CALLER };
+
+  ctrl._updateBrowserHistory({}, "D2");
+
+  expect(writes).toEqual([]);
+  expect(state.navFromHash).toBe(false);
+});

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -128,6 +128,21 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     " returns to the calling app (see View1._updateBrowserHistory)
     result->ms_next-s_set-check_nav_app_call = abap_true.
 
+    " prepare_app_stack( ) just saved the calling app under a NEW draft id -
+    " one that includes everything the user changed on the client since the
+    " caller last rendered (two-way bound switches, checkboxes, input; they
+    " arrive with the event that triggered this navigation). The caller's
+    " history entry, however, still carries the draft of that last render, so
+    " Back would restore it WITHOUT those changes. Hand the fresh draft to the
+    " frontend, which repoints the caller's entry at it before pushing the
+    " called app's route. Only the first hop of a request sets this: in a chain
+    " A -> B -> C the entry to repoint is A's, the app the user came from.
+    IF result->ms_next-s_set-nav_app_call_prev_id IS INITIAL.
+      result->ms_next-s_set-nav_app_call_prev_app =
+          z2ui5_cl_a2ui5_context=>rtti_get_classname_by_ref( mo_app->mo_app ).
+      result->ms_next-s_set-nav_app_call_prev_id  = mo_app->ms_draft-id.
+    ENDIF.
+
   ENDMETHOD.
 
   METHOD factory_stack_leave.

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -222,6 +222,7 @@ CLASS ltcl_test IMPLEMENTATION.
     DATA lo_action TYPE REF TO z2ui5_cl_core_action.
     DATA lo_new_app TYPE REF TO ltcl_test_app.
     DATA lo_result TYPE REF TO z2ui5_cl_core_action.
+    DATA lo_chained TYPE REF TO z2ui5_cl_core_action.
 
     IF sy-sysid = `ABC`.
       RETURN.
@@ -265,6 +266,26 @@ CLASS ltcl_test IMPLEMENTATION.
     " popovers are carried across the app stack
     cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
                                         act = lo_result->ms_next-s_set-s_popover-xml ).
+
+    " the frontend is told to push a route entry for the called app, and where
+    " the CALLING app was just saved - it repoints the caller's history entry at
+    " that draft, so Back restores the state the user left it in, not the one it
+    " was last rendered with
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_result->ms_next-s_set-check_nav_app_call ).
+    cl_abap_unit_assert=>assert_equals( exp = `CURRENT_DRAFT`
+                                        act = lo_result->ms_next-s_set-nav_app_call_prev_id ).
+    cl_abap_unit_assert=>assert_not_initial( lo_result->ms_next-s_set-nav_app_call_prev_app ).
+
+    " a chained call ( A -> B -> C ) keeps the FIRST caller - that is the entry
+    " the browser is standing on, i.e. the app the user navigated away from
+    lo_result->ms_next-o_app_call  = NEW ltcl_test_app( ).
+    lo_result->mo_app->ms_draft-id = `SECOND_DRAFT`.
+
+    lo_chained = lo_result->factory_stack_call( ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `CURRENT_DRAFT`
+                                        act = lo_chained->ms_next-s_set-nav_app_call_prev_id ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -76,8 +76,8 @@ INTERFACE z2ui5_if_core_types
         check_destroy             TYPE abap_bool,
         check_update_model        TYPE abap_bool,
       END OF s_view,
-      s_view_nest          TYPE ty_s_view_nest,
-      s_view_nest2         TYPE ty_s_view_nest,
+      s_view_nest           TYPE ty_s_view_nest,
+      s_view_nest2          TYPE ty_s_view_nest,
       BEGIN OF s_popup,
         xml                TYPE string,
         id                 TYPE string,
@@ -126,9 +126,9 @@ INTERFACE z2ui5_if_core_types
       BEGIN OF s_follow_up_action,
         custom_js TYPE string_table,
       END OF s_follow_up_action,
-      set_app_state_active TYPE abap_bool,
-      set_push_state       TYPE string,
-      set_nav_back         TYPE abap_bool,
+      set_app_state_active  TYPE abap_bool,
+      set_push_state        TYPE string,
+      set_nav_back          TYPE abap_bool,
       " Hash-based app routing (UI5 Router style): when active, the frontend
       " keeps the URL hash in sync with the running app as a bookmarkable route,
       " and the browser Back/Forward buttons navigate between apps via that hash
@@ -139,13 +139,25 @@ INTERFACE z2ui5_if_core_types
       " state; 'FRESH' syncs the class only '#/app/<CLASS>' so they start the
       " app fresh; 'DEFAULT' turns routing off again; an empty value means 'no
       " change' (a session keeps the mode it already has).
-      set_nav_routing      TYPE string,
+      set_nav_routing       TYPE string,
       " Forward app navigation via a backend nav_app_call: tells the frontend to
       " PUSH a new route history entry ('#/app/<CLASS>' of the called app) so the
       " browser Back button returns to the calling app - the routing equivalent
       " of a UI5 navTo. A plain roundtrip only replaces the current route.
-      check_nav_app_call   TYPE abap_bool,
-      s_stateful           TYPE ty_s_http_res-s_stateful,
+      check_nav_app_call    TYPE abap_bool,
+      " The CALLING app of that nav_app_call, as class + the draft id it was
+      " saved under right before the navigation. That draft carries every
+      " client-side model change the user made since the caller last rendered
+      " (switches, checkboxes, input) - its history entry, however, still points
+      " at the older draft of that last render. The frontend therefore repoints
+      " the caller's entry at this draft before pushing the called app's route,
+      " so browser Back restores the caller exactly as the user left it (KEEP
+      " mode only - a FRESH route carries no draft). Set for the FIRST hop of a
+      " request only, so a chain of nav_app_calls keeps the entry of the app the
+      " user actually navigated away from.
+      nav_app_call_prev_app TYPE string,
+      nav_app_call_prev_id  TYPE string,
+      s_stateful            TYPE ty_s_http_res-s_stateful,
     END OF ty_s_next_frontend.
 
   TYPES:

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -233,6 +233,11 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `                // latest draft so a later Forward restores the newest state.` && |\n| &&
              `                const route = Lib.routeForApp(app, draftForRoute);` && |\n| &&
              `                if (PARAMS.CHECK_NAV_APP_CALL) {` && |\n| &&
+             `                  // repoint the caller's entry first - it borrows the echo` && |\n| &&
+             `                  // guard, so restore it to this app before pushing the route` && |\n| &&
+             `                  this._repointCallerEntry(PARAMS, draftForRoute);` && |\n| &&
+             `                  state.currentApp = app;` && |\n| &&
+             `                  state.currentDraftId = draftForRoute;` && |\n| &&
              `                  _hashChanger.setHash(route);` && |\n| &&
              `                } else if (_hashChanger.getHash() !== route) {` && |\n| &&
              `                  _hashChanger.replaceHash(route);` && |\n| &&
@@ -262,6 +267,34 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        } catch (e) {` && |\n| &&
              `          Lib.logError("_updateBrowserHistory: history update failed", e);` && |\n| &&
              `        }` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      // Point the CALLING app's history entry at the draft the backend saved` && |\n| &&
+             `      // for it during this very nav_app_call (PARAMS.NAV_APP_CALL_PREV_*).` && |\n| &&
+             `      // That draft carries every client-side change the user made since the` && |\n| &&
+             `      // caller last rendered - two-way bound switches, checkboxes, input - all` && |\n| &&
+             `      // of which travelled to the backend with the event that triggered the` && |\n| &&
+             `      // navigation. The entry itself still carries the older draft of that` && |\n| &&
+             `      // last render, so without this Back restores the caller as it was` && |\n| &&
+             `      // RENDERED and silently drops those changes. The entry is still the top` && |\n| &&
+             `      // one here (the called app's route is pushed right after), so a` && |\n| &&
+             `      // replaceHash updates it in place and leaves the history depth alone.` && |\n| &&
+             `      // KEEP mode only - a FRESH route carries no draft and always restarts` && |\n| &&
+             `      // the app anyway.` && |\n| &&
+             `      _repointCallerEntry(PARAMS, draftForRoute) {` && |\n| &&
+             `        const state = AppState.state;` && |\n| &&
+             `        const prevApp = PARAMS.NAV_APP_CALL_PREV_APP;` && |\n| &&
+             `        const prevDraft = PARAMS.NAV_APP_CALL_PREV_ID;` && |\n| &&
+             `        if (!draftForRoute || !prevApp || !prevDraft) return;` && |\n| &&
+             `        const prevRoute = Lib.routeForApp(prevApp, prevDraft);` && |\n| &&
+             `        if (_hashChanger.getHash() === prevRoute) return;` && |\n| &&
+             `        // Server.onHashChange ignores the echo of our own hash writes by` && |\n| &&
+             `        // comparing the route's draft id against currentDraftId - adopt the` && |\n| &&
+             `        // caller's fresh draft BEFORE replacing, or the write reads as a user` && |\n| &&
+             `        // navigation and fires a restore roundtrip. The caller of this method` && |\n| &&
+             `        // sets the state back to the called app right afterwards.` && |\n| &&
+             `        state.currentDraftId = prevDraft;` && |\n| &&
+             `        _hashChanger.replaceHash(prevRoute);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // Execute the follow-up JS snippets stashed by Server.responseSuccess.` && |\n| &&
@@ -384,7 +417,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
-             `        // METHOD_DESTROY is optional: only call it when the app asked for a` && |\n| &&
+             `        // METHOD_DESTROY is optional: only call it when the app asked for a` && |\n|.
+    result = result &&
              `        // parent teardown method. An empty value used to reach oParent[""]()` && |\n| &&
              `        // and throw on every render (e.g. app 065 passes only method_insert).` && |\n| &&
              `        if (METHOD_DESTROY) {` && |\n| &&
@@ -417,8 +451,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `      destroyNestView() {` && |\n| &&
              `        ViewSlots.destroy("NEST");` && |\n| &&
-             `      },` && |\n|.
-    result = result &&
+             `      },` && |\n| &&
              `      destroyNestView2() {` && |\n| &&
              `        ViewSlots.destroy("NEST2");` && |\n| &&
              `      },` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -126,6 +126,11 @@ INTERFACE z2ui5_if_client
   "! in the route '#/app/<CLASS>/<DRAFT>'; fresh routes by class only
   "! '#/app/<CLASS>' and always starts the app fresh; default disables routing
   "! (framework behaviour as before this feature).
+  "!
+  "! In keep mode the calling app's route entry is advanced to the draft saved
+  "! for it during the nav_app_call, so Back restores it as the user LEFT it -
+  "! including everything two-way bound that changed on the client since it
+  "! last rendered and travelled to the backend with the triggering event.
   METHODS set_nav_routing
     IMPORTING
       mode TYPE string DEFAULT cs_nav_mode-keep.


### PR DESCRIPTION
With hash routing in KEEP mode, browser Back after a client->nav_app_call
restored the CALLING app as it was last RENDERED, silently dropping every
client-side change the user made before navigating away - two-way bound
switches, checkboxes and input that had travelled to the backend with the
very event that triggered the navigation.

The state was never lost: factory( ) applies the model delta and
prepare_app_stack( ) saves the caller under a NEW draft id. Only its history
entry was stale - it still carried the draft of the previous render, and
that is what Server.onHashChange restores.

factory_stack_call now hands the frontend the calling app's class and that
fresh draft (nav_app_call_prev_app / _id, first hop of a request only, so a
chain A -> B -> C keeps A's entry), and View1._repointCallerEntry
replaceHashes the caller's entry onto it before pushing the called app's
route - adopting currentDraftId first so the write stays our own echo and
does not fire a restore roundtrip. FRESH mode is untouched: its routes carry
no draft and restart the app by design.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VmtGFh7jMEDD1EBCNGmao5