### PR TITLE
Add SMART_VARIANT_INIT action for sap.ui.comp variant management

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -53,42 +53,6 @@ sap.ui.define(
     const SMART_VARIANT_INIT_TRIES = 50;
     const SMART_VARIANT_INIT_DELAY = 100;
 
-    // TEMPORARY diagnostic logging for the smart-variant handshake. Set back to
-    // false (or drop the sviLog calls) before this branch is merged - it is here
-    // to trace one live run in a system that has sap.ui.comp, which no test can
-    // reproduce offline.
-    const SMART_VARIANT_INIT_DEBUG = true;
-    function sviLog(...args) {
-      if (SMART_VARIANT_INIT_DEBUG) console.log("[SVI]", ...args);
-    }
-    function sviState(oSVM, when) {
-      if (!SMART_VARIANT_INIT_DEBUG) return;
-      try {
-        sviLog(when, {
-          perso: String(oSVM._oPersoControl),
-          isInitialized: oSVM._bIsInitialized,
-          isPageVariant: oSVM.isPageVariant ? oSVM.isPageVariant() : "n/a",
-          variants: Object.keys(oSVM._mVariants || {}).length,
-          items: oSVM.getVariantItems ? oSVM.getVariantItems().length : "n/a",
-          persistencyPromise: !!(
-            oSVM.oModel &&
-            oSVM.oModel.getPersistencyPromise &&
-            oSVM.oModel.getPersistencyPromise()
-          ),
-          controlPromise: !!oSVM._oControlPromise,
-          metadataPromise: !!oSVM._oMetadataPromise,
-          wrappers: (oSVM._aPersonalizableControls || []).map((w) => [
-            w.control &&
-              (w.control.getId ? w.control.getId() : String(w.control)),
-            w.type,
-            !!w.bInitialized,
-          ]),
-        });
-      } catch (e) {
-        sviLog(when, "state dump failed", e && e.message);
-      }
-    }
-
     // ------------------------------------------------------------------
     // Launchpad helpers
     // ------------------------------------------------------------------
@@ -820,17 +784,11 @@ sap.ui.define(
     function evSmartVariantInit(oController, args) {
       const [, svmId, controlId] = args;
       let tries = 0;
-      sviLog("action called", { svmId, controlId });
       const run = () => {
         const oSVM = ViewSlots.resolveById(svmId);
         const control = controlId ? ViewSlots.resolveById(controlId) : null;
         if (!oSVM || (controlId && !control)) {
           // the view may still be building - wait for both controls to exist
-          sviLog("waiting for controls", {
-            attempt: tries,
-            svm: !!oSVM,
-            control: !!control,
-          });
           if (tries++ < SMART_VARIANT_INIT_TRIES) {
             setTimeout(run, SMART_VARIANT_INIT_DELAY);
             return;
@@ -872,26 +830,16 @@ sap.ui.define(
         // addPersonalizableControl() returns early for isPageVariant() and only
         // the single-control case reaches setPersControler() - which is exactly
         // why a controller-less app ends up with no anchor and no promise.
-        sviState(oSVM, "before anchor");
         if (oSVM._oPersoControl) {
-          sviLog("anchor already set by the runtime");
+          // a runtime that anchors the control itself is left alone
         } else if (typeof oSVM.setPersControler === "function") {
           oSVM.setPersControler(target);
-          sviLog(
-            "setPersControler called with",
-            target.getId ? target.getId() : target,
-          );
         } else {
           // older runtimes without the setter: the field alone still carries
           // the write path (saving), which is better than nothing
           oSVM._oPersoControl = target;
-          sviLog("no setPersControler - assigned the field instead");
         }
         ensureInitialised(oSVM, target, 0);
-        // snapshots after the handshake, to see what the load flow produced
-        setTimeout(() => sviState(oSVM, "t+1s"), 1000);
-        setTimeout(() => sviState(oSVM, "t+3s"), 3000);
-        setTimeout(() => sviState(oSVM, "t+8s"), 8000);
       };
 
       // With the anchor in place the load flow still has to be started once.
@@ -906,7 +854,6 @@ sap.ui.define(
           ? oSVM._getControlWrapper(target)
           : null;
         if (!wrapper) {
-          sviLog("no wrapper yet", { attempt });
           if (attempt < SMART_VARIANT_INIT_TRIES) {
             setTimeout(
               () => ensureInitialised(oSVM, target, attempt + 1),
@@ -915,20 +862,8 @@ sap.ui.define(
           }
           return;
         }
-        if (wrapper.bInitialized) {
-          sviLog("wrapper already initialised - not calling initialise again");
-          return;
-        }
-        sviLog("calling initialise", {
-          attempt,
-          control: target.getId ? target.getId() : target,
-        });
-        try {
-          oSVM.initialise(() => sviLog("initialise callback fired"), target);
-        } catch (e) {
-          sviLog("initialise threw", e && e.message);
-        }
-        sviState(oSVM, "right after initialise");
+        if (wrapper.bInitialized) return;
+        oSVM.initialise(() => {}, target);
       }
 
       run();

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -46,6 +46,13 @@ sap.ui.define(
     // instant jump. Shared by every scroll path in evScrollTo.
     const SMOOTH_SCROLL_MS = 300;
 
+    // SMART_VARIANT_INIT waits for the smart controls to register themselves at
+    // the SmartVariantManagement - that happens once their OData metadata has
+    // loaded, so the wait has to survive a slow service (5s) but must not run
+    // forever when no smart control is there at all.
+    const SMART_VARIANT_INIT_TRIES = 50;
+    const SMART_VARIANT_INIT_DELAY = 100;
+
     // ------------------------------------------------------------------
     // Launchpad helpers
     // ------------------------------------------------------------------
@@ -759,6 +766,57 @@ sap.ui.define(
       view.bindElement(`${path}/${args[2]}`);
     }
 
+    // SMART_VARIANT_INIT: run the handshake a controller would do for
+    // sap.ui.comp variant management - oSVM.initialise(fnCallback, oPersoControl).
+    // Without it the control keeps _oPersoControl null, which makes saving a view
+    // throw inside sap.ui.fl (getAppComponentForControl(null).getId()) and stops
+    // stored variants from being loaded at all.
+    // args = [_, svmId, controlId?]: the SmartVariantManagement's id and,
+    // optionally, the personalizable control to anchor it to (default: the first
+    // control that registered itself). Both are resolved through the slot lookup,
+    // and the callback is a no-op - nothing app-supplied is evaluated.
+    // The smart controls register at the SmartVariantManagement asynchronously,
+    // once their OData metadata has arrived, so the call waits for a registration
+    // instead of firing into an empty list ("initialise on an unknown control").
+    function evSmartVariantInit(oController, args) {
+      const [, svmId, controlId] = args;
+      const oSVM = ViewSlots.resolveById(svmId);
+      if (!oSVM || typeof oSVM.initialise !== "function") {
+        Lib.logError(
+          `SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'`,
+        );
+        return;
+      }
+      let tries = 0;
+      const run = () => {
+        if (Lib.isDestroyed(oSVM)) return;
+        const registered = oSVM.getPersonalizableControls
+          ? oSVM.getPersonalizableControls()
+          : [];
+        if (!registered.length) {
+          if (tries++ < SMART_VARIANT_INIT_TRIES) {
+            setTimeout(run, SMART_VARIANT_INIT_DELAY);
+            return;
+          }
+          Lib.logError(
+            `SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'`,
+          );
+          return;
+        }
+        const control = controlId
+          ? ViewSlots.resolveById(controlId)
+          : ViewSlots.resolveById(registered[0].getControl());
+        if (!control) {
+          Lib.logError(
+            `SMART_VARIANT_INIT: personalizable control '${controlId}' not found`,
+          );
+          return;
+        }
+        oSVM.initialise(() => {}, control);
+      };
+      run();
+    }
+
     function evUrlHelper(oController, args) {
       const params = args[2] ?? {};
       const actions = {
@@ -1047,6 +1105,7 @@ sap.ui.define(
       Z2UI5: evZ2ui5Custom,
       WIZARD_SET_NEXT_STEP: evWizardSetNextStep,
       PLAY_AUDIO: evPlayAudio,
+      SMART_VARIANT_INIT: evSmartVariantInit,
       CONTROL_BY_ID: evControlCallById,
       CONTROL_GLOBAL: evControlCall,
       BINDING_CALL: evBindingCall,

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -826,15 +826,32 @@ sap.ui.define(
         }
         // The anchor - guarded, so a runtime that sets it itself is left alone.
         if (!oSVM._oPersoControl) oSVM._oPersoControl = target;
-        // Only initialise what nobody has initialised yet: the smart control
-        // does it for itself once registered, and a second call is an error.
+        ensureInitialised(oSVM, target, 0);
+      };
+
+      // With the anchor in place the load flow still has to be started once.
+      // The smart control does that itself when it registers - but only then,
+      // and it may already have tried (and aborted) before the anchor existed.
+      // So wait for the control's wrapper and initialise it if nobody has:
+      // a wrapper is required (initialise answers "unknown control" without
+      // one) and an initialised wrapper must be left alone ("already executed").
+      function ensureInitialised(oSVM, target, attempt) {
+        if (Lib.isDestroyed(oSVM)) return;
         const wrapper = oSVM._getControlWrapper
           ? oSVM._getControlWrapper(target)
           : null;
-        if (wrapper && !wrapper.bInitialized) {
-          oSVM.initialise(() => {}, target);
+        if (!wrapper) {
+          if (attempt < SMART_VARIANT_INIT_TRIES) {
+            setTimeout(
+              () => ensureInitialised(oSVM, target, attempt + 1),
+              SMART_VARIANT_INIT_DELAY,
+            );
+          }
+          return;
         }
-      };
+        if (!wrapper.bInitialized) oSVM.initialise(() => {}, target);
+      }
+
       run();
     }
 

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -53,6 +53,42 @@ sap.ui.define(
     const SMART_VARIANT_INIT_TRIES = 50;
     const SMART_VARIANT_INIT_DELAY = 100;
 
+    // TEMPORARY diagnostic logging for the smart-variant handshake. Set back to
+    // false (or drop the sviLog calls) before this branch is merged - it is here
+    // to trace one live run in a system that has sap.ui.comp, which no test can
+    // reproduce offline.
+    const SMART_VARIANT_INIT_DEBUG = true;
+    function sviLog(...args) {
+      if (SMART_VARIANT_INIT_DEBUG) console.log("[SVI]", ...args);
+    }
+    function sviState(oSVM, when) {
+      if (!SMART_VARIANT_INIT_DEBUG) return;
+      try {
+        sviLog(when, {
+          perso: String(oSVM._oPersoControl),
+          isInitialized: oSVM._bIsInitialized,
+          isPageVariant: oSVM.isPageVariant ? oSVM.isPageVariant() : "n/a",
+          variants: Object.keys(oSVM._mVariants || {}).length,
+          items: oSVM.getVariantItems ? oSVM.getVariantItems().length : "n/a",
+          persistencyPromise: !!(
+            oSVM.oModel &&
+            oSVM.oModel.getPersistencyPromise &&
+            oSVM.oModel.getPersistencyPromise()
+          ),
+          controlPromise: !!oSVM._oControlPromise,
+          metadataPromise: !!oSVM._oMetadataPromise,
+          wrappers: (oSVM._aPersonalizableControls || []).map((w) => [
+            w.control &&
+              (w.control.getId ? w.control.getId() : String(w.control)),
+            w.type,
+            !!w.bInitialized,
+          ]),
+        });
+      } catch (e) {
+        sviLog(when, "state dump failed", e && e.message);
+      }
+    }
+
     // ------------------------------------------------------------------
     // Launchpad helpers
     // ------------------------------------------------------------------
@@ -784,11 +820,17 @@ sap.ui.define(
     function evSmartVariantInit(oController, args) {
       const [, svmId, controlId] = args;
       let tries = 0;
+      sviLog("action called", { svmId, controlId });
       const run = () => {
         const oSVM = ViewSlots.resolveById(svmId);
         const control = controlId ? ViewSlots.resolveById(controlId) : null;
         if (!oSVM || (controlId && !control)) {
           // the view may still be building - wait for both controls to exist
+          sviLog("waiting for controls", {
+            attempt: tries,
+            svm: !!oSVM,
+            control: !!control,
+          });
           if (tries++ < SMART_VARIANT_INIT_TRIES) {
             setTimeout(run, SMART_VARIANT_INIT_DELAY);
             return;
@@ -825,8 +867,18 @@ sap.ui.define(
           if (!target) return;
         }
         // The anchor - guarded, so a runtime that sets it itself is left alone.
-        if (!oSVM._oPersoControl) oSVM._oPersoControl = target;
+        sviState(oSVM, "before anchor");
+        if (!oSVM._oPersoControl) {
+          oSVM._oPersoControl = target;
+          sviLog("anchor set to", target.getId ? target.getId() : target);
+        } else {
+          sviLog("anchor already set by the runtime");
+        }
         ensureInitialised(oSVM, target, 0);
+        // snapshots after the handshake, to see what the load flow produced
+        setTimeout(() => sviState(oSVM, "t+1s"), 1000);
+        setTimeout(() => sviState(oSVM, "t+3s"), 3000);
+        setTimeout(() => sviState(oSVM, "t+8s"), 8000);
       };
 
       // With the anchor in place the load flow still has to be started once.
@@ -841,6 +893,7 @@ sap.ui.define(
           ? oSVM._getControlWrapper(target)
           : null;
         if (!wrapper) {
+          sviLog("no wrapper yet", { attempt });
           if (attempt < SMART_VARIANT_INIT_TRIES) {
             setTimeout(
               () => ensureInitialised(oSVM, target, attempt + 1),
@@ -849,7 +902,20 @@ sap.ui.define(
           }
           return;
         }
-        if (!wrapper.bInitialized) oSVM.initialise(() => {}, target);
+        if (wrapper.bInitialized) {
+          sviLog("wrapper already initialised - not calling initialise again");
+          return;
+        }
+        sviLog("calling initialise", {
+          attempt,
+          control: target.getId ? target.getId() : target,
+        });
+        try {
+          oSVM.initialise(() => sviLog("initialise callback fired"), target);
+        } catch (e) {
+          sviLog("initialise threw", e && e.message);
+        }
+        sviState(oSVM, "right after initialise");
       }
 
       run();

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -813,6 +813,13 @@ sap.ui.define(
           return;
         }
         oSVM.initialise(() => {}, control);
+        // The documented call is the one above - but measured against SAPUI5
+        // 1.150 it leaves the control's own _oPersoControl untouched (the layer
+        // moved behind a SmartVariantManagementMediator), and that field is
+        // exactly what _newVariant hands to sap.ui.fl when a view is saved.
+        // Assigning it is the only path that makes saving work; it is guarded,
+        // so a version whose initialise() does set it is left alone.
+        if (!oSVM._oPersoControl) oSVM._oPersoControl = control;
       };
       run();
     }

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -866,13 +866,26 @@ sap.ui.define(
           target = ViewSlots.resolveById(registered[0].getControl());
           if (!target) return;
         }
-        // The anchor - guarded, so a runtime that sets it itself is left alone.
+        // The anchor. setPersControler() is sap.ui.comp's own setter and does
+        // more than assign the field: it also creates the control promise that
+        // initialise() insists on. A page variant never gets that call -
+        // addPersonalizableControl() returns early for isPageVariant() and only
+        // the single-control case reaches setPersControler() - which is exactly
+        // why a controller-less app ends up with no anchor and no promise.
         sviState(oSVM, "before anchor");
-        if (!oSVM._oPersoControl) {
-          oSVM._oPersoControl = target;
-          sviLog("anchor set to", target.getId ? target.getId() : target);
-        } else {
+        if (oSVM._oPersoControl) {
           sviLog("anchor already set by the runtime");
+        } else if (typeof oSVM.setPersControler === "function") {
+          oSVM.setPersControler(target);
+          sviLog(
+            "setPersControler called with",
+            target.getId ? target.getId() : target,
+          );
+        } else {
+          // older runtimes without the setter: the field alone still carries
+          // the write path (saving), which is better than nothing
+          oSVM._oPersoControl = target;
+          sviLog("no setPersControler - assigned the field instead");
         }
         ensureInitialised(oSVM, target, 0);
         // snapshots after the handshake, to see what the load flow produced

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -812,14 +812,16 @@ sap.ui.define(
           );
           return;
         }
-        oSVM.initialise(() => {}, control);
-        // The documented call is the one above - but measured against SAPUI5
-        // 1.150 it leaves the control's own _oPersoControl untouched (the layer
-        // moved behind a SmartVariantManagementMediator), and that field is
-        // exactly what _newVariant hands to sap.ui.fl when a view is saved.
-        // Assigning it is the only path that makes saving work; it is guarded,
-        // so a version whose initialise() does set it is left alone.
+        // Anchor FIRST, then run the documented init flow. Measured against
+        // SAPUI5 1.150: initialise() does not set the control's own
+        // _oPersoControl (the work moved behind a SmartVariantManagementMediator),
+        // yet that field is what _newVariant hands to sap.ui.fl on save AND what
+        // the load flow needs to turn stored variants into view entries - so
+        // calling initialise() first meant loading with a null anchor and an
+        // empty variant list after every restart. The assignment is guarded, so
+        // a version whose initialise() does set it is left alone.
         if (!oSVM._oPersoControl) oSVM._oPersoControl = control;
+        oSVM.initialise(() => {}, control);
       };
       run();
     }

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -766,62 +766,74 @@ sap.ui.define(
       view.bindElement(`${path}/${args[2]}`);
     }
 
-    // SMART_VARIANT_INIT: run the handshake a controller would do for
-    // sap.ui.comp variant management - oSVM.initialise(fnCallback, oPersoControl).
-    // Without it the control keeps _oPersoControl null, which makes saving a view
-    // throw inside sap.ui.fl (getAppComponentForControl(null).getId()) and stops
-    // stored variants from being loaded at all.
-    // args = [_, svmId, controlId?]: the SmartVariantManagement's id and,
-    // optionally, the personalizable control to anchor it to (default: the first
-    // control that registered itself). Both are resolved through the slot lookup,
-    // and the callback is a no-op - nothing app-supplied is evaluated.
-    // The smart controls register at the SmartVariantManagement asynchronously,
-    // once their OData metadata has arrived, so the call waits for a registration
-    // instead of firing into an empty list ("initialise on an unknown control").
+    // SMART_VARIANT_INIT: place the anchor sap.ui.comp variant management needs
+    // and that only an app controller would otherwise set - the personalizable
+    // control the SmartVariantManagement works against (_oPersoControl).
+    // args = [_, svmId, controlId?].
+    //
+    // Why an anchor and not a call: SmartVariantManagement.initialise(fn, control)
+    // aborts its load flow when `_oPersoControl` is missing ("no personalizable
+    // component available") and marks that control's wrapper as done - a second
+    // call answers "already executed". The smart controls call initialise on
+    // themselves as soon as their metadata arrives, so an anchor set too late
+    // buys nothing: saving works (it only reads the field) but stored variants
+    // are never loaded. Hence: set the field as EARLY as the control exists, and
+    // leave the initialise call to the smart control, which then finds the
+    // anchor in place. Only when no control id was given does this wait for the
+    // registration list and call initialise itself (nobody else will).
     function evSmartVariantInit(oController, args) {
       const [, svmId, controlId] = args;
-      const oSVM = ViewSlots.resolveById(svmId);
-      if (!oSVM || typeof oSVM.initialise !== "function") {
-        Lib.logError(
-          `SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'`,
-        );
-        return;
-      }
       let tries = 0;
       const run = () => {
-        if (Lib.isDestroyed(oSVM)) return;
-        const registered = oSVM.getPersonalizableControls
-          ? oSVM.getPersonalizableControls()
-          : [];
-        if (!registered.length) {
+        const oSVM = ViewSlots.resolveById(svmId);
+        const control = controlId ? ViewSlots.resolveById(controlId) : null;
+        if (!oSVM || (controlId && !control)) {
+          // the view may still be building - wait for both controls to exist
           if (tries++ < SMART_VARIANT_INIT_TRIES) {
             setTimeout(run, SMART_VARIANT_INIT_DELAY);
             return;
           }
           Lib.logError(
-            `SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'`,
+            `SMART_VARIANT_INIT: '${controlId ? `${svmId}' / '${controlId}` : svmId}' not found`,
           );
           return;
         }
-        const control = controlId
-          ? ViewSlots.resolveById(controlId)
-          : ViewSlots.resolveById(registered[0].getControl());
-        if (!control) {
+        if (Lib.isDestroyed(oSVM) || typeof oSVM.initialise !== "function") {
           Lib.logError(
-            `SMART_VARIANT_INIT: personalizable control '${controlId}' not found`,
+            `SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'`,
           );
           return;
         }
-        // Anchor FIRST, then run the documented init flow. Measured against
-        // SAPUI5 1.150: initialise() does not set the control's own
-        // _oPersoControl (the work moved behind a SmartVariantManagementMediator),
-        // yet that field is what _newVariant hands to sap.ui.fl on save AND what
-        // the load flow needs to turn stored variants into view entries - so
-        // calling initialise() first meant loading with a null anchor and an
-        // empty variant list after every restart. The assignment is guarded, so
-        // a version whose initialise() does set it is left alone.
-        if (!oSVM._oPersoControl) oSVM._oPersoControl = control;
-        oSVM.initialise(() => {}, control);
+        let target = control;
+        if (!target) {
+          // no control named: fall back to the first one that registered, which
+          // means waiting for that registration (it follows the metadata load)
+          const registered = oSVM.getPersonalizableControls
+            ? oSVM.getPersonalizableControls()
+            : [];
+          if (!registered.length) {
+            if (tries++ < SMART_VARIANT_INIT_TRIES) {
+              setTimeout(run, SMART_VARIANT_INIT_DELAY);
+              return;
+            }
+            Lib.logError(
+              `SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'`,
+            );
+            return;
+          }
+          target = ViewSlots.resolveById(registered[0].getControl());
+          if (!target) return;
+        }
+        // The anchor - guarded, so a runtime that sets it itself is left alone.
+        if (!oSVM._oPersoControl) oSVM._oPersoControl = target;
+        // Only initialise what nobody has initialised yet: the smart control
+        // does it for itself once registered, and a second call is an error.
+        const wrapper = oSVM._getControlWrapper
+          ? oSVM._getControlWrapper(target)
+          : null;
+        if (wrapper && !wrapper.bInitialized) {
+          oSVM.initialise(() => {}, target);
+        }
       };
       run();
     }

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -676,6 +676,12 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     return {
       _oPersoControl: null,
       initialised,
+      // sap.ui.comp's own setter: anchors the control AND creates the control
+      // promise initialise() checks - a page variant never gets this call
+      setPersControler(control) {
+        this._oPersoControl = control;
+        this._oControlPromise = {};
+      },
       getPersonalizableControls: () =>
         registeredIds.map((id) => ({ getControl: () => id })),
       _getControlWrapper: (control) =>
@@ -689,6 +695,22 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
   test("anchors the perso control the app named", () => {
     const { FrontendAction, controls } = load();
     const oSVM = svm(["smartFilterBar"]);
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
+    // the setter, not the field: it also creates the control promise
+    expect(oSVM._oControlPromise).toBeTruthy();
+  });
+
+  test("falls back to the field when the runtime has no setter", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar"]);
+    delete oSVM.setPersControler;
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
     FrontendAction.execute(null, [

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -728,11 +728,12 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
   });
 
-  test("anchors before the control has registered", () => {
+  test("anchors before the control has registered, initialises after", async () => {
     const { FrontendAction, controls } = load();
     // nothing registered yet - the anchor still has to be placed, because the
     // control's own initialise() aborts without it and marks itself as done
-    const oSVM = svm([]);
+    const registered = [];
+    const oSVM = svm(registered);
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
     FrontendAction.execute(null, [
@@ -742,6 +743,11 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     ]);
     expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
     expect(oSVM.initialised).toEqual([]);
+    // the control registers a moment later (its metadata arrived) - the
+    // pending wait picks that up and starts the load flow nobody else would
+    registered.push("smartFilterBar");
+    await new Promise((r) => setTimeout(r, 250));
+    expect(oSVM.initialised).toEqual([{ id: "smartFilterBar" }]);
   });
 
   test("leaves a perso control the runtime set itself untouched", () => {

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -729,6 +729,23 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
   });
 
+  test("anchors the perso control before running the init flow", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar"]);
+    const seen = [];
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    oSVM.initialise = () => seen.push(String(oSVM._oPersoControl?.id));
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    // the load flow behind initialise() needs the anchor already in place -
+    // running it first left the variant list empty after every restart
+    expect(seen).toEqual(["smartFilterBar"]);
+  });
+
   test("leaves a perso control the control set itself untouched", () => {
     const { FrontendAction, controls } = load();
     const oSVM = svm(["smartFilterBar"]);

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -713,6 +713,39 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(errors).toEqual([]);
   });
 
+  test("assigns the perso control when initialise() leaves it unset", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar"]);
+    oSVM._oPersoControl = null;
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    // SAPUI5 1.150: initialise() is called but does not set the field, and
+    // _newVariant reads exactly that field when a view is saved
+    expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
+  });
+
+  test("leaves a perso control the control set itself untouched", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar"]);
+    const own = { id: "set-by-initialise" };
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    oSVM.initialise = () => {
+      oSVM._oPersoControl = own;
+    };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    expect(oSVM._oPersoControl).toBe(own);
+  });
+
   test("logs an error when the id is not a SmartVariantManagement", () => {
     const { FrontendAction, controls, errors } = load();
     controls.pageVariantId = { id: "not-a-variant-control" };

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -31,6 +31,7 @@ function load() {
     logError: (m) => errors.push(m),
     runCallbacks: () => {},
     whenRendered: (_control, _owner, fn) => fn(),
+    isDestroyed: (o) => Boolean(o?.isDestroyed && o.isDestroyed()),
   };
   const AppState = { state: { onBeforeEventFrontend: [] } };
   function Filter(path, operator, value1, value2) {
@@ -664,5 +665,59 @@ test.describe("BIND_ELEMENT", () => {
     const { FrontendAction, errors } = load();
     FrontendAction.execute(null, ["BIND_ELEMENT", "POPOVER", "5", "/T_PRODUCTS"]);
     expect(errors.some((e) => String(e).includes("no view for slot"))).toBe(true);
+  });
+});
+
+test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
+  // A SmartVariantManagement stub: records the initialise() handshake and
+  // reports the controls that have registered themselves so far.
+  function svm(registeredIds) {
+    const initialised = [];
+    return {
+      initialised,
+      getPersonalizableControls: () =>
+        registeredIds.map((id) => ({ getControl: () => id })),
+      initialise: (fn, control) => initialised.push(control),
+    };
+  }
+
+  test("initialises the page variant with the given personalizable control", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar", "smartTable"]);
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    expect(oSVM.initialised).toEqual([{ id: "smartFilterBar" }]);
+  });
+
+  test("falls back to the first control that registered itself", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartTable"]);
+    controls.pageVariantId = oSVM;
+    controls.smartTable = { id: "smartTable" };
+    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
+    expect(oSVM.initialised).toEqual([{ id: "smartTable" }]);
+  });
+
+  test("waits instead of initialising on an empty registration list", () => {
+    const { FrontendAction, controls, errors } = load();
+    const oSVM = svm([]);
+    controls.pageVariantId = oSVM;
+    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
+    // still pending: nothing initialised, nothing logged as an error yet
+    expect(oSVM.initialised).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test("logs an error when the id is not a SmartVariantManagement", () => {
+    const { FrontendAction, controls, errors } = load();
+    controls.pageVariantId = { id: "not-a-variant-control" };
+    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("no SmartVariantManagement");
   });
 });

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -669,21 +669,39 @@ test.describe("BIND_ELEMENT", () => {
 });
 
 test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
-  // A SmartVariantManagement stub: records the initialise() handshake and
-  // reports the controls that have registered themselves so far.
-  function svm(registeredIds) {
+  // A SmartVariantManagement stub: records initialise() calls, reports the
+  // controls that registered so far and their wrappers' initialised state.
+  function svm(registeredIds, initialisedIds = []) {
     const initialised = [];
     return {
+      _oPersoControl: null,
       initialised,
       getPersonalizableControls: () =>
         registeredIds.map((id) => ({ getControl: () => id })),
+      _getControlWrapper: (control) =>
+        registeredIds.includes(control?.id)
+          ? { bInitialized: initialisedIds.includes(control.id) }
+          : null,
       initialise: (fn, control) => initialised.push(control),
     };
   }
 
-  test("initialises the page variant with the given personalizable control", () => {
+  test("anchors the perso control the app named", () => {
     const { FrontendAction, controls } = load();
-    const oSVM = svm(["smartFilterBar", "smartTable"]);
+    const oSVM = svm(["smartFilterBar"]);
+    controls.pageVariantId = oSVM;
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
+    expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
+  });
+
+  test("initialises a registered control that nobody initialised yet", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartFilterBar"]);
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
     FrontendAction.execute(null, [
@@ -694,29 +712,11 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(oSVM.initialised).toEqual([{ id: "smartFilterBar" }]);
   });
 
-  test("falls back to the first control that registered itself", () => {
+  test("does not re-initialise a control that already ran", () => {
     const { FrontendAction, controls } = load();
-    const oSVM = svm(["smartTable"]);
-    controls.pageVariantId = oSVM;
-    controls.smartTable = { id: "smartTable" };
-    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
-    expect(oSVM.initialised).toEqual([{ id: "smartTable" }]);
-  });
-
-  test("waits instead of initialising on an empty registration list", () => {
-    const { FrontendAction, controls, errors } = load();
-    const oSVM = svm([]);
-    controls.pageVariantId = oSVM;
-    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
-    // still pending: nothing initialised, nothing logged as an error yet
-    expect(oSVM.initialised).toEqual([]);
-    expect(errors).toEqual([]);
-  });
-
-  test("assigns the perso control when initialise() leaves it unset", () => {
-    const { FrontendAction, controls } = load();
-    const oSVM = svm(["smartFilterBar"]);
-    oSVM._oPersoControl = null;
+    // wrapper already initialised: sap.ui.comp answers a second call with
+    // "initialise on ... already executed" - the anchor is all that is left to do
+    const oSVM = svm(["smartFilterBar"], ["smartFilterBar"]);
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
     FrontendAction.execute(null, [
@@ -724,37 +724,33 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
       "pageVariantId",
       "smartFilterBar",
     ]);
-    // SAPUI5 1.150: initialise() is called but does not set the field, and
-    // _newVariant reads exactly that field when a view is saved
+    expect(oSVM.initialised).toEqual([]);
     expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
   });
 
-  test("anchors the perso control before running the init flow", () => {
+  test("anchors before the control has registered", () => {
     const { FrontendAction, controls } = load();
-    const oSVM = svm(["smartFilterBar"]);
-    const seen = [];
+    // nothing registered yet - the anchor still has to be placed, because the
+    // control's own initialise() aborts without it and marks itself as done
+    const oSVM = svm([]);
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
-    oSVM.initialise = () => seen.push(String(oSVM._oPersoControl?.id));
     FrontendAction.execute(null, [
       "SMART_VARIANT_INIT",
       "pageVariantId",
       "smartFilterBar",
     ]);
-    // the load flow behind initialise() needs the anchor already in place -
-    // running it first left the variant list empty after every restart
-    expect(seen).toEqual(["smartFilterBar"]);
+    expect(oSVM._oPersoControl).toEqual({ id: "smartFilterBar" });
+    expect(oSVM.initialised).toEqual([]);
   });
 
-  test("leaves a perso control the control set itself untouched", () => {
+  test("leaves a perso control the runtime set itself untouched", () => {
     const { FrontendAction, controls } = load();
     const oSVM = svm(["smartFilterBar"]);
-    const own = { id: "set-by-initialise" };
+    const own = { id: "set-by-runtime" };
+    oSVM._oPersoControl = own;
     controls.pageVariantId = oSVM;
     controls.smartFilterBar = { id: "smartFilterBar" };
-    oSVM.initialise = () => {
-      oSVM._oPersoControl = own;
-    };
     FrontendAction.execute(null, [
       "SMART_VARIANT_INIT",
       "pageVariantId",
@@ -763,10 +759,24 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(oSVM._oPersoControl).toBe(own);
   });
 
+  test("falls back to the first registered control when none is named", () => {
+    const { FrontendAction, controls } = load();
+    const oSVM = svm(["smartTable"]);
+    controls.pageVariantId = oSVM;
+    controls.smartTable = { id: "smartTable" };
+    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
+    expect(oSVM._oPersoControl).toEqual({ id: "smartTable" });
+  });
+
   test("logs an error when the id is not a SmartVariantManagement", () => {
     const { FrontendAction, controls, errors } = load();
     controls.pageVariantId = { id: "not-a-variant-control" };
-    FrontendAction.execute(null, ["SMART_VARIANT_INIT", "pageVariantId"]);
+    controls.smartFilterBar = { id: "smartFilterBar" };
+    FrontendAction.execute(null, [
+      "SMART_VARIANT_INIT",
+      "pageVariantId",
+      "smartFilterBar",
+    ]);
     expect(errors.length).toBe(1);
     expect(errors[0]).toContain("no SmartVariantManagement");
   });

--- a/node/tests/loadModule.js
+++ b/node/tests/loadModule.js
@@ -28,6 +28,13 @@ function loadModule(relPath, { deps = {}, sandbox = {} } = {}) {
       },
     },
     URL,
+    // Timers are browser globals the modules legitimately use (deferred
+    // retries, START_TIMER); a vm context has none of its own, so hand the
+    // host's in - otherwise those paths die with "setTimeout is not defined".
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
     ...sandbox,
   };
   if (!("window" in context)) context.window = context;

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -888,13 +888,26 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          target = ViewSlots.resolveById(registered[0].getControl());` && |\n| &&
              `          if (!target) return;` && |\n| &&
              `        }` && |\n| &&
-             `        // The anchor - guarded, so a runtime that sets it itself is left alone.` && |\n| &&
+             `        // The anchor. setPersControler() is sap.ui.comp's own setter and does` && |\n| &&
+             `        // more than assign the field: it also creates the control promise that` && |\n| &&
+             `        // initialise() insists on. A page variant never gets that call -` && |\n| &&
+             `        // addPersonalizableControl() returns early for isPageVariant() and only` && |\n| &&
+             `        // the single-control case reaches setPersControler() - which is exactly` && |\n| &&
+             `        // why a controller-less app ends up with no anchor and no promise.` && |\n| &&
              `        sviState(oSVM, "before anchor");` && |\n| &&
-             `        if (!oSVM._oPersoControl) {` && |\n| &&
-             `          oSVM._oPersoControl = target;` && |\n| &&
-             `          sviLog("anchor set to", target.getId ? target.getId() : target);` && |\n| &&
-             `        } else {` && |\n| &&
+             `        if (oSVM._oPersoControl) {` && |\n| &&
              `          sviLog("anchor already set by the runtime");` && |\n| &&
+             `        } else if (typeof oSVM.setPersControler === "function") {` && |\n| &&
+             `          oSVM.setPersControler(target);` && |\n| &&
+             `          sviLog(` && |\n| &&
+             `            "setPersControler called with",` && |\n| &&
+             `            target.getId ? target.getId() : target,` && |\n| &&
+             `          );` && |\n| &&
+             `        } else {` && |\n| &&
+             `          // older runtimes without the setter: the field alone still carries` && |\n| &&
+             `          // the write path (saving), which is better than nothing` && |\n| &&
+             `          oSVM._oPersoControl = target;` && |\n| &&
+             `          sviLog("no setPersControler - assigned the field instead");` && |\n| &&
              `        }` && |\n| &&
              `        ensureInitialised(oSVM, target, 0);` && |\n| &&
              `        // snapshots after the handshake, to see what the load flow produced` && |\n| &&
@@ -1206,7 +1219,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      SET_SIZE_LIMIT: evSetSizeLimit,` && |\n| &&
              `      HISTORY_BACK: evHistoryBack,` && |\n| &&
              `      NAV_TO_ROUTE: evNavToRoute,` && |\n| &&
-             `      CLIPBOARD_COPY: evClipboardCopy,` && |\n| &&
+             `      CLIPBOARD_COPY: evClipboardCopy,` && |\n|.
+    result = result &&
              `      CLIPBOARD_APP_STATE: evClipboardAppState,` && |\n| &&
              `      SET_ODATA_MODEL: evSetODataModel,` && |\n| &&
              `      STORE_DATA: evStoreData,` && |\n| &&
@@ -1219,8 +1233,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      POPUP_CLOSE: () => ViewSlots.destroy("POPUP"),` && |\n| &&
              `      POPOVER_CLOSE: () => ViewSlots.destroy("POPOVER"),` && |\n| &&
              `      BIND_ELEMENT: evBindElement,` && |\n| &&
-             `      URLHELPER: evUrlHelper,` && |\n|.
-    result = result &&
+             `      URLHELPER: evUrlHelper,` && |\n| &&
              `      IMAGE_EDITOR_POPUP_CLOSE: evImageEditorPopupClose,` && |\n| &&
              `      SET_TITLE: evSetTitle,` && |\n| &&
              `      SET_TITLE_LAUNCHPAD: evSetTitleLaunchpad,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -835,6 +835,13 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        oSVM.initialise(() => {}, control);` && |\n| &&
+             `        // The documented call is the one above - but measured against SAPUI5` && |\n| &&
+             `        // 1.150 it leaves the control's own _oPersoControl untouched (the layer` && |\n| &&
+             `        // moved behind a SmartVariantManagementMediator), and that field is` && |\n| &&
+             `        // exactly what _newVariant hands to sap.ui.fl when a view is saved.` && |\n| &&
+             `        // Assigning it is the only path that makes saving work; it is guarded,` && |\n| &&
+             `        // so a version whose initialise() does set it is left alone.` && |\n| &&
+             `        if (!oSVM._oPersoControl) oSVM._oPersoControl = control;` && |\n| &&
              `      };` && |\n| &&
              `      run();` && |\n| &&
              `    }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -787,63 +787,75 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    // SMART_VARIANT_INIT: run the handshake a controller would do for` && |\n| &&
-             `    // sap.ui.comp variant management - oSVM.initialise(fnCallback, oPersoControl).` && |\n| &&
-             `    // Without it the control keeps _oPersoControl null, which makes saving a view` && |\n| &&
-             `    // throw inside sap.ui.fl (getAppComponentForControl(null).getId()) and stops` && |\n| &&
-             `    // stored variants from being loaded at all.` && |\n| &&
-             `    // args = [_, svmId, controlId?]: the SmartVariantManagement's id and,` && |\n| &&
-             `    // optionally, the personalizable control to anchor it to (default: the first` && |\n| &&
-             `    // control that registered itself). Both are resolved through the slot lookup,` && |\n| &&
-             `    // and the callback is a no-op - nothing app-supplied is evaluated.` && |\n| &&
-             `    // The smart controls register at the SmartVariantManagement asynchronously,` && |\n| &&
-             `    // once their OData metadata has arrived, so the call waits for a registration` && |\n| &&
-             `    // instead of firing into an empty list ("initialise on an unknown control").` && |\n| &&
+             `    // SMART_VARIANT_INIT: place the anchor sap.ui.comp variant management needs` && |\n| &&
+             `    // and that only an app controller would otherwise set - the personalizable` && |\n| &&
+             `    // control the SmartVariantManagement works against (_oPersoControl).` && |\n| &&
+             `    // args = [_, svmId, controlId?].` && |\n| &&
+             `    //` && |\n| &&
+             `    // Why an anchor and not a call: SmartVariantManagement.initialise(fn, control)` && |\n| &&
+             `    // aborts its load flow when ``_oPersoControl`` is missing ("no personalizable` && |\n| &&
+             `    // component available") and marks that control's wrapper as done - a second` && |\n| &&
+             `    // call answers "already executed". The smart controls call initialise on` && |\n| &&
+             `    // themselves as soon as their metadata arrives, so an anchor set too late` && |\n| &&
+             `    // buys nothing: saving works (it only reads the field) but stored variants` && |\n| &&
+             `    // are never loaded. Hence: set the field as EARLY as the control exists, and` && |\n| &&
+             `    // leave the initialise call to the smart control, which then finds the` && |\n| &&
+             `    // anchor in place. Only when no control id was given does this wait for the` && |\n| &&
+             `    // registration list and call initialise itself (nobody else will).` && |\n| &&
              `    function evSmartVariantInit(oController, args) {` && |\n| &&
              `      const [, svmId, controlId] = args;` && |\n| &&
-             `      const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
-             `      if (!oSVM || typeof oSVM.initialise !== "function") {` && |\n| &&
-             `        Lib.logError(` && |\n| &&
-             `          ``SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
-             `        );` && |\n| &&
-             `        return;` && |\n| &&
-             `      }` && |\n| &&
              `      let tries = 0;` && |\n| &&
              `      const run = () => {` && |\n| &&
-             `        if (Lib.isDestroyed(oSVM)) return;` && |\n| &&
-             `        const registered = oSVM.getPersonalizableControls` && |\n| &&
-             `          ? oSVM.getPersonalizableControls()` && |\n| &&
-             `          : [];` && |\n| &&
-             `        if (!registered.length) {` && |\n| &&
+             `        const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
+             `        const control = controlId ? ViewSlots.resolveById(controlId) : null;` && |\n| &&
+             `        if (!oSVM || (controlId && !control)) {` && |\n| &&
+             `          // the view may still be building - wait for both controls to exist` && |\n| &&
              `          if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
              `            setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
              `            return;` && |\n| &&
-             `          }` && |\n|.
+             `          }` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``SMART_VARIANT_INIT: '${controlId ? ``${svmId}' / '${controlId}`` : svmId}' not found``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n|.
     result = result &&
+             `        if (Lib.isDestroyed(oSVM) || typeof oSVM.initialise !== "function") {` && |\n| &&
              `          Lib.logError(` && |\n| &&
-             `            ``SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'``,` && |\n| &&
+             `            ``SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
              `          );` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        const control = controlId` && |\n| &&
-             `          ? ViewSlots.resolveById(controlId)` && |\n| &&
-             `          : ViewSlots.resolveById(registered[0].getControl());` && |\n| &&
-             `        if (!control) {` && |\n| &&
-             `          Lib.logError(` && |\n| &&
-             `            ``SMART_VARIANT_INIT: personalizable control '${controlId}' not found``,` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
+             `        let target = control;` && |\n| &&
+             `        if (!target) {` && |\n| &&
+             `          // no control named: fall back to the first one that registered, which` && |\n| &&
+             `          // means waiting for that registration (it follows the metadata load)` && |\n| &&
+             `          const registered = oSVM.getPersonalizableControls` && |\n| &&
+             `            ? oSVM.getPersonalizableControls()` && |\n| &&
+             `            : [];` && |\n| &&
+             `          if (!registered.length) {` && |\n| &&
+             `            if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
+             `              setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
+             `              return;` && |\n| &&
+             `            }` && |\n| &&
+             `            Lib.logError(` && |\n| &&
+             `              ``SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'``,` && |\n| &&
+             `            );` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n| &&
+             `          target = ViewSlots.resolveById(registered[0].getControl());` && |\n| &&
+             `          if (!target) return;` && |\n| &&
              `        }` && |\n| &&
-             `        // Anchor FIRST, then run the documented init flow. Measured against` && |\n| &&
-             `        // SAPUI5 1.150: initialise() does not set the control's own` && |\n| &&
-             `        // _oPersoControl (the work moved behind a SmartVariantManagementMediator),` && |\n| &&
-             `        // yet that field is what _newVariant hands to sap.ui.fl on save AND what` && |\n| &&
-             `        // the load flow needs to turn stored variants into view entries - so` && |\n| &&
-             `        // calling initialise() first meant loading with a null anchor and an` && |\n| &&
-             `        // empty variant list after every restart. The assignment is guarded, so` && |\n| &&
-             `        // a version whose initialise() does set it is left alone.` && |\n| &&
-             `        if (!oSVM._oPersoControl) oSVM._oPersoControl = control;` && |\n| &&
-             `        oSVM.initialise(() => {}, control);` && |\n| &&
+             `        // The anchor - guarded, so a runtime that sets it itself is left alone.` && |\n| &&
+             `        if (!oSVM._oPersoControl) oSVM._oPersoControl = target;` && |\n| &&
+             `        // Only initialise what nobody has initialised yet: the smart control` && |\n| &&
+             `        // does it for itself once registered, and a second call is an error.` && |\n| &&
+             `        const wrapper = oSVM._getControlWrapper` && |\n| &&
+             `          ? oSVM._getControlWrapper(target)` && |\n| &&
+             `          : null;` && |\n| &&
+             `        if (wrapper && !wrapper.bInitialized) {` && |\n| &&
+             `          oSVM.initialise(() => {}, target);` && |\n| &&
+             `        }` && |\n| &&
              `      };` && |\n| &&
              `      run();` && |\n| &&
              `    }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -73,42 +73,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    const SMART_VARIANT_INIT_TRIES = 50;` && |\n| &&
              `    const SMART_VARIANT_INIT_DELAY = 100;` && |\n| &&
              `` && |\n| &&
-             `    // TEMPORARY diagnostic logging for the smart-variant handshake. Set back to` && |\n| &&
-             `    // false (or drop the sviLog calls) before this branch is merged - it is here` && |\n| &&
-             `    // to trace one live run in a system that has sap.ui.comp, which no test can` && |\n| &&
-             `    // reproduce offline.` && |\n| &&
-             `    const SMART_VARIANT_INIT_DEBUG = true;` && |\n| &&
-             `    function sviLog(...args) {` && |\n| &&
-             `      if (SMART_VARIANT_INIT_DEBUG) console.log("[SVI]", ...args);` && |\n| &&
-             `    }` && |\n| &&
-             `    function sviState(oSVM, when) {` && |\n| &&
-             `      if (!SMART_VARIANT_INIT_DEBUG) return;` && |\n| &&
-             `      try {` && |\n| &&
-             `        sviLog(when, {` && |\n| &&
-             `          perso: String(oSVM._oPersoControl),` && |\n| &&
-             `          isInitialized: oSVM._bIsInitialized,` && |\n| &&
-             `          isPageVariant: oSVM.isPageVariant ? oSVM.isPageVariant() : "n/a",` && |\n| &&
-             `          variants: Object.keys(oSVM._mVariants || {}).length,` && |\n| &&
-             `          items: oSVM.getVariantItems ? oSVM.getVariantItems().length : "n/a",` && |\n| &&
-             `          persistencyPromise: !!(` && |\n| &&
-             `            oSVM.oModel &&` && |\n| &&
-             `            oSVM.oModel.getPersistencyPromise &&` && |\n| &&
-             `            oSVM.oModel.getPersistencyPromise()` && |\n| &&
-             `          ),` && |\n| &&
-             `          controlPromise: !!oSVM._oControlPromise,` && |\n| &&
-             `          metadataPromise: !!oSVM._oMetadataPromise,` && |\n| &&
-             `          wrappers: (oSVM._aPersonalizableControls || []).map((w) => [` && |\n| &&
-             `            w.control &&` && |\n| &&
-             `              (w.control.getId ? w.control.getId() : String(w.control)),` && |\n| &&
-             `            w.type,` && |\n| &&
-             `            !!w.bInitialized,` && |\n| &&
-             `          ]),` && |\n| &&
-             `        });` && |\n| &&
-             `      } catch (e) {` && |\n| &&
-             `        sviLog(when, "state dump failed", e && e.message);` && |\n| &&
-             `      }` && |\n| &&
-             `    }` && |\n| &&
-             `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `    // Launchpad helpers` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -417,8 +381,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // the classic demo kit controller pattern` && |\n| &&
              `    // oList.getBinding("items").filter([new Filter(...)]). Same safety` && |\n| &&
              `    // boundary as CONTROL_BY_ID: only whitelisted binding methods,` && |\n| &&
-             `    // only whitelisted filter operators, everything built from data` && |\n|.
-    result = result &&
+             `    // only whitelisted filter operators, everything built from data` && |\n| &&
              `    // (path/operator/values), never from code strings.` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
@@ -454,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // of groups, each group an array of [path, operator, value1, value2?]` && |\n| &&
              `    // rows - OR inside a group, AND across groups (the FacetFilter /` && |\n| &&
              `    // ViewSettingsDialog multi-facet shape). Data only: paths, whitelisted` && |\n| &&
-             `    // operators and values - never code. An empty groups array clears.` && |\n| &&
+             `    // operators and values - never code. An empty groups array clears.` && |\n|.
+    result = result &&
              `    function buildFilterGroups(binding, json) {` && |\n| &&
              `      let groups;` && |\n| &&
              `      try {` && |\n| &&
@@ -818,8 +782,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const path = String(args[3] ?? "").replace(/[{}]/g, "");` && |\n| &&
              `      if (!path) {` && |\n| &&
              `        Lib.logError("BIND_ELEMENT: empty binding path");` && |\n| &&
-             `        return;` && |\n|.
-    result = result &&
+             `        return;` && |\n| &&
              `      }` && |\n| &&
              `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
@@ -842,17 +805,11 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    function evSmartVariantInit(oController, args) {` && |\n| &&
              `      const [, svmId, controlId] = args;` && |\n| &&
              `      let tries = 0;` && |\n| &&
-             `      sviLog("action called", { svmId, controlId });` && |\n| &&
              `      const run = () => {` && |\n| &&
              `        const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
              `        const control = controlId ? ViewSlots.resolveById(controlId) : null;` && |\n| &&
              `        if (!oSVM || (controlId && !control)) {` && |\n| &&
              `          // the view may still be building - wait for both controls to exist` && |\n| &&
-             `          sviLog("waiting for controls", {` && |\n| &&
-             `            attempt: tries,` && |\n| &&
-             `            svm: !!oSVM,` && |\n| &&
-             `            control: !!control,` && |\n| &&
-             `          });` && |\n| &&
              `          if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
              `            setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
              `            return;` && |\n| &&
@@ -861,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            ``SMART_VARIANT_INIT: '${controlId ? ``${svmId}' / '${controlId}`` : svmId}' not found``,` && |\n| &&
              `          );` && |\n| &&
              `          return;` && |\n| &&
-             `        }` && |\n| &&
+             `        }` && |\n|.
+    result = result &&
              `        if (Lib.isDestroyed(oSVM) || typeof oSVM.initialise !== "function") {` && |\n| &&
              `          Lib.logError(` && |\n| &&
              `            ``SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
@@ -894,26 +852,16 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        // addPersonalizableControl() returns early for isPageVariant() and only` && |\n| &&
              `        // the single-control case reaches setPersControler() - which is exactly` && |\n| &&
              `        // why a controller-less app ends up with no anchor and no promise.` && |\n| &&
-             `        sviState(oSVM, "before anchor");` && |\n| &&
              `        if (oSVM._oPersoControl) {` && |\n| &&
-             `          sviLog("anchor already set by the runtime");` && |\n| &&
+             `          // a runtime that anchors the control itself is left alone` && |\n| &&
              `        } else if (typeof oSVM.setPersControler === "function") {` && |\n| &&
              `          oSVM.setPersControler(target);` && |\n| &&
-             `          sviLog(` && |\n| &&
-             `            "setPersControler called with",` && |\n| &&
-             `            target.getId ? target.getId() : target,` && |\n| &&
-             `          );` && |\n| &&
              `        } else {` && |\n| &&
              `          // older runtimes without the setter: the field alone still carries` && |\n| &&
              `          // the write path (saving), which is better than nothing` && |\n| &&
              `          oSVM._oPersoControl = target;` && |\n| &&
-             `          sviLog("no setPersControler - assigned the field instead");` && |\n| &&
              `        }` && |\n| &&
              `        ensureInitialised(oSVM, target, 0);` && |\n| &&
-             `        // snapshots after the handshake, to see what the load flow produced` && |\n| &&
-             `        setTimeout(() => sviState(oSVM, "t+1s"), 1000);` && |\n| &&
-             `        setTimeout(() => sviState(oSVM, "t+3s"), 3000);` && |\n| &&
-             `        setTimeout(() => sviState(oSVM, "t+8s"), 8000);` && |\n| &&
              `      };` && |\n| &&
              `` && |\n| &&
              `      // With the anchor in place the load flow still has to be started once.` && |\n| &&
@@ -928,7 +876,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          ? oSVM._getControlWrapper(target)` && |\n| &&
              `          : null;` && |\n| &&
              `        if (!wrapper) {` && |\n| &&
-             `          sviLog("no wrapper yet", { attempt });` && |\n| &&
              `          if (attempt < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
              `            setTimeout(` && |\n| &&
              `              () => ensureInitialised(oSVM, target, attempt + 1),` && |\n| &&
@@ -937,20 +884,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          }` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        if (wrapper.bInitialized) {` && |\n| &&
-             `          sviLog("wrapper already initialised - not calling initialise again");` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        sviLog("calling initialise", {` && |\n| &&
-             `          attempt,` && |\n| &&
-             `          control: target.getId ? target.getId() : target,` && |\n| &&
-             `        });` && |\n| &&
-             `        try {` && |\n| &&
-             `          oSVM.initialise(() => sviLog("initialise callback fired"), target);` && |\n| &&
-             `        } catch (e) {` && |\n| &&
-             `          sviLog("initialise threw", e && e.message);` && |\n| &&
-             `        }` && |\n| &&
-             `        sviState(oSVM, "right after initialise");` && |\n| &&
+             `        if (wrapper.bInitialized) return;` && |\n| &&
+             `        oSVM.initialise(() => {}, target);` && |\n| &&
              `      }` && |\n| &&
              `` && |\n| &&
              `      run();` && |\n| &&
@@ -1219,8 +1154,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      SET_SIZE_LIMIT: evSetSizeLimit,` && |\n| &&
              `      HISTORY_BACK: evHistoryBack,` && |\n| &&
              `      NAV_TO_ROUTE: evNavToRoute,` && |\n| &&
-             `      CLIPBOARD_COPY: evClipboardCopy,` && |\n|.
-    result = result &&
+             `      CLIPBOARD_COPY: evClipboardCopy,` && |\n| &&
              `      CLIPBOARD_APP_STATE: evClipboardAppState,` && |\n| &&
              `      SET_ODATA_MODEL: evSetODataModel,` && |\n| &&
              `      STORE_DATA: evStoreData,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -66,6 +66,13 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // instant jump. Shared by every scroll path in evScrollTo.` && |\n| &&
              `    const SMOOTH_SCROLL_MS = 300;` && |\n| &&
              `` && |\n| &&
+             `    // SMART_VARIANT_INIT waits for the smart controls to register themselves at` && |\n| &&
+             `    // the SmartVariantManagement - that happens once their OData metadata has` && |\n| &&
+             `    // loaded, so the wait has to survive a slow service (5s) but must not run` && |\n| &&
+             `    // forever when no smart control is there at all.` && |\n| &&
+             `    const SMART_VARIANT_INIT_TRIES = 50;` && |\n| &&
+             `    const SMART_VARIANT_INIT_DELAY = 100;` && |\n| &&
+             `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `    // Launchpad helpers` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -410,15 +417,15 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // of groups, each group an array of [path, operator, value1, value2?]` && |\n| &&
              `    // rows - OR inside a group, AND across groups (the FacetFilter /` && |\n| &&
              `    // ViewSettingsDialog multi-facet shape). Data only: paths, whitelisted` && |\n| &&
-             `    // operators and values - never code. An empty groups array clears.` && |\n| &&
+             `    // operators and values - never code. An empty groups array clears.` && |\n|.
+    result = result &&
              `    function buildFilterGroups(binding, json) {` && |\n| &&
              `      let groups;` && |\n| &&
              `      try {` && |\n| &&
              `        groups = JSON.parse(json);` && |\n| &&
              `      } catch {` && |\n| &&
              `        Lib.logError("BINDING_CALL: malformed filter groups JSON");` && |\n| &&
-             `        return;` && |\n|.
-    result = result &&
+             `        return;` && |\n| &&
              `      }` && |\n| &&
              `      if (!Array.isArray(groups)) {` && |\n| &&
              `        Lib.logError("BINDING_CALL: filter groups must be an array");` && |\n| &&
@@ -780,6 +787,58 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // SMART_VARIANT_INIT: run the handshake a controller would do for` && |\n| &&
+             `    // sap.ui.comp variant management - oSVM.initialise(fnCallback, oPersoControl).` && |\n| &&
+             `    // Without it the control keeps _oPersoControl null, which makes saving a view` && |\n| &&
+             `    // throw inside sap.ui.fl (getAppComponentForControl(null).getId()) and stops` && |\n| &&
+             `    // stored variants from being loaded at all.` && |\n| &&
+             `    // args = [_, svmId, controlId?]: the SmartVariantManagement's id and,` && |\n| &&
+             `    // optionally, the personalizable control to anchor it to (default: the first` && |\n| &&
+             `    // control that registered itself). Both are resolved through the slot lookup,` && |\n| &&
+             `    // and the callback is a no-op - nothing app-supplied is evaluated.` && |\n| &&
+             `    // The smart controls register at the SmartVariantManagement asynchronously,` && |\n| &&
+             `    // once their OData metadata has arrived, so the call waits for a registration` && |\n| &&
+             `    // instead of firing into an empty list ("initialise on an unknown control").` && |\n| &&
+             `    function evSmartVariantInit(oController, args) {` && |\n| &&
+             `      const [, svmId, controlId] = args;` && |\n| &&
+             `      const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
+             `      if (!oSVM || typeof oSVM.initialise !== "function") {` && |\n| &&
+             `        Lib.logError(` && |\n| &&
+             `          ``SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
+             `        );` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      let tries = 0;` && |\n| &&
+             `      const run = () => {` && |\n| &&
+             `        if (Lib.isDestroyed(oSVM)) return;` && |\n| &&
+             `        const registered = oSVM.getPersonalizableControls` && |\n| &&
+             `          ? oSVM.getPersonalizableControls()` && |\n| &&
+             `          : [];` && |\n| &&
+             `        if (!registered.length) {` && |\n| &&
+             `          if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
+             `            setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n|.
+    result = result &&
+             `          Lib.logError(` && |\n| &&
+             `            ``SMART_VARIANT_INIT: no personalizable control registered at '${svmId}'``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        const control = controlId` && |\n| &&
+             `          ? ViewSlots.resolveById(controlId)` && |\n| &&
+             `          : ViewSlots.resolveById(registered[0].getControl());` && |\n| &&
+             `        if (!control) {` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``SMART_VARIANT_INIT: personalizable control '${controlId}' not found``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        oSVM.initialise(() => {}, control);` && |\n| &&
+             `      };` && |\n| &&
+             `      run();` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function evUrlHelper(oController, args) {` && |\n| &&
              `      const params = args[2] ?? {};` && |\n| &&
              `      const actions = {` && |\n| &&
@@ -818,8 +877,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const editor = ViewSlots.byId("POPUP", "imageEditor");` && |\n| &&
              `        if (editor) image = editor.getImagePngDataURL();` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n|.
-    result = result &&
+             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n| &&
              `      }` && |\n| &&
              `      ViewSlots.destroy("POPUP");` && |\n| &&
              `      oController.eB(["SAVE"], image);` && |\n| &&
@@ -1069,6 +1127,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      Z2UI5: evZ2ui5Custom,` && |\n| &&
              `      WIZARD_SET_NEXT_STEP: evWizardSetNextStep,` && |\n| &&
              `      PLAY_AUDIO: evPlayAudio,` && |\n| &&
+             `      SMART_VARIANT_INIT: evSmartVariantInit,` && |\n| &&
              `      CONTROL_BY_ID: evControlCallById,` && |\n| &&
              `      CONTROL_GLOBAL: evControlCall,` && |\n| &&
              `      BINDING_CALL: evBindingCall,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -848,15 +848,32 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        }` && |\n| &&
              `        // The anchor - guarded, so a runtime that sets it itself is left alone.` && |\n| &&
              `        if (!oSVM._oPersoControl) oSVM._oPersoControl = target;` && |\n| &&
-             `        // Only initialise what nobody has initialised yet: the smart control` && |\n| &&
-             `        // does it for itself once registered, and a second call is an error.` && |\n| &&
+             `        ensureInitialised(oSVM, target, 0);` && |\n| &&
+             `      };` && |\n| &&
+             `` && |\n| &&
+             `      // With the anchor in place the load flow still has to be started once.` && |\n| &&
+             `      // The smart control does that itself when it registers - but only then,` && |\n| &&
+             `      // and it may already have tried (and aborted) before the anchor existed.` && |\n| &&
+             `      // So wait for the control's wrapper and initialise it if nobody has:` && |\n| &&
+             `      // a wrapper is required (initialise answers "unknown control" without` && |\n| &&
+             `      // one) and an initialised wrapper must be left alone ("already executed").` && |\n| &&
+             `      function ensureInitialised(oSVM, target, attempt) {` && |\n| &&
+             `        if (Lib.isDestroyed(oSVM)) return;` && |\n| &&
              `        const wrapper = oSVM._getControlWrapper` && |\n| &&
              `          ? oSVM._getControlWrapper(target)` && |\n| &&
              `          : null;` && |\n| &&
-             `        if (wrapper && !wrapper.bInitialized) {` && |\n| &&
-             `          oSVM.initialise(() => {}, target);` && |\n| &&
+             `        if (!wrapper) {` && |\n| &&
+             `          if (attempt < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
+             `            setTimeout(` && |\n| &&
+             `              () => ensureInitialised(oSVM, target, attempt + 1),` && |\n| &&
+             `              SMART_VARIANT_INIT_DELAY,` && |\n| &&
+             `            );` && |\n| &&
+             `          }` && |\n| &&
+             `          return;` && |\n| &&
              `        }` && |\n| &&
-             `      };` && |\n| &&
+             `        if (!wrapper.bInitialized) oSVM.initialise(() => {}, target);` && |\n| &&
+             `      }` && |\n| &&
+             `` && |\n| &&
              `      run();` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -73,6 +73,42 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    const SMART_VARIANT_INIT_TRIES = 50;` && |\n| &&
              `    const SMART_VARIANT_INIT_DELAY = 100;` && |\n| &&
              `` && |\n| &&
+             `    // TEMPORARY diagnostic logging for the smart-variant handshake. Set back to` && |\n| &&
+             `    // false (or drop the sviLog calls) before this branch is merged - it is here` && |\n| &&
+             `    // to trace one live run in a system that has sap.ui.comp, which no test can` && |\n| &&
+             `    // reproduce offline.` && |\n| &&
+             `    const SMART_VARIANT_INIT_DEBUG = true;` && |\n| &&
+             `    function sviLog(...args) {` && |\n| &&
+             `      if (SMART_VARIANT_INIT_DEBUG) console.log("[SVI]", ...args);` && |\n| &&
+             `    }` && |\n| &&
+             `    function sviState(oSVM, when) {` && |\n| &&
+             `      if (!SMART_VARIANT_INIT_DEBUG) return;` && |\n| &&
+             `      try {` && |\n| &&
+             `        sviLog(when, {` && |\n| &&
+             `          perso: String(oSVM._oPersoControl),` && |\n| &&
+             `          isInitialized: oSVM._bIsInitialized,` && |\n| &&
+             `          isPageVariant: oSVM.isPageVariant ? oSVM.isPageVariant() : "n/a",` && |\n| &&
+             `          variants: Object.keys(oSVM._mVariants || {}).length,` && |\n| &&
+             `          items: oSVM.getVariantItems ? oSVM.getVariantItems().length : "n/a",` && |\n| &&
+             `          persistencyPromise: !!(` && |\n| &&
+             `            oSVM.oModel &&` && |\n| &&
+             `            oSVM.oModel.getPersistencyPromise &&` && |\n| &&
+             `            oSVM.oModel.getPersistencyPromise()` && |\n| &&
+             `          ),` && |\n| &&
+             `          controlPromise: !!oSVM._oControlPromise,` && |\n| &&
+             `          metadataPromise: !!oSVM._oMetadataPromise,` && |\n| &&
+             `          wrappers: (oSVM._aPersonalizableControls || []).map((w) => [` && |\n| &&
+             `            w.control &&` && |\n| &&
+             `              (w.control.getId ? w.control.getId() : String(w.control)),` && |\n| &&
+             `            w.type,` && |\n| &&
+             `            !!w.bInitialized,` && |\n| &&
+             `          ]),` && |\n| &&
+             `        });` && |\n| &&
+             `      } catch (e) {` && |\n| &&
+             `        sviLog(when, "state dump failed", e && e.message);` && |\n| &&
+             `      }` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `    // Launchpad helpers` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
@@ -381,7 +417,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // the classic demo kit controller pattern` && |\n| &&
              `    // oList.getBinding("items").filter([new Filter(...)]). Same safety` && |\n| &&
              `    // boundary as CONTROL_BY_ID: only whitelisted binding methods,` && |\n| &&
-             `    // only whitelisted filter operators, everything built from data` && |\n| &&
+             `    // only whitelisted filter operators, everything built from data` && |\n|.
+    result = result &&
              `    // (path/operator/values), never from code strings.` && |\n| &&
              `    // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
@@ -417,8 +454,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // of groups, each group an array of [path, operator, value1, value2?]` && |\n| &&
              `    // rows - OR inside a group, AND across groups (the FacetFilter /` && |\n| &&
              `    // ViewSettingsDialog multi-facet shape). Data only: paths, whitelisted` && |\n| &&
-             `    // operators and values - never code. An empty groups array clears.` && |\n|.
-    result = result &&
+             `    // operators and values - never code. An empty groups array clears.` && |\n| &&
              `    function buildFilterGroups(binding, json) {` && |\n| &&
              `      let groups;` && |\n| &&
              `      try {` && |\n| &&
@@ -782,7 +818,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const path = String(args[3] ?? "").replace(/[{}]/g, "");` && |\n| &&
              `      if (!path) {` && |\n| &&
              `        Lib.logError("BIND_ELEMENT: empty binding path");` && |\n| &&
-             `        return;` && |\n| &&
+             `        return;` && |\n|.
+    result = result &&
              `      }` && |\n| &&
              `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
@@ -805,11 +842,17 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    function evSmartVariantInit(oController, args) {` && |\n| &&
              `      const [, svmId, controlId] = args;` && |\n| &&
              `      let tries = 0;` && |\n| &&
+             `      sviLog("action called", { svmId, controlId });` && |\n| &&
              `      const run = () => {` && |\n| &&
              `        const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
              `        const control = controlId ? ViewSlots.resolveById(controlId) : null;` && |\n| &&
              `        if (!oSVM || (controlId && !control)) {` && |\n| &&
              `          // the view may still be building - wait for both controls to exist` && |\n| &&
+             `          sviLog("waiting for controls", {` && |\n| &&
+             `            attempt: tries,` && |\n| &&
+             `            svm: !!oSVM,` && |\n| &&
+             `            control: !!control,` && |\n| &&
+             `          });` && |\n| &&
              `          if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
              `            setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
              `            return;` && |\n| &&
@@ -818,8 +861,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            ``SMART_VARIANT_INIT: '${controlId ? ``${svmId}' / '${controlId}`` : svmId}' not found``,` && |\n| &&
              `          );` && |\n| &&
              `          return;` && |\n| &&
-             `        }` && |\n|.
-    result = result &&
+             `        }` && |\n| &&
              `        if (Lib.isDestroyed(oSVM) || typeof oSVM.initialise !== "function") {` && |\n| &&
              `          Lib.logError(` && |\n| &&
              `            ``SMART_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
@@ -847,8 +889,18 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          if (!target) return;` && |\n| &&
              `        }` && |\n| &&
              `        // The anchor - guarded, so a runtime that sets it itself is left alone.` && |\n| &&
-             `        if (!oSVM._oPersoControl) oSVM._oPersoControl = target;` && |\n| &&
+             `        sviState(oSVM, "before anchor");` && |\n| &&
+             `        if (!oSVM._oPersoControl) {` && |\n| &&
+             `          oSVM._oPersoControl = target;` && |\n| &&
+             `          sviLog("anchor set to", target.getId ? target.getId() : target);` && |\n| &&
+             `        } else {` && |\n| &&
+             `          sviLog("anchor already set by the runtime");` && |\n| &&
+             `        }` && |\n| &&
              `        ensureInitialised(oSVM, target, 0);` && |\n| &&
+             `        // snapshots after the handshake, to see what the load flow produced` && |\n| &&
+             `        setTimeout(() => sviState(oSVM, "t+1s"), 1000);` && |\n| &&
+             `        setTimeout(() => sviState(oSVM, "t+3s"), 3000);` && |\n| &&
+             `        setTimeout(() => sviState(oSVM, "t+8s"), 8000);` && |\n| &&
              `      };` && |\n| &&
              `` && |\n| &&
              `      // With the anchor in place the load flow still has to be started once.` && |\n| &&
@@ -863,6 +915,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          ? oSVM._getControlWrapper(target)` && |\n| &&
              `          : null;` && |\n| &&
              `        if (!wrapper) {` && |\n| &&
+             `          sviLog("no wrapper yet", { attempt });` && |\n| &&
              `          if (attempt < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
              `            setTimeout(` && |\n| &&
              `              () => ensureInitialised(oSVM, target, attempt + 1),` && |\n| &&
@@ -871,7 +924,20 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          }` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        if (!wrapper.bInitialized) oSVM.initialise(() => {}, target);` && |\n| &&
+             `        if (wrapper.bInitialized) {` && |\n| &&
+             `          sviLog("wrapper already initialised - not calling initialise again");` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        sviLog("calling initialise", {` && |\n| &&
+             `          attempt,` && |\n| &&
+             `          control: target.getId ? target.getId() : target,` && |\n| &&
+             `        });` && |\n| &&
+             `        try {` && |\n| &&
+             `          oSVM.initialise(() => sviLog("initialise callback fired"), target);` && |\n| &&
+             `        } catch (e) {` && |\n| &&
+             `          sviLog("initialise threw", e && e.message);` && |\n| &&
+             `        }` && |\n| &&
+             `        sviState(oSVM, "right after initialise");` && |\n| &&
              `      }` && |\n| &&
              `` && |\n| &&
              `      run();` && |\n| &&
@@ -1153,7 +1219,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      POPUP_CLOSE: () => ViewSlots.destroy("POPUP"),` && |\n| &&
              `      POPOVER_CLOSE: () => ViewSlots.destroy("POPOVER"),` && |\n| &&
              `      BIND_ELEMENT: evBindElement,` && |\n| &&
-             `      URLHELPER: evUrlHelper,` && |\n| &&
+             `      URLHELPER: evUrlHelper,` && |\n|.
+    result = result &&
              `      IMAGE_EDITOR_POPUP_CLOSE: evImageEditorPopupClose,` && |\n| &&
              `      SET_TITLE: evSetTitle,` && |\n| &&
              `      SET_TITLE_LAUNCHPAD: evSetTitleLaunchpad,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -834,14 +834,16 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          );` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        oSVM.initialise(() => {}, control);` && |\n| &&
-             `        // The documented call is the one above - but measured against SAPUI5` && |\n| &&
-             `        // 1.150 it leaves the control's own _oPersoControl untouched (the layer` && |\n| &&
-             `        // moved behind a SmartVariantManagementMediator), and that field is` && |\n| &&
-             `        // exactly what _newVariant hands to sap.ui.fl when a view is saved.` && |\n| &&
-             `        // Assigning it is the only path that makes saving work; it is guarded,` && |\n| &&
-             `        // so a version whose initialise() does set it is left alone.` && |\n| &&
+             `        // Anchor FIRST, then run the documented init flow. Measured against` && |\n| &&
+             `        // SAPUI5 1.150: initialise() does not set the control's own` && |\n| &&
+             `        // _oPersoControl (the work moved behind a SmartVariantManagementMediator),` && |\n| &&
+             `        // yet that field is what _newVariant hands to sap.ui.fl on save AND what` && |\n| &&
+             `        // the load flow needs to turn stored variants into view entries - so` && |\n| &&
+             `        // calling initialise() first meant loading with a null anchor and an` && |\n| &&
+             `        // empty variant list after every restart. The assignment is guarded, so` && |\n| &&
+             `        // a version whose initialise() does set it is left alone.` && |\n| &&
              `        if (!oSVM._oPersoControl) oSVM._oPersoControl = control;` && |\n| &&
+             `        oSVM.initialise(() => {}, control);` && |\n| &&
              `      };` && |\n| &&
              `      run();` && |\n| &&
              `    }` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -49,6 +49,7 @@ INTERFACE z2ui5_if_client
       control_global            TYPE string VALUE `CONTROL_GLOBAL`,
       binding_call              TYPE string VALUE `BINDING_CALL`,
       bind_element              TYPE string VALUE `BIND_ELEMENT`,
+      smart_variant_init        TYPE string VALUE `SMART_VARIANT_INIT`,
 
       "obsolet?
       image_editor_popup_close  TYPE string VALUE `IMAGE_EDITOR_POPUP_CLOSE`,
@@ -302,6 +303,15 @@ INTERFACE z2ui5_if_client
   "! cs_event-control_global - call a whitelisted method on a global object
   "! (MESSAGE_TOAST, MESSAGE_BOX, BUSY_INDICATOR, THEMING):
   "! t_arg = object, method, params.
+  "! cs_event-smart_variant_init - run the initialise( ) handshake sap.ui.comp
+  "! variant management needs (a controller would call
+  "! oSmartVariantManagement.initialise( fnCallback, oPersonalizableControl )).
+  "! Without it the control keeps no personalizable control, saving a view fails
+  "! inside sap.ui.fl and stored variants are never loaded:
+  "! t_arg = SmartVariantManagement id, personalizable control id (optional,
+  "! default: the first control that registered itself). The action waits for
+  "! that registration, which the smart controls do once their OData metadata
+  "! has loaded.
   "! cs_event-binding_call - apply a declarative filter/sorter to an
   "! aggregation binding, the client-side equivalent of the UI5 controller
   "! pattern getBinding('items').filter(...); the model data stays untouched:


### PR DESCRIPTION
# Description

Adds support for the `SMART_VARIANT_INIT` frontend action to initialize sap.ui.comp SmartVariantManagement controls in controller-less applications.

## What Changed

- **New Action**: `SMART_VARIANT_INIT` enables apps to set up the personalizable control anchor (`_oPersoControl`) that SmartVariantManagement requires for loading and saving variants
- **Implementation**: Added `evSmartVariantInit()` function that:
  - Sets the anchor early (before the smart control's own initialization attempt)
  - Falls back to the first registered control when no specific control ID is provided
  - Waits for control registration with configurable retry logic (50 tries × 100ms = 5s max)
  - Handles both modern runtimes (via `setPersControler()` setter) and older ones (direct field assignment)
  - Ensures the control's wrapper is initialized exactly once
- **Helper**: Added `Lib.isDestroyed()` utility to safely check if a control has been destroyed
- **Constants**: Added `SMART_VARIANT_INIT_TRIES` and `SMART_VARIANT_INIT_DELAY` for retry configuration
- **API**: Registered the action in the public interface (`z2ui5_if_client`)
- **Test Infrastructure**: Updated test module loader to provide timer globals (`setTimeout`, `clearTimeout`, etc.) needed by deferred retry logic

## Why This Matters

Without this action, controller-less apps cannot properly initialize SmartVariantManagement:
- Variants are never loaded from storage (saving still works but loading fails)
- The control has no personalizable component anchor, causing initialization to abort early
- The action bridges the gap between the framework's initialization flow and what sap.ui.comp expects

## How to Test

Run the new test suite:
```
npm test -- node/tests/frontendAction.spec.js --grep "SMART_VARIANT_INIT"
```

The tests verify:
- Anchor placement via setter and fallback
- Control initialization (single and deferred)
- Skipping re-initialization of already-initialized controls
- Fallback to first registered control when none is named
- Error handling for missing or invalid controls

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added (9 new test cases in `SMART_VARIANT_INIT` suite)
- [x] No manual edits under `src/00/` or `src/01/03/` (generated via ABAP class)
- [x] Public API in `src/02/` extended additively (new constant only)
- [x] Changes made via abapGit: no (direct file edits for JS/tests, ABAP class regenerated)

https://claude.ai/code/session_01D4nC8BzRbmm4q4gPZZrUrY