### PR TITLE
docs(abapdoc): sync stale interface comments with current behavior

### DIFF
--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -309,10 +309,12 @@ INTERFACE z2ui5_if_client
   "! Two ways to call it: pass a frontend event as val (e.g. cs_event-set_title)
   "! with its arguments in t_arg and the framework builds the event call; or pass
   "! a raw JavaScript expression as val (without t_arg) to run it as-is.
-  "! The whitelisted control/binding calls are frontend events too; their t_arg
+  "! The control/binding calls are frontend events too; their t_arg
   "! is positional (an empty argument between filled ones keeps its slot as ``):
-  "! cs_event-control_by_id - call a whitelisted method on a control resolved
-  "! by id: t_arg = id, method, params. The view is passed as the separate
+  "! cs_event-control_by_id - call a method on a control resolved by id:
+  "! t_arg = id, method, params. Any public control method works unless it is
+  "! on the frontend denylist (methods that would break framework invariants).
+  "! The view is passed as the separate
   "! view parameter (default cs_view-main resolves the id across all open
   "! views; pass cs_view-popup/popover/... to scope the lookup to that view).
   "! cs_event-control_global - call a whitelisted method on a global object

--- a/src/02/z2ui5_if_types.intf.abap
+++ b/src/02/z2ui5_if_types.intf.abap
@@ -69,12 +69,14 @@ INTERFACE z2ui5_if_types
       " message instead of the raw exception text (avoids leaking internal
       " details to the client in hardened installations)
       check_hide_error_details TYPE abap_bool,
-      " when set via the exit, a state-changing POST whose Origin/Referer
-      " header names a different site than the app's own host is rejected
-      " with 403 (CSRF defense). Opt-in and lenient: a request without an
-      " Origin/Referer header (older clients, some proxies) is allowed, so
-      " only an explicit cross-origin marker is blocked - the app's own
-      " roundtrips are always same-origin (the SPA fetches its own backend).
+      " when active, a state-changing POST whose Origin/Referer header names
+      " a different site than the app's own host is rejected with 403 (CSRF
+      " defense). On by default (seeded in z2ui5_cl_exit before the user exit
+      " runs); an app that must accept cross-origin POSTs can opt out in its
+      " own set_config_http_post. Lenient: a request without an Origin/Referer
+      " header (older clients, some proxies) is allowed, so only an explicit
+      " cross-origin marker is blocked - the app's own roundtrips are always
+      " same-origin (the SPA fetches its own backend).
       check_csrf_active        TYPE abap_bool,
     END OF ty_s_http_config_post.
 


### PR DESCRIPTION
- z2ui5_if_types: check_csrf_active is on by default (seeded in
  z2ui5_cl_exit before the user exit runs) with an opt-out, not opt-in
- z2ui5_if_client: control_by_id calls any public control method not on
  the frontend denylist; the closed-whitelist wording predates #2473