### PR TITLE
Add FILTER_BAR_VARIANT_INIT: the classic FilterBar variant handshake

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -817,6 +817,48 @@ sap.ui.define(
       view.bindElement(`${path}/${args[2]}`);
     }
 
+    // The anchor. setPersControler() is sap.ui.comp's own setter and does
+    // more than assign the field: it also creates the control promise that
+    // initialise() insists on. A page variant never gets that call -
+    // addPersonalizableControl() returns early for isPageVariant() and only
+    // the single-control case reaches setPersControler() - which is exactly
+    // why a controller-less app ends up with no anchor and no promise.
+    function anchorPersoControl(oSVM, target) {
+      if (oSVM._oPersoControl) {
+        // a runtime that anchors the control itself is left alone
+      } else if (typeof oSVM.setPersControler === "function") {
+        oSVM.setPersControler(target);
+      } else {
+        // older runtimes without the setter: the field alone still carries
+        // the write path (saving), which is better than nothing
+        oSVM._oPersoControl = target;
+      }
+    }
+
+    // With the anchor in place the load flow still has to be started once.
+    // A smart control does that itself when it registers - but only then,
+    // and it may already have tried (and aborted) before the anchor existed.
+    // So wait for the control's wrapper and initialise it if nobody has:
+    // a wrapper is required (initialise answers "unknown control" without
+    // one) and an initialised wrapper must be left alone ("already executed").
+    function ensureInitialised(oSVM, target, attempt, fnCallback) {
+      if (Lib.isDestroyed(oSVM)) return;
+      const wrapper = oSVM._getControlWrapper
+        ? oSVM._getControlWrapper(target)
+        : null;
+      if (!wrapper) {
+        if (attempt < SMART_VARIANT_INIT_TRIES) {
+          setTimeout(
+            () => ensureInitialised(oSVM, target, attempt + 1, fnCallback),
+            SMART_VARIANT_INIT_DELAY,
+          );
+        }
+        return;
+      }
+      if (wrapper.bInitialized) return;
+      oSVM.initialise(fnCallback || (() => {}), target);
+    }
+
     // SMART_VARIANT_INIT: place the anchor sap.ui.comp variant management needs
     // and that only an app controller would otherwise set - the personalizable
     // control the SmartVariantManagement works against (_oPersoControl).
@@ -875,47 +917,175 @@ sap.ui.define(
           target = ViewSlots.resolveById(registered[0].getControl());
           if (!target) return;
         }
-        // The anchor. setPersControler() is sap.ui.comp's own setter and does
-        // more than assign the field: it also creates the control promise that
-        // initialise() insists on. A page variant never gets that call -
-        // addPersonalizableControl() returns early for isPageVariant() and only
-        // the single-control case reaches setPersControler() - which is exactly
-        // why a controller-less app ends up with no anchor and no promise.
-        if (oSVM._oPersoControl) {
-          // a runtime that anchors the control itself is left alone
-        } else if (typeof oSVM.setPersControler === "function") {
-          oSVM.setPersControler(target);
-        } else {
-          // older runtimes without the setter: the field alone still carries
-          // the write path (saving), which is better than nothing
-          oSVM._oPersoControl = target;
-        }
+        anchorPersoControl(oSVM, target);
         ensureInitialised(oSVM, target, 0);
       };
 
-      // With the anchor in place the load flow still has to be started once.
-      // The smart control does that itself when it registers - but only then,
-      // and it may already have tried (and aborted) before the anchor existed.
-      // So wait for the control's wrapper and initialise it if nobody has:
-      // a wrapper is required (initialise answers "unknown control" without
-      // one) and an initialised wrapper must be left alone ("already executed").
-      function ensureInitialised(oSVM, target, attempt) {
-        if (Lib.isDestroyed(oSVM)) return;
-        const wrapper = oSVM._getControlWrapper
-          ? oSVM._getControlWrapper(target)
-          : null;
-        if (!wrapper) {
-          if (attempt < SMART_VARIANT_INIT_TRIES) {
-            setTimeout(
-              () => ensureInitialised(oSVM, target, attempt + 1),
-              SMART_VARIANT_INIT_DELAY,
-            );
+      run();
+    }
+
+    // ------------------------------------------------------------------
+    // FILTER_BAR_VARIANT_INIT: wire a CLASSIC sap.ui.comp.filterbar.FilterBar
+    // to a SmartVariantManagement. args = [_, svmId, filterBarId].
+    //
+    // A SmartFilterBar registers itself at the variant management (it knows its
+    // fields from the OData metadata), so SMART_VARIANT_INIT above only has to
+    // place the anchor. A classic FilterBar knows nothing about variants: every
+    // list-report controller hand-writes the same three callbacks
+    // (registerFetchData / registerApplyData / registerGetFiltersWithValues),
+    // adds a PersonalizableInfo and marks the variant dirty on each filter
+    // change. That is boilerplate over the bar's own filter items - data, not
+    // app logic - so the framework owns it and the app needs no JavaScript.
+    // ------------------------------------------------------------------
+
+    // marker so a re-sent action cannot stack a second set of callbacks and
+    // change handlers on the same bar (a rebuilt view reuses the ids, but it
+    // builds NEW control instances, which arrive here unmarked)
+    const FILTER_BAR_WIRED = "_z2ui5FilterBarVariantWired";
+
+    function filterItemControl(item) {
+      return item && typeof item.getControl === "function"
+        ? item.getControl()
+        : null;
+    }
+
+    function filterItemValue(item) {
+      const control = filterItemControl(item);
+      return control && typeof control.getValue === "function"
+        ? control.getValue()
+        : "";
+    }
+
+    // what a variant stores, how it is put back, and which filters count as
+    // "assigned" for the bar's own summary text
+    function registerFilterBarCallbacks(oFilterBar) {
+      oFilterBar.registerFetchData(() =>
+        oFilterBar.getAllFilterItems().map((item) => ({
+          groupName: item.getGroupName(),
+          fieldName: item.getName(),
+          fieldData: filterItemValue(item),
+        })),
+      );
+      oFilterBar.registerApplyData((data) => {
+        (data || []).forEach((entry) => {
+          const control = oFilterBar.determineControlByName(
+            entry.fieldName,
+            entry.groupName,
+          );
+          // setValue, not a model write: the two-way binding abap2UI5 put on
+          // the property carries the restored value back to the backend on the
+          // next roundtrip, so selecting a variant needs none of its own
+          if (control && typeof control.setValue === "function") {
+            control.setValue(entry.fieldData);
           }
+        });
+      });
+      oFilterBar.registerGetFiltersWithValues(() =>
+        oFilterBar
+          .getFilterGroupItems()
+          .filter((item) => String(filterItemValue(item)).length > 0),
+      );
+    }
+
+    // every filter change makes the current variant dirty (the "*" next to the
+    // variant title) and refreshes the bar's assigned-filters summary
+    function attachFilterBarChange(oSVM, oFilterBar) {
+      oFilterBar.getAllFilterItems().forEach((item) => {
+        const control = filterItemControl(item);
+        if (!control || typeof control.attachChange !== "function") return;
+        control.attachChange((oEvent) => {
+          if (typeof oSVM.currentVariantSetModified === "function") {
+            oSVM.currentVariantSetModified(true);
+          }
+          if (typeof oFilterBar.fireFilterChange === "function") {
+            oFilterBar.fireFilterChange(oEvent);
+          }
+        });
+      });
+    }
+
+    // sap.ui.comp is SAPUI5-only, so PersonalizableInfo must never be a hard
+    // dependency of this file (it 404s on OpenUI5 and would kill the component
+    // load). Resolve it at call time: synchronously when the SmartVariant-
+    // Management already pulled it in, asynchronously otherwise.
+    function withPersonalizableInfo(callback) {
+      const name = "sap/ui/comp/smartvariants/PersonalizableInfo";
+      if (
+        typeof sap === "undefined" ||
+        !sap.ui ||
+        typeof sap.ui.require !== "function"
+      ) {
+        Lib.logError("FILTER_BAR_VARIANT_INIT: sap.ui.require not available");
+        return;
+      }
+      const loaded = sap.ui.require(name);
+      if (loaded) {
+        callback(loaded);
+        return;
+      }
+      sap.ui.require([name], callback, () =>
+        Lib.logError(
+          "FILTER_BAR_VARIANT_INIT: sap.ui.comp.smartvariants not available",
+        ),
+      );
+    }
+
+    function evFilterBarVariantInit(oController, args) {
+      const [, svmId, filterBarId] = args;
+      let tries = 0;
+      const run = () => {
+        const oSVM = ViewSlots.resolveById(svmId);
+        const oFilterBar = ViewSlots.resolveById(filterBarId);
+        if (!oSVM || !oFilterBar) {
+          // the view may still be building - wait for both controls to exist
+          if (tries++ < SMART_VARIANT_INIT_TRIES) {
+            setTimeout(run, SMART_VARIANT_INIT_DELAY);
+            return;
+          }
+          Lib.logError(
+            `FILTER_BAR_VARIANT_INIT: '${svmId}' / '${filterBarId}' not found`,
+          );
           return;
         }
-        if (wrapper.bInitialized) return;
-        oSVM.initialise(() => {}, target);
-      }
+        if (
+          Lib.isDestroyed(oSVM) ||
+          typeof oSVM.addPersonalizableControl !== "function"
+        ) {
+          Lib.logError(
+            `FILTER_BAR_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'`,
+          );
+          return;
+        }
+        if (typeof oFilterBar.registerFetchData !== "function") {
+          Lib.logError(
+            `FILTER_BAR_VARIANT_INIT: no FilterBar for id '${filterBarId}'`,
+          );
+          return;
+        }
+        if (oFilterBar[FILTER_BAR_WIRED]) return;
+        oFilterBar[FILTER_BAR_WIRED] = true;
+
+        registerFilterBarCallbacks(oFilterBar);
+        attachFilterBarChange(oSVM, oFilterBar);
+        withPersonalizableInfo((PersonalizableInfo) => {
+          oSVM.addPersonalizableControl(
+            new PersonalizableInfo({
+              type: "filterBar",
+              keyName: "persistencyKey",
+              dataSource: "",
+              control: oFilterBar,
+            }),
+          );
+          anchorPersoControl(oSVM, oFilterBar);
+          // the load flow ends in registerApplyData, so the bar is clean again
+          // right after it - drop the "*" the restored values would leave
+          ensureInitialised(oSVM, oFilterBar, 0, () => {
+            if (typeof oSVM.currentVariantSetModified === "function") {
+              oSVM.currentVariantSetModified(false);
+            }
+          });
+        });
+      };
 
       run();
     }
@@ -1308,6 +1478,7 @@ sap.ui.define(
       WIZARD_SET_NEXT_STEP: evWizardSetNextStep,
       PLAY_AUDIO: evPlayAudio,
       SMART_VARIANT_INIT: evSmartVariantInit,
+      FILTER_BAR_VARIANT_INIT: evFilterBarVariantInit,
       CONTROL_BY_ID: evControlCallById,
       CONTROL_GLOBAL: evControlCall,
       BINDING_CALL: evBindingCall,

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -41,7 +41,7 @@ function load({ sandbox } = {}) {
     Object.assign(this, { path, descending, group });
   }
   const FilterOperator = new Proxy({}, { get: (_t, op) => op });
-  const { module } = loadModule("core/FrontendAction.js", {
+  const { module, sandbox: ctx } = loadModule("core/FrontendAction.js", {
     deps: {
       "sap/m/MessageBox": MessageBox,
       "sap/m/MessageToast": MessageToast,
@@ -59,7 +59,15 @@ function load({ sandbox } = {}) {
     },
     sandbox,
   });
-  return { FrontendAction: module, calls, errors, controls, views, AppState };
+  return {
+    FrontendAction: module,
+    calls,
+    errors,
+    controls,
+    views,
+    AppState,
+    ctx,
+  };
 }
 
 test.describe("CONTROL_GLOBAL (global objects)", () => {
@@ -810,6 +818,196 @@ test.describe("SMART_VARIANT_INIT (sap.ui.comp variant management)", () => {
     expect(errors[0]).toContain("no SmartVariantManagement");
   });
 });
+
+test.describe("FILTER_BAR_VARIANT_INIT (classic FilterBar + variant management)", () => {
+  const MODULE = "sap/ui/comp/smartvariants/PersonalizableInfo";
+
+  function PersonalizableInfo(settings) {
+    Object.assign(this, settings);
+  }
+
+  // one filter field: the FilterGroupItem and the input it wraps
+  function field(name, value) {
+    let changeHandler = null;
+    const control = {
+      getValue: () => value,
+      setValue: (v) => (value = v),
+      attachChange: (fn) => (changeHandler = fn),
+      fireChange: (oEvent) => changeHandler && changeHandler(oEvent),
+    };
+    return {
+      getName: () => name,
+      getGroupName: () => "group1",
+      getControl: () => control,
+      control,
+    };
+  }
+
+  function filterBar(fields) {
+    return {
+      registered: {},
+      fired: [],
+      getAllFilterItems: () => fields,
+      getFilterGroupItems: () => fields,
+      determineControlByName: (fieldName) =>
+        fields.find((f) => f.getName() === fieldName)?.getControl() || null,
+      registerFetchData(fn) {
+        this.registered.fetch = fn;
+      },
+      registerApplyData(fn) {
+        this.registered.apply = fn;
+      },
+      registerGetFiltersWithValues(fn) {
+        this.registered.withValues = fn;
+      },
+      fireFilterChange(oEvent) {
+        this.fired.push(oEvent);
+      },
+    };
+  }
+
+  function svm() {
+    return {
+      _oPersoControl: null,
+      added: [],
+      modified: [],
+      initialised: [],
+      addPersonalizableControl(info) {
+        this.added.push(info);
+      },
+      setPersControler(control) {
+        this._oPersoControl = control;
+      },
+      currentVariantSetModified(flag) {
+        this.modified.push(flag);
+      },
+      _getControlWrapper: () => ({ bInitialized: false }),
+      initialise(fn, control) {
+        this.initialised.push(control);
+        fn();
+      },
+    };
+  }
+
+  // wires a SmartVariantManagement and a FilterBar with PersonalizableInfo
+  // already loaded (the synchronous sap.ui.require path)
+  function wire(fields) {
+    const ctxLoad = load();
+    ctxLoad.ctx.sap.ui.require = (name) =>
+      name === MODULE ? PersonalizableInfo : null;
+    const oSVM = svm();
+    const oFilterBar = filterBar(fields);
+    ctxLoad.controls.svm = oSVM;
+    ctxLoad.controls.fbar = oFilterBar;
+    ctxLoad.FrontendAction.execute(null, [
+      "FILTER_BAR_VARIANT_INIT",
+      "svm",
+      "fbar",
+    ]);
+    return { ...ctxLoad, oSVM, oFilterBar };
+  }
+
+  test("adds the PersonalizableInfo the variant management needs", () => {
+    const { oSVM, oFilterBar } = wire([field("PRODUCT", "table")]);
+    expect(oSVM.added.length).toBe(1);
+    expect(oSVM.added[0]).toMatchObject({
+      type: "filterBar",
+      keyName: "persistencyKey",
+      control: oFilterBar,
+    });
+    // and anchors the bar, so saving a variant reaches sap.ui.fl
+    expect(oSVM._oPersoControl).toBe(oFilterBar);
+    expect(oSVM.initialised).toEqual([oFilterBar]);
+    // the load flow's callback drops the "*" the restored values would leave
+    expect(oSVM.modified).toEqual([false]);
+  });
+
+  test("fetchData collects group, field and value of every filter", () => {
+    const { oFilterBar } = wire([
+      field("PRODUCT", "table"),
+      field("QUANTITY", ""),
+    ]);
+    expect(oFilterBar.registered.fetch()).toEqual([
+      { groupName: "group1", fieldName: "PRODUCT", fieldData: "table" },
+      { groupName: "group1", fieldName: "QUANTITY", fieldData: "" },
+    ]);
+  });
+
+  test("applyData writes a stored variant back into the filter controls", () => {
+    const fields = [field("PRODUCT", ""), field("QUANTITY", "")];
+    const { oFilterBar } = wire(fields);
+    oFilterBar.registered.apply([
+      { groupName: "group1", fieldName: "PRODUCT", fieldData: "chair" },
+      { groupName: "group1", fieldName: "QUANTITY", fieldData: "123" },
+    ]);
+    expect(fields.map((f) => f.getControl().getValue())).toEqual([
+      "chair",
+      "123",
+    ]);
+  });
+
+  test("getFiltersWithValues reports only the filled filters", () => {
+    const fields = [field("PRODUCT", "table"), field("QUANTITY", "")];
+    const { oFilterBar } = wire(fields);
+    expect(oFilterBar.registered.withValues()).toEqual([fields[0]]);
+  });
+
+  test("a filter change marks the variant modified and refreshes the bar", () => {
+    const fields = [field("PRODUCT", "table")];
+    const { oSVM, oFilterBar } = wire(fields);
+    const oEvent = { id: "change" };
+    fields[0].control.fireChange(oEvent);
+    expect(oSVM.modified).toEqual([false, true]);
+    expect(oFilterBar.fired).toEqual([oEvent]);
+  });
+
+  test("does not wire the same bar a second time", () => {
+    const { FrontendAction, oSVM } = wire([field("PRODUCT", "table")]);
+    FrontendAction.execute(null, ["FILTER_BAR_VARIANT_INIT", "svm", "fbar"]);
+    expect(oSVM.added.length).toBe(1);
+  });
+
+  test("waits for sap.ui.comp when PersonalizableInfo is not loaded yet", () => {
+    const { FrontendAction, controls, ctx } = load();
+    let pending = null;
+    ctx.sap.ui.require = (name, callback) => {
+      if (Array.isArray(name)) {
+        pending = callback;
+        return undefined;
+      }
+      return null;
+    };
+    const oSVM = svm();
+    const oFilterBar = filterBar([field("PRODUCT", "table")]);
+    controls.svm = oSVM;
+    controls.fbar = oFilterBar;
+    FrontendAction.execute(null, ["FILTER_BAR_VARIANT_INIT", "svm", "fbar"]);
+    // the callbacks are in place immediately, only the variant control waits
+    expect(typeof oFilterBar.registered.fetch).toBe("function");
+    expect(oSVM.added.length).toBe(0);
+    pending(PersonalizableInfo);
+    expect(oSVM.added.length).toBe(1);
+  });
+
+  test("logs when the named control is not a FilterBar", () => {
+    const { FrontendAction, controls, errors } = load();
+    controls.svm = svm();
+    controls.fbar = { id: "not-a-filter-bar" };
+    FrontendAction.execute(null, ["FILTER_BAR_VARIANT_INIT", "svm", "fbar"]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("no FilterBar");
+  });
+
+  test("logs when the named id is not a SmartVariantManagement", () => {
+    const { FrontendAction, controls, errors } = load();
+    controls.svm = { id: "not-a-variant-control" };
+    controls.fbar = filterBar([field("PRODUCT", "table")]);
+    FrontendAction.execute(null, ["FILTER_BAR_VARIANT_INIT", "svm", "fbar"]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("no SmartVariantManagement");
+  });
+});
+
 
 test.describe("CONTROL_BY_ID setAsyncURLHandler (MessagePopover URL policy)", () => {
   // the control takes a live callback, so the wire carries a POLICY NAME and

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -839,6 +839,48 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      view.bindElement(``${path}/${args[2]}``);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // The anchor. setPersControler() is sap.ui.comp's own setter and does` && |\n| &&
+             `    // more than assign the field: it also creates the control promise that` && |\n| &&
+             `    // initialise() insists on. A page variant never gets that call -` && |\n| &&
+             `    // addPersonalizableControl() returns early for isPageVariant() and only` && |\n| &&
+             `    // the single-control case reaches setPersControler() - which is exactly` && |\n| &&
+             `    // why a controller-less app ends up with no anchor and no promise.` && |\n| &&
+             `    function anchorPersoControl(oSVM, target) {` && |\n| &&
+             `      if (oSVM._oPersoControl) {` && |\n| &&
+             `        // a runtime that anchors the control itself is left alone` && |\n| &&
+             `      } else if (typeof oSVM.setPersControler === "function") {` && |\n| &&
+             `        oSVM.setPersControler(target);` && |\n| &&
+             `      } else {` && |\n| &&
+             `        // older runtimes without the setter: the field alone still carries` && |\n| &&
+             `        // the write path (saving), which is better than nothing` && |\n| &&
+             `        oSVM._oPersoControl = target;` && |\n| &&
+             `      }` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // With the anchor in place the load flow still has to be started once.` && |\n| &&
+             `    // A smart control does that itself when it registers - but only then,` && |\n| &&
+             `    // and it may already have tried (and aborted) before the anchor existed.` && |\n| &&
+             `    // So wait for the control's wrapper and initialise it if nobody has:` && |\n| &&
+             `    // a wrapper is required (initialise answers "unknown control" without` && |\n| &&
+             `    // one) and an initialised wrapper must be left alone ("already executed").` && |\n| &&
+             `    function ensureInitialised(oSVM, target, attempt, fnCallback) {` && |\n| &&
+             `      if (Lib.isDestroyed(oSVM)) return;` && |\n| &&
+             `      const wrapper = oSVM._getControlWrapper` && |\n| &&
+             `        ? oSVM._getControlWrapper(target)` && |\n| &&
+             `        : null;` && |\n| &&
+             `      if (!wrapper) {` && |\n| &&
+             `        if (attempt < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
+             `          setTimeout(` && |\n| &&
+             `            () => ensureInitialised(oSVM, target, attempt + 1, fnCallback),` && |\n| &&
+             `            SMART_VARIANT_INIT_DELAY,` && |\n| &&
+             `          );` && |\n| &&
+             `        }` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      if (wrapper.bInitialized) return;` && |\n| &&
+             `      oSVM.initialise(fnCallback || (() => {}), target);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // SMART_VARIANT_INIT: place the anchor sap.ui.comp variant management needs` && |\n| &&
              `    // and that only an app controller would otherwise set - the personalizable` && |\n| &&
              `    // control the SmartVariantManagement works against (_oPersoControl).` && |\n| &&
@@ -897,47 +939,175 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          target = ViewSlots.resolveById(registered[0].getControl());` && |\n| &&
              `          if (!target) return;` && |\n| &&
              `        }` && |\n| &&
-             `        // The anchor. setPersControler() is sap.ui.comp's own setter and does` && |\n| &&
-             `        // more than assign the field: it also creates the control promise that` && |\n| &&
-             `        // initialise() insists on. A page variant never gets that call -` && |\n| &&
-             `        // addPersonalizableControl() returns early for isPageVariant() and only` && |\n| &&
-             `        // the single-control case reaches setPersControler() - which is exactly` && |\n| &&
-             `        // why a controller-less app ends up with no anchor and no promise.` && |\n| &&
-             `        if (oSVM._oPersoControl) {` && |\n| &&
-             `          // a runtime that anchors the control itself is left alone` && |\n| &&
-             `        } else if (typeof oSVM.setPersControler === "function") {` && |\n| &&
-             `          oSVM.setPersControler(target);` && |\n| &&
-             `        } else {` && |\n| &&
-             `          // older runtimes without the setter: the field alone still carries` && |\n| &&
-             `          // the write path (saving), which is better than nothing` && |\n| &&
-             `          oSVM._oPersoControl = target;` && |\n| &&
-             `        }` && |\n| &&
+             `        anchorPersoControl(oSVM, target);` && |\n| &&
              `        ensureInitialised(oSVM, target, 0);` && |\n| &&
              `      };` && |\n| &&
              `` && |\n| &&
-             `      // With the anchor in place the load flow still has to be started once.` && |\n| &&
-             `      // The smart control does that itself when it registers - but only then,` && |\n| &&
-             `      // and it may already have tried (and aborted) before the anchor existed.` && |\n| &&
-             `      // So wait for the control's wrapper and initialise it if nobody has:` && |\n| &&
-             `      // a wrapper is required (initialise answers "unknown control" without` && |\n| &&
-             `      // one) and an initialised wrapper must be left alone ("already executed").` && |\n| &&
-             `      function ensureInitialised(oSVM, target, attempt) {` && |\n| &&
-             `        if (Lib.isDestroyed(oSVM)) return;` && |\n| &&
-             `        const wrapper = oSVM._getControlWrapper` && |\n| &&
-             `          ? oSVM._getControlWrapper(target)` && |\n| &&
-             `          : null;` && |\n| &&
-             `        if (!wrapper) {` && |\n| &&
-             `          if (attempt < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
-             `            setTimeout(` && |\n| &&
-             `              () => ensureInitialised(oSVM, target, attempt + 1),` && |\n| &&
-             `              SMART_VARIANT_INIT_DELAY,` && |\n| &&
-             `            );` && |\n| &&
+             `      run();` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // ------------------------------------------------------------------` && |\n| &&
+             `    // FILTER_BAR_VARIANT_INIT: wire a CLASSIC sap.ui.comp.filterbar.FilterBar` && |\n| &&
+             `    // to a SmartVariantManagement. args = [_, svmId, filterBarId].` && |\n| &&
+             `    //` && |\n| &&
+             `    // A SmartFilterBar registers itself at the variant management (it knows its` && |\n| &&
+             `    // fields from the OData metadata), so SMART_VARIANT_INIT above only has to` && |\n| &&
+             `    // place the anchor. A classic FilterBar knows nothing about variants: every` && |\n| &&
+             `    // list-report controller hand-writes the same three callbacks` && |\n| &&
+             `    // (registerFetchData / registerApplyData / registerGetFiltersWithValues),` && |\n| &&
+             `    // adds a PersonalizableInfo and marks the variant dirty on each filter` && |\n| &&
+             `    // change. That is boilerplate over the bar's own filter items - data, not` && |\n| &&
+             `    // app logic - so the framework owns it and the app needs no JavaScript.` && |\n| &&
+             `    // ------------------------------------------------------------------` && |\n| &&
+             `` && |\n| &&
+             `    // marker so a re-sent action cannot stack a second set of callbacks and` && |\n| &&
+             `    // change handlers on the same bar (a rebuilt view reuses the ids, but it` && |\n| &&
+             `    // builds NEW control instances, which arrive here unmarked)` && |\n| &&
+             `    const FILTER_BAR_WIRED = "_z2ui5FilterBarVariantWired";` && |\n| &&
+             `` && |\n| &&
+             `    function filterItemControl(item) {` && |\n| &&
+             `      return item && typeof item.getControl === "function"` && |\n| &&
+             `        ? item.getControl()` && |\n| &&
+             `        : null;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    function filterItemValue(item) {` && |\n| &&
+             `      const control = filterItemControl(item);` && |\n| &&
+             `      return control && typeof control.getValue === "function"` && |\n| &&
+             `        ? control.getValue()` && |\n| &&
+             `        : "";` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // what a variant stores, how it is put back, and which filters count as` && |\n| &&
+             `    // "assigned" for the bar's own summary text` && |\n| &&
+             `    function registerFilterBarCallbacks(oFilterBar) {` && |\n| &&
+             `      oFilterBar.registerFetchData(() =>` && |\n| &&
+             `        oFilterBar.getAllFilterItems().map((item) => ({` && |\n| &&
+             `          groupName: item.getGroupName(),` && |\n| &&
+             `          fieldName: item.getName(),` && |\n| &&
+             `          fieldData: filterItemValue(item),` && |\n| &&
+             `        })),` && |\n| &&
+             `      );` && |\n| &&
+             `      oFilterBar.registerApplyData((data) => {` && |\n| &&
+             `        (data || []).forEach((entry) => {` && |\n| &&
+             `          const control = oFilterBar.determineControlByName(` && |\n| &&
+             `            entry.fieldName,` && |\n| &&
+             `            entry.groupName,` && |\n| &&
+             `          );` && |\n| &&
+             `          // setValue, not a model write: the two-way binding abap2UI5 put on` && |\n| &&
+             `          // the property carries the restored value back to the backend on the` && |\n| &&
+             `          // next roundtrip, so selecting a variant needs none of its own` && |\n| &&
+             `          if (control && typeof control.setValue === "function") {` && |\n| &&
+             `            control.setValue(entry.fieldData);` && |\n| &&
              `          }` && |\n| &&
+             `        });` && |\n| &&
+             `      });` && |\n| &&
+             `      oFilterBar.registerGetFiltersWithValues(() =>` && |\n| &&
+             `        oFilterBar` && |\n| &&
+             `          .getFilterGroupItems()` && |\n| &&
+             `          .filter((item) => String(filterItemValue(item)).length > 0),` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // every filter change makes the current variant dirty (the "*" next to the` && |\n| &&
+             `    // variant title) and refreshes the bar's assigned-filters summary` && |\n| &&
+             `    function attachFilterBarChange(oSVM, oFilterBar) {` && |\n| &&
+             `      oFilterBar.getAllFilterItems().forEach((item) => {` && |\n| &&
+             `        const control = filterItemControl(item);` && |\n| &&
+             `        if (!control || typeof control.attachChange !== "function") return;` && |\n| &&
+             `        control.attachChange((oEvent) => {` && |\n| &&
+             `          if (typeof oSVM.currentVariantSetModified === "function") {` && |\n| &&
+             `            oSVM.currentVariantSetModified(true);` && |\n| &&
+             `          }` && |\n| &&
+             `          if (typeof oFilterBar.fireFilterChange === "function") {` && |\n| &&
+             `            oFilterBar.fireFilterChange(oEvent);` && |\n| &&
+             `          }` && |\n| &&
+             `        });` && |\n| &&
+             `      });` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // sap.ui.comp is SAPUI5-only, so PersonalizableInfo must never be a hard` && |\n| &&
+             `    // dependency of this file (it 404s on OpenUI5 and would kill the component` && |\n| &&
+             `    // load). Resolve it at call time: synchronously when the SmartVariant-` && |\n| &&
+             `    // Management already pulled it in, asynchronously otherwise.` && |\n| &&
+             `    function withPersonalizableInfo(callback) {` && |\n| &&
+             `      const name = "sap/ui/comp/smartvariants/PersonalizableInfo";` && |\n| &&
+             `      if (` && |\n| &&
+             `        typeof sap === "undefined" ||` && |\n| &&
+             `        !sap.ui ||` && |\n| &&
+             `        typeof sap.ui.require !== "function"` && |\n| &&
+             `      ) {` && |\n| &&
+             `        Lib.logError("FILTER_BAR_VARIANT_INIT: sap.ui.require not available");` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      const loaded = sap.ui.require(name);` && |\n| &&
+             `      if (loaded) {` && |\n| &&
+             `        callback(loaded);` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      sap.ui.require([name], callback, () =>` && |\n| &&
+             `        Lib.logError(` && |\n| &&
+             `          "FILTER_BAR_VARIANT_INIT: sap.ui.comp.smartvariants not available",` && |\n| &&
+             `        ),` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    function evFilterBarVariantInit(oController, args) {` && |\n| &&
+             `      const [, svmId, filterBarId] = args;` && |\n| &&
+             `      let tries = 0;` && |\n| &&
+             `      const run = () => {` && |\n| &&
+             `        const oSVM = ViewSlots.resolveById(svmId);` && |\n| &&
+             `        const oFilterBar = ViewSlots.resolveById(filterBarId);` && |\n| &&
+             `        if (!oSVM || !oFilterBar) {` && |\n| &&
+             `          // the view may still be building - wait for both controls to exist` && |\n| &&
+             `          if (tries++ < SMART_VARIANT_INIT_TRIES) {` && |\n| &&
+             `            setTimeout(run, SMART_VARIANT_INIT_DELAY);` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``FILTER_BAR_VARIANT_INIT: '${svmId}' / '${filterBarId}' not found``,` && |\n| &&
+             `          );` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        if (wrapper.bInitialized) return;` && |\n| &&
-             `        oSVM.initialise(() => {}, target);` && |\n| &&
-             `      }` && |\n| &&
+             `        if (` && |\n| &&
+             `          Lib.isDestroyed(oSVM) ||` && |\n| &&
+             `          typeof oSVM.addPersonalizableControl !== "function"` && |\n| &&
+             `        ) {` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``FILTER_BAR_VARIANT_INIT: no SmartVariantManagement for id '${svmId}'``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        if (typeof oFilterBar.registerFetchData !== "function") {` && |\n| &&
+             `          Lib.logError(` && |\n| &&
+             `            ``FILTER_BAR_VARIANT_INIT: no FilterBar for id '${filterBarId}'``,` && |\n| &&
+             `          );` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        if (oFilterBar[FILTER_BAR_WIRED]) return;` && |\n| &&
+             `        oFilterBar[FILTER_BAR_WIRED] = true;` && |\n| &&
+             `` && |\n| &&
+             `        registerFilterBarCallbacks(oFilterBar);` && |\n| &&
+             `        attachFilterBarChange(oSVM, oFilterBar);` && |\n| &&
+             `        withPersonalizableInfo((PersonalizableInfo) => {` && |\n| &&
+             `          oSVM.addPersonalizableControl(` && |\n| &&
+             `            new PersonalizableInfo({` && |\n| &&
+             `              type: "filterBar",` && |\n| &&
+             `              keyName: "persistencyKey",` && |\n| &&
+             `              dataSource: "",` && |\n| &&
+             `              control: oFilterBar,` && |\n| &&
+             `            }),` && |\n| &&
+             `          );` && |\n| &&
+             `          anchorPersoControl(oSVM, oFilterBar);` && |\n| &&
+             `          // the load flow ends in registerApplyData, so the bar is clean again` && |\n| &&
+             `          // right after it - drop the "*" the restored values would leave` && |\n| &&
+             `          ensureInitialised(oSVM, oFilterBar, 0, () => {` && |\n| &&
+             `            if (typeof oSVM.currentVariantSetModified === "function") {` && |\n| &&
+             `              oSVM.currentVariantSetModified(false);` && |\n| &&
+             `            }` && |\n| &&
+             `          });` && |\n| &&
+             `        });` && |\n| &&
+             `      };` && |\n| &&
              `` && |\n| &&
              `      run();` && |\n| &&
              `    }` && |\n| &&
@@ -1049,7 +1219,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `` && |\n| &&
              `    // the same normalized form for an actual keydown event` && |\n| &&
              `    function shortcutFromEvent(oEvent) {` && |\n| &&
-             `      const key = String(oEvent.key ?? "").toLowerCase();` && |\n| &&
+             `      const key = String(oEvent.key ?? "").toLowerCase();` && |\n|.
+    result = result &&
              `      // a bare modifier press is not a shortcut` && |\n| &&
              `      if (key === "" || SHORTCUT_MODIFIERS.includes(shortcutToken(key)))` && |\n| &&
              `        return "";` && |\n| &&
@@ -1219,8 +1390,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          inline: args[4] || "nearest",` && |\n| &&
              `        });` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        Lib.logError(``SCROLL_INTO_VIEW: failed for '${args[1]}'``, e);` && |\n|.
-    result = result &&
+             `        Lib.logError(``SCROLL_INTO_VIEW: failed for '${args[1]}'``, e);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
@@ -1331,6 +1501,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      WIZARD_SET_NEXT_STEP: evWizardSetNextStep,` && |\n| &&
              `      PLAY_AUDIO: evPlayAudio,` && |\n| &&
              `      SMART_VARIANT_INIT: evSmartVariantInit,` && |\n| &&
+             `      FILTER_BAR_VARIANT_INIT: evFilterBarVariantInit,` && |\n| &&
              `      CONTROL_BY_ID: evControlCallById,` && |\n| &&
              `      CONTROL_GLOBAL: evControlCall,` && |\n| &&
              `      BINDING_CALL: evBindingCall,` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -51,6 +51,7 @@ INTERFACE z2ui5_if_client
       binding_call              TYPE string VALUE `BINDING_CALL`,
       bind_element              TYPE string VALUE `BIND_ELEMENT`,
       smart_variant_init        TYPE string VALUE `SMART_VARIANT_INIT`,
+      filter_bar_variant_init   TYPE string VALUE `FILTER_BAR_VARIANT_INIT`,
 
       "obsolet?
       image_editor_popup_close  TYPE string VALUE `IMAGE_EDITOR_POPUP_CLOSE`,
@@ -326,6 +327,18 @@ INTERFACE z2ui5_if_client
   "! default: the first control that registered itself). The action waits for
   "! that registration, which the smart controls do once their OData metadata
   "! has loaded.
+  "! cs_event-filter_bar_variant_init - wire a classic
+  "! sap.ui.comp.filterbar.FilterBar to a SmartVariantManagement:
+  "! t_arg = SmartVariantManagement id, FilterBar id. A SmartFilterBar knows
+  "! its own fields and registers itself (see smart_variant_init above); a
+  "! classic FilterBar does not, so a list report normally hand-writes the
+  "! same controller boilerplate - registerFetchData / registerApplyData /
+  "! registerGetFiltersWithValues, addPersonalizableControl( ) with a
+  "! PersonalizableInfo, and a change handler per filter field that marks the
+  "! variant as modified. This action does all of it, so saving, selecting and
+  "! restoring a variant works without a single line of JavaScript. The
+  "! restored values reach the backend through the two-way binding of the
+  "! filter fields, no extra roundtrip needed.
   "! cs_event-keyboard_shortcut - bind a key combination to a named backend
   "! event, the declarative equivalent of a sap.ui.core.CommandExecution
   "! shortcut: t_arg = combination, event name. The combination is spelled


### PR DESCRIPTION
A sap.ui.comp SmartFilterBar knows its own fields from the OData metadata
and registers itself at a SmartVariantManagement, so SMART_VARIANT_INIT
only has to place the anchor. The CLASSIC sap.ui.comp.filterbar.FilterBar
knows nothing about variants: an app has to hand it three callbacks
(registerFetchData / registerApplyData / registerGetFiltersWithValues),
add a PersonalizableInfo and mark the variant modified on every filter
change. That is the same boilerplate in every list report - it reads the
bar's own filter items and writes them back, no app logic in it - and
until now it was the one part of such a screen that forced an abap2UI5
app to ship JavaScript.

The new frontend action does all of it from two ids:

  client->follow_up_action(
      val   = client->cs_event-filter_bar_variant_init
      t_arg = VALUE #( ( `svm` ) ( `fbar` ) ) ).

registerApplyData restores a variant through the controls' own setValue,
so the two-way binding carries the values back to the backend on the next
roundtrip - selecting a variant needs no roundtrip of its own. The
PersonalizableInfo module is resolved at call time (synchronously when
the variant control already pulled it in, asynchronously otherwise):
sap.ui.comp is SAPUI5-only and must never become a hard dependency of
FrontendAction.js, which also loads on OpenUI5.

The anchor/initialise logic SMART_VARIANT_INIT already carried is now
shared by both actions instead of living inside one handler. Nine specs
cover the new action.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G6YtB2n8uvFDmTv87Nba6S