### PR TITLE
Fix stale check_csrf_active wording and repair the red browser test suite

### DIFF
--- a/node/tests/e2e/error-view.spec.js
+++ b/node/tests/e2e/error-view.spec.js
@@ -37,7 +37,39 @@ async function showErrorView(/** @type {boolean} */ withRetry) {
             const options = retry
               ? { onRetry: () => (window["__retried"] = true) }
               : undefined;
-            ErrorView.show("something broke", undefined, options);
+            // ErrorView.show prefers the friendly UI5 dialog and only builds
+            // the raw-DOM overlay tested here when sap.m cannot be resolved.
+            // In a real browser those controls are always loaded, so deny just
+            // the sap/m/* lookups for the duration of this one call: the
+            // synchronous form returns undefined (showFriendlyDialog bails)
+            // and the array form takes the errback (loadFriendlyDialogAsync
+            // bails), which is exactly the last-resort path the overlay exists
+            // for. Restored right after, so UI5's own module loading - which
+            // also goes through sap.ui.require - stays untouched.
+            const realRequire = window["sap"].ui.require;
+            const isControl = (/** @type {any} */ dep) =>
+              typeof dep === "string" && dep.startsWith("sap/m/");
+            window["sap"].ui.require = function (
+              /** @type {any} */ deps,
+              /** @type {any} */ cb,
+              /** @type {any} */ errback,
+            ) {
+              if (typeof deps === "string") {
+                return isControl(deps)
+                  ? undefined
+                  : realRequire.call(this, deps);
+              }
+              if (Array.isArray(deps) && deps.some(isControl)) {
+                if (errback) errback(new Error("sap.m denied by test"));
+                return undefined;
+              }
+              return realRequire.call(this, deps, cb, errback);
+            };
+            try {
+              ErrorView.show("something broke", undefined, options);
+            } finally {
+              window["sap"].ui.require = realRequire;
+            }
             resolve(undefined);
           },
         );

--- a/node/tests/e2e/roundtrip.spec.js
+++ b/node/tests/e2e/roundtrip.spec.js
@@ -60,9 +60,7 @@ test("chains the session draft across roundtrips", async ({ request }) => {
   expect(second.S_FRONT.ID).not.toBe(first.S_FRONT.ID);
 });
 
-test("returns the backend-built view XML on app start", async ({
-  request,
-}) => {
+test("returns the backend-built view XML on app start", async ({ request }) => {
   const body = await (
     await request.post("/", {
       data: frontBody({ SEARCH: "?app_start=z2ui5_cl_app_hello_world" }),
@@ -106,9 +104,7 @@ test("applies the model delta before on_event and answers the event", async ({
     })
   ).json();
 
-  expect(second.S_FRONT.PARAMS?.S_MSG_BOX?.TEXT).toBe(
-    "Your name is Roundtrip",
-  );
+  expect(second.S_FRONT.PARAMS?.S_MSG_BOX?.TEXT).toBe("Your name is Roundtrip");
   // an event roundtrip without view_display must not resend the view
   expect(second.S_FRONT.PARAMS?.S_VIEW?.XML).toBeUndefined();
 });
@@ -118,8 +114,12 @@ test("rejects a broken request body with a framework error", async ({
 }) => {
   const res = await request.post("/", { data: "no json at all" });
 
+  // The single top-level catch in z2ui5_cl_http_handler=>_main turns the
+  // parse failure into a 500 carrying the raw exception text, so the frontend
+  // shows the real reason instead of the generic SAP ICF 500 page. Assert on
+  // that text - the body deliberately does not carry a product marker.
   expect(res.status()).toBe(500);
-  expect(await res.text()).toContain("abap2UI5");
+  expect(await res.text()).toContain("Json parsing error");
 });
 
 test("boots the UI5 shell in the browser and issues the initial roundtrip", async ({

--- a/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
@@ -177,7 +177,7 @@ CLASS ltcl_test_http_handler IMPLEMENTATION.
 
   METHOD test_csrf_inactive.
 
-    " opt-in: with csrf disabled even a cross-origin request is allowed
+    " opt-out: with csrf disabled even a cross-origin request is allowed
     DATA(lv_rejected) = z2ui5_cl_http_handler=>_check_csrf_rejected(
                             active  = abap_false
                             origin  = `https://evil.example.com`

--- a/src/02/z2ui5_if_types.intf.abap
+++ b/src/02/z2ui5_if_types.intf.abap
@@ -69,12 +69,15 @@ INTERFACE z2ui5_if_types
       " message instead of the raw exception text (avoids leaking internal
       " details to the client in hardened installations)
       check_hide_error_details TYPE abap_bool,
-      " when set via the exit, a state-changing POST whose Origin/Referer
-      " header names a different site than the app's own host is rejected
-      " with 403 (CSRF defense). Opt-in and lenient: a request without an
-      " Origin/Referer header (older clients, some proxies) is allowed, so
-      " only an explicit cross-origin marker is blocked - the app's own
-      " roundtrips are always same-origin (the SPA fetches its own backend).
+      " a state-changing POST whose Origin/Referer header names a different
+      " site than the app's own host is rejected with 403 (CSRF defense).
+      " On by default: z2ui5_cl_exit=>set_config_http_post seeds abap_true
+      " before the user exit runs, so an app that must accept cross-origin
+      " POSTs opts out by setting it back to abap_false in its own exit.
+      " Lenient: a request without an Origin/Referer header (older clients,
+      " some proxies) is allowed, so only an explicit cross-origin marker is
+      " blocked - the app's own roundtrips are always same-origin (the SPA
+      " fetches its own backend).
       check_csrf_active        TYPE abap_bool,
     END OF ty_s_http_config_post.
 


### PR DESCRIPTION
# Description

Two independent fixes, neither changing product behaviour.

### 1. `check_csrf_active` comments (`858f3c3`)

`check_csrf_active` was opt-in when CSRF defense arrived in #2479. #2486 changed it to be seeded with `abap_true` in `z2ui5_cl_exit=>set_config_http_post` before the user exit runs, making it on-by-default with an opt-out. Two comments still described the old behaviour:

- `src/02/z2ui5_if_types.intf.abap` — called the field *"when set via the exit"* and *"Opt-in"*.
- `src/02/z2ui5_cl_http_handler.clas.testclasses.abap` — `test_csrf_inactive` was labelled *"opt-in"*.

The already-correct comments (`z2ui5_cl_http_handler.clas.abap:54`, `z2ui5_cl_exit.clas.abap:118`, `z2ui5_cl_exit.clas.testclasses.abap:60`) were left alone. `check_hide_error_details` still reads *"when set via the exit"*, which is correct for that field — it does default to `abap_false`.

### 2. `test_browser` (`7fb8294`)

`test_browser` has failed on **every one of the last 30 runs**, across all branches — 15 failures (5 tests × 3 browsers). All of them are stale assertions, not product defects.

**`error-view.spec.js` (4 tests).** #2469 made `ErrorView.show` prefer the friendly UI5 dialog, falling back to the raw-DOM overlay only when `sap.m` cannot be resolved. In a real browser those controls are always loaded, so the overlay these tests assert on was never built. The fix denies just the `sap/m/*` lookups for the duration of the `show()` call — the synchronous form returns `undefined` so `showFriendlyDialog` bails, the array form takes the errback so `loadFriendlyDialogAsync` bails — which is precisely the last-resort path the overlay exists for. `sap.ui.require` is restored immediately after, so UI5's own module loading is untouched. This preserves the split documented in `errorView.spec.js`, which states the raw overlay is covered by the browser suite.

**`roundtrip.spec.js` (1 test).** The case asserted the 500 body contains `"abap2UI5"`. The top-level catch in `z2ui5_cl_http_handler=>_main` answers with the raw exception text — for a malformed body that is the ajson message `Json parsing error: Not JSON @Line 1, Offset 1`. No product marker, and none was ever promised (the body was already `lx->get_text( )` before #2486). The assertion now targets the framework error text, keeping the point of the case: a broken body yields a 500 carrying the real reason instead of the generic SAP ICF error page.

## How to test

- The `roundtrip` case was reproduced failing on `origin/main` and passing with this change, run locally against the transpiled backend (`auto_downport` + `auto_transpile` + Playwright).
- The 317 JS unit tests still pass.
- The four `error-view` cases could **not** be exercised locally — they need UI5 from `sdk.openui5.org`, which the dev container cannot reach (proxy returns 403), so `beforeAll` times out there for an unrelated reason. They rest on the code path described above; CI is the check.

## Checklist

- [ ] `npx abaplint` passes (0 issues) — not run locally; the abaplint check on this PR is green
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — comment text only
- [x] Changes were made via abapGit: no