### PR TITLE
Fix router hash handling to prevent doubled slashes in URLs

### DIFF
--- a/app/webapp/core/Router.js
+++ b/app/webapp/core/Router.js
@@ -79,9 +79,13 @@ sap.ui.define(
     // The app hash the browser currently stands on. Inside the FLP the
     // HashChanger is the shell's own and already returns the inner hash;
     // appHashOf normalizes the standalone case (and any release that hands
-    // back the full hash) to the same shape.
+    // back the full hash) to the same shape. Standalone, hasher trims the
+    // "/" it prepended on write; the FLP shell hands the inner hash back
+    // without one - re-add it so comparisons against the slash-prefixed
+    // routes this router builds hold on both stacks.
     function getHash() {
-      return appHashOf(hashChanger().getHash());
+      const app = appHashOf(hashChanger().getHash());
+      return app && !app.startsWith("/") ? `/${app}` : app;
     }
 
     // Build an absolute URL for an app hash, keeping the FLP shell hash in
@@ -113,7 +117,9 @@ sap.ui.define(
     }
 
     function segmentsOf(sHash) {
-      const app = appHashOf(sHash).replace(/^\//, "");
+      // tolerate any number of leading slashes: routes written before navTo
+      // stripped its slash live on in bookmarks and history as "#//app/X"
+      const app = appHashOf(sHash).replace(/^\/+/, "");
       const marker = "app/";
       if (!app.startsWith(marker)) return null;
       // Stop at any route/query separator, then split class / draft id.
@@ -147,11 +153,22 @@ sap.ui.define(
     // returns to the current app), replaceHash updates the current one in
     // place and leaves the history depth alone. Both go through the
     // HashChanger, so inside the FLP only the app hash is rewritten.
+    //
+    // The hash is handed over WITHOUT its leading slash: standalone, the
+    // HashChanger's engine (hasher, prependHash "/") unconditionally prepends
+    // one more - a slash-prefixed route would put "#//app/X" into the URL.
+    // Reads through the HashChanger come back trimmed, so the frontend never
+    // noticed, but the backend parses window.location.hash raw: the double
+    // slash hid the route from it and every browser Back/Forward/reload fell
+    // back to the "?app_start=" boot query (the app restarted instead of the
+    // routed one being restored). Inside the FLP the shell appends the hash
+    // after "&/" - the canonical launchpad spelling is slash-less anyway.
     function navTo(sRoute, bReplace) {
+      const sHash = String(sRoute || "").replace(/^\/+/, "");
       if (bReplace) {
-        hashChanger().replaceHash(sRoute);
+        hashChanger().replaceHash(sHash);
       } else {
-        hashChanger().setHash(sRoute);
+        hashChanger().setHash(sHash);
       }
     }
 
@@ -313,13 +330,13 @@ sap.ui.define(
           const newUrl = `${window.location.pathname}${window.location.search}#${getRawHash()}${PARAMS.SET_PUSH_STATE}`;
           history.pushState(null, "", newUrl);
         }
-        // Keep the leading "/" so the live URL matches the format the copy
-        // link (FrontendAction.evClipboardAppState) writes and the backend
-        // restore path expects: the app-state id is read as a URL parameter
-        // of the app hash, i.e. after exactly one "/". Without the slash the
-        // live hash is "#z2ui5-xapp-state=..." and the historic "+2" parser
-        // ate the leading "z", so bookmarking/reloading the live URL never
-        // restored the app state (only the explicitly copied link did).
+        // The live URL must match the format the copy link
+        // (FrontendAction.evClipboardAppState) writes and the backend restore
+        // path expects: the app-state id is read as a URL parameter of the
+        // app hash, i.e. after exactly one "/". navTo strips the leading
+        // slash and standalone hasher prepends exactly one again; inside the
+        // FLP the shell appends the slash-less hash after "&/" - both end up
+        // in the canonical single-slash form.
         const newHash = PARAMS.SET_APP_STATE_ACTIVE
           ? `/z2ui5-xapp-state=${ID || ""}`
           : "";

--- a/node/srv/zcl_tst_nav_detail.clas.abap
+++ b/node/srv/zcl_tst_nav_detail.clas.abap
@@ -1,0 +1,29 @@
+CLASS zcl_tst_nav_detail DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS zcl_tst_nav_detail IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+    DATA view TYPE REF TO z2ui5_cl_xml_view.
+    DATA page TYPE REF TO z2ui5_cl_xml_view.
+
+    me->client = client.
+
+    IF client->check_on_init( ) IS NOT INITIAL.
+      view = z2ui5_cl_xml_view=>factory( ).
+      page = view->shell( )->page( title = `NAV DETAIL` ).
+      page->label( `detail-marker` ).
+      client->view_display( view->stringify( ) ).
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/node/srv/zcl_tst_nav_detail.clas.abap
+++ b/node/srv/zcl_tst_nav_detail.clas.abap
@@ -17,7 +17,11 @@ CLASS zcl_tst_nav_detail IMPLEMENTATION.
 
     me->client = client.
 
-    IF client->check_on_init( ) IS NOT INITIAL.
+    " check_on_navigated also fires when browser Forward / reload restores
+    " this app from its KEEP-route draft - the view must be rendered again
+    " there (the app contract; see docs life_cycle.md)
+    IF client->check_on_init( ) IS NOT INITIAL
+        OR client->check_on_navigated( ) IS NOT INITIAL.
       view = z2ui5_cl_xml_view=>factory( ).
       page = view->shell( )->page( title = `NAV DETAIL` ).
       page->label( `detail-marker` ).

--- a/node/srv/zcl_tst_nav_detail.clas.xml
+++ b/node/srv/zcl_tst_nav_detail.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_TST_NAV_DETAIL</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>e2e fixture - routing detail page</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/node/srv/zcl_tst_nav_hub.clas.abap
+++ b/node/srv/zcl_tst_nav_hub.clas.abap
@@ -1,0 +1,61 @@
+CLASS zcl_tst_nav_hub DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA input   TYPE string.
+    DATA counter TYPE i.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+    METHODS view_display.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS zcl_tst_nav_hub IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+    DATA lo_detail TYPE REF TO zcl_tst_nav_detail.
+
+    me->client = client.
+
+    IF client->check_on_init( ) IS NOT INITIAL.
+      view_display( ).
+
+    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+      view_display( ).
+
+    ELSEIF client->check_on_event( ) IS NOT INITIAL.
+      CASE client->get( )-event.
+        WHEN `INC`.
+          counter = counter + 1.
+          view_display( ).
+        WHEN `GO_DETAIL`.
+          CREATE OBJECT lo_detail.
+          client->nav_app_call( lo_detail ).
+      ENDCASE.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+    DATA view TYPE REF TO z2ui5_cl_xml_view.
+    DATA page TYPE REF TO z2ui5_cl_xml_view.
+
+    client->set_nav_routing( client->cs_nav_mode-fresh ).
+
+    view = z2ui5_cl_xml_view=>factory( ).
+    page = view->shell( )->page( title = `NAV HUB FRESH` ).
+
+    page->label( `hub-marker` ).
+    page->input( client->_bind_edit( input ) ).
+    page->button( text  = |increment ({ counter })|
+                  press = client->_event( `INC` ) ).
+    page->button( text  = `go-detail`
+                  press = client->_event( `GO_DETAIL` ) ).
+
+    client->view_display( view->stringify( ) ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/node/srv/zcl_tst_nav_hub.clas.xml
+++ b/node/srv/zcl_tst_nav_hub.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_TST_NAV_HUB</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>e2e fixture - FRESH-mode routing hub</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/node/srv/zcl_tst_nav_hub_keep.clas.abap
+++ b/node/srv/zcl_tst_nav_hub_keep.clas.abap
@@ -1,0 +1,61 @@
+CLASS zcl_tst_nav_hub_keep DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA input   TYPE string.
+    DATA counter TYPE i.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+    METHODS view_display.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS zcl_tst_nav_hub_keep IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+    DATA lo_detail TYPE REF TO zcl_tst_nav_detail.
+
+    me->client = client.
+
+    IF client->check_on_init( ) IS NOT INITIAL.
+      view_display( ).
+
+    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+      view_display( ).
+
+    ELSEIF client->check_on_event( ) IS NOT INITIAL.
+      CASE client->get( )-event.
+        WHEN `INC`.
+          counter = counter + 1.
+          view_display( ).
+        WHEN `GO_DETAIL`.
+          CREATE OBJECT lo_detail.
+          client->nav_app_call( lo_detail ).
+      ENDCASE.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+    DATA view TYPE REF TO z2ui5_cl_xml_view.
+    DATA page TYPE REF TO z2ui5_cl_xml_view.
+
+    client->set_nav_routing( client->cs_nav_mode-keep ).
+
+    view = z2ui5_cl_xml_view=>factory( ).
+    page = view->shell( )->page( title = `NAV HUB KEEP` ).
+
+    page->label( `hubkeep-marker` ).
+    page->input( client->_bind_edit( input ) ).
+    page->button( text  = |increment ({ counter })|
+                  press = client->_event( `INC` ) ).
+    page->button( text  = `go-detail`
+                  press = client->_event( `GO_DETAIL` ) ).
+
+    client->view_display( view->stringify( ) ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/node/srv/zcl_tst_nav_hub_keep.clas.xml
+++ b/node/srv/zcl_tst_nav_hub_keep.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_TST_NAV_HUB_KEEP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>e2e fixture - KEEP-mode routing hub</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/node/tests/e2e/nav-back-forward.spec.js
+++ b/node/tests/e2e/nav-back-forward.spec.js
@@ -30,23 +30,26 @@ if (process.env.PW_CHROMIUM_PATH) {
   });
 }
 
+async function mirrorCdn(page) {
+  if (!MIRROR) return;
+  await page.route("https://sdk.openui5.org/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname
+      .replace(/\/sap-ui-cachebuster/g, "")
+      .replace(/\/~[^/]*~[a-zA-Z0-9]*/g, "");
+    try {
+      const resp = await route.fetch({ url: `${MIRROR}${path}` });
+      await route.fulfill({ response: resp });
+    } catch (e) {
+      await route.abort();
+    }
+  });
+}
+
 test("browser Back then Forward across a FRESH-mode nav_app_call", async ({
   page,
 }) => {
-  if (MIRROR) {
-    await page.route("https://sdk.openui5.org/**", async (route) => {
-      const url = new URL(route.request().url());
-      const path = url.pathname
-        .replace(/\/sap-ui-cachebuster/g, "")
-        .replace(/\/~[^/]*~[a-zA-Z0-9]*/g, "");
-      try {
-        const resp = await route.fetch({ url: `${MIRROR}${path}` });
-        await route.fulfill({ response: resp });
-      } catch (e) {
-        await route.abort();
-      }
-    });
-  }
+  await mirrorCdn(page);
 
   await page.goto("/?app_start=zcl_tst_nav_hub");
   await expect(page.getByText("hub-marker")).toBeVisible({ timeout: 30000 });
@@ -65,6 +68,36 @@ test("browser Back then Forward across a FRESH-mode nav_app_call", async ({
   await expect(page.getByText("hub-marker")).toBeVisible();
 
   // browser Forward -> the detail app must be restored from its route
+  await page.goForward();
+  await expect(page.getByText("detail-marker")).toBeVisible();
+});
+
+test("browser Back then Forward across a KEEP-mode nav_app_call", async ({
+  page,
+}) => {
+  await mirrorCdn(page);
+
+  await page.goto("/?app_start=zcl_tst_nav_hub_keep");
+  await expect(page.getByText("hubkeep-marker")).toBeVisible({
+    timeout: 30000,
+  });
+  // KEEP routes carry the app-state draft: /app/<CLASS>/<DRAFT>
+  expect(page.url()).toMatch(/#\/app\/ZCL_TST_NAV_HUB_KEEP\/[0-9A-F]{32}/);
+
+  // put some state in, so Back has something to restore
+  await page.getByRole("button", { name: /increment/ }).click();
+  await expect(page.getByRole("button", { name: "increment (1)" })).toBeVisible();
+
+  await page.getByRole("button", { name: "go-detail" }).click();
+  await expect(page.getByText("detail-marker")).toBeVisible();
+  expect(page.url()).toMatch(/#\/app\/ZCL_TST_NAV_DETAIL\/[0-9A-F]{32}/);
+
+  // browser Back -> the hub comes back EXACTLY as the user left it
+  await page.goBack();
+  await expect(page.getByText("hubkeep-marker")).toBeVisible();
+  await expect(page.getByRole("button", { name: "increment (1)" })).toBeVisible();
+
+  // browser Forward -> the detail app must be restored from its draft route
   await page.goForward();
   await expect(page.getByText("detail-marker")).toBeVisible();
 });

--- a/node/tests/e2e/nav-back-forward.spec.js
+++ b/node/tests/e2e/nav-back-forward.spec.js
@@ -1,0 +1,70 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+// Reproduces the browser Back/Forward cycle over a FRESH-mode routed app
+// (the z2ui5_cl_demo_app_468 / 469 scenario) against the transpiled backend:
+// hub app with set_nav_routing(fresh) -> nav_app_call(detail) -> browser
+// Back (hub restarts fresh) -> browser Forward (detail must come back).
+//
+// Regression coverage for the doubled route slash: hasher (the HashChanger's
+// engine) prepends a "/" of its own, so slash-prefixed routes ended up as
+// "#//app/X" in the URL. The frontend never noticed (reads come back
+// trimmed), but the backend parses window.location.hash raw - the route no
+// longer matched, every Back/Forward restore fell back to the "?app_start="
+// boot query, and pressing Forward appeared to do nothing (the boot app was
+// rendered again instead of the routed one).
+//
+// The fixture apps live in node/srv/zcl_tst_nav_*.clas.abap and are copied
+// into the transpiled backend by `npm run auto_transpile`.
+
+// Sandboxed environments without a route to the UI5 CDN can serve the
+// framework from a local mirror (e.g. `ui5 serve`) by setting
+// UI5_MIRROR_URL=http://localhost:8081 - requests to the CDN are then
+// fulfilled locally, with the cachebuster segments stripped. A custom
+// browser build can be picked via PW_CHROMIUM_PATH. CI sets neither and
+// runs against the real CDN with the pinned Playwright browsers.
+const MIRROR = process.env.UI5_MIRROR_URL;
+if (process.env.PW_CHROMIUM_PATH) {
+  test.use({
+    launchOptions: { executablePath: process.env.PW_CHROMIUM_PATH },
+  });
+}
+
+test("browser Back then Forward across a FRESH-mode nav_app_call", async ({
+  page,
+}) => {
+  if (MIRROR) {
+    await page.route("https://sdk.openui5.org/**", async (route) => {
+      const url = new URL(route.request().url());
+      const path = url.pathname
+        .replace(/\/sap-ui-cachebuster/g, "")
+        .replace(/\/~[^/]*~[a-zA-Z0-9]*/g, "");
+      try {
+        const resp = await route.fetch({ url: `${MIRROR}${path}` });
+        await route.fulfill({ response: resp });
+      } catch (e) {
+        await route.abort();
+      }
+    });
+  }
+
+  await page.goto("/?app_start=zcl_tst_nav_hub");
+  await expect(page.getByText("hub-marker")).toBeVisible({ timeout: 30000 });
+  // the routed URL carries the canonical single-slash route
+  expect(page.url()).toContain("#/app/ZCL_TST_NAV_HUB");
+  expect(page.url()).not.toContain("#//");
+
+  // forward navigation via backend nav_app_call pushes the detail route
+  await page.getByRole("button", { name: "go-detail" }).click();
+  await expect(page.getByText("detail-marker")).toBeVisible();
+  expect(page.url()).toContain("#/app/ZCL_TST_NAV_DETAIL");
+  expect(page.url()).not.toContain("#//");
+
+  // browser Back -> the hub restarts fresh (FRESH mode routes by class only)
+  await page.goBack();
+  await expect(page.getByText("hub-marker")).toBeVisible();
+
+  // browser Forward -> the detail app must be restored from its route
+  await page.goForward();
+  await expect(page.getByText("detail-marker")).toBeVisible();
+});

--- a/node/tests/router.spec.js
+++ b/node/tests/router.spec.js
@@ -241,6 +241,14 @@ test("a non-app hash and disabled routing are both ignored", () => {
 // 3b. Write side - sync
 // ---------------------------------------------------------------------------
 
+// Writes reach the HashChanger WITHOUT the route's leading slash: standalone,
+// hasher (prependHash "/") adds exactly one of its own - handing it a
+// slash-prefixed route put "#//app/X" into the URL, which the frontend never
+// saw (reads come back trimmed) but which hid the route from the backend's
+// raw window.location.hash parser: every Back/Forward/reload fell back to
+// the "?app_start=" boot query and restarted the boot app instead of
+// restoring the routed one (forward navigation appeared to do nothing).
+
 // the response of the roundtrip that ran client->nav_app_call
 function navCallParams() {
   return {
@@ -257,7 +265,7 @@ test("a plain roundtrip replaces the current entry with the newest draft", () =>
   Router.sync({}, "D2");
 
   expect(writes).toEqual([
-    { op: "replace", hash: `/app/${CALLER}/D2`, guard: "D2" },
+    { op: "replace", hash: `app/${CALLER}/D2`, guard: "D2" },
   ]);
 });
 
@@ -271,9 +279,9 @@ test("a nav_app_call repoints the caller's entry, then pushes the called app", (
   expect(writes).toEqual([
     // the caller's entry now points at the draft that carries the user's
     // client-side changes ...
-    { op: "replace", hash: `/app/${CALLER}/D2`, guard: "D2" },
+    { op: "replace", hash: `app/${CALLER}/D2`, guard: "D2" },
     // ... and the called app gets a NEW entry, so Back returns to it
-    { op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" },
+    { op: "set", hash: `app/${CALLEE}/D9`, guard: "D9" },
   ]);
   // the state ends up on the called app (the repoint must not leak)
   expect(state.currentApp).toBe(CALLEE);
@@ -288,7 +296,7 @@ test("the repoint is skipped when the caller's entry is already current", () => 
   Router.sync(navCallParams(), "D9");
 
   expect(writes).toEqual([
-    { op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" },
+    { op: "set", hash: `app/${CALLEE}/D9`, guard: "D9" },
   ]);
 });
 
@@ -299,7 +307,7 @@ test("a nav_app_call without the caller info only pushes (older backend)", () =>
   Router.sync({ CHECK_NAV_APP_CALL: true }, "D9");
 
   expect(writes).toEqual([
-    { op: "set", hash: `/app/${CALLEE}/D9`, guard: "D9" },
+    { op: "set", hash: `app/${CALLEE}/D9`, guard: "D9" },
   ]);
 });
 
@@ -311,7 +319,7 @@ test("FRESH mode routes by class only and never repoints", () => {
 
   Router.sync(navCallParams(), "D9");
 
-  expect(writes).toEqual([{ op: "set", hash: `/app/${CALLEE}`, guard: null }]);
+  expect(writes).toEqual([{ op: "set", hash: `app/${CALLEE}`, guard: null }]);
 });
 
 test("a render caused by browser Back/Forward writes no hash at all", () => {
@@ -336,7 +344,7 @@ test("the routing mode arrives with every response and switches modes live", () 
   expect(state.navRouting).toBe(true);
   expect(state.navMode).toBe("KEEP");
   expect(writes).toEqual([
-    { op: "replace", hash: `/app/${CALLER}/D2`, guard: "D2" },
+    { op: "replace", hash: `app/${CALLER}/D2`, guard: "D2" },
   ]);
 
   // DEFAULT turns routing off again and hands the hash back to the app
@@ -363,10 +371,35 @@ test("set_push_state keeps the FLP shell hash in the pushed URL", () => {
   expect(standalone.pushes).toEqual(["/sap/z2ui5#/app/X/D1?pos=42"]);
 });
 
-test("the app-state hash is written with its leading slash", () => {
+test("the app-state hash reaches the HashChanger slash-less too", () => {
+  // hasher prepends the one canonical "/" - the live URL becomes
+  // "#/z2ui5-xapp-state=ABC", exactly the format the copy link writes
   const { Router, writes } = loadRouter({ state: { navRouting: false } });
   Router.sync({ SET_APP_STATE_ACTIVE: true }, "ABC");
   expect(writes).toEqual([
-    { op: "replace", hash: "/z2ui5-xapp-state=ABC", guard: "D1" },
+    { op: "replace", hash: "z2ui5-xapp-state=ABC", guard: "D1" },
   ]);
+});
+
+test("navTo strips every leading slash before writing", () => {
+  // regression: with the slash left in, hasher turned "/app/X" into
+  // "#//app/X" and the backend route parser no longer matched it
+  const { Router, writes } = loadRouter();
+  Router.navTo(`/app/${CALLEE}/D9`);
+  Router.navTo(`//app/${CALLEE}`, true);
+  expect(writes).toEqual([
+    { op: "set", hash: `app/${CALLEE}/D9`, guard: "D1" },
+    { op: "replace", hash: `app/${CALLEE}`, guard: "D1" },
+  ]);
+});
+
+test("routes with stacked leading slashes still parse (old history entries)", () => {
+  // "#//app/X" URLs written before navTo stripped its slash live on in
+  // bookmarks and history entries - Back/Forward hands them to the router
+  const { Router } = loadRouter();
+  expect(Router.parse(`#//app/${CALLEE}/D9`)).toEqual({
+    app: CALLEE,
+    draft: "D9",
+  });
+  expect(Router.appOf(`//app/${CALLEE}`)).toBe(CALLEE);
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "auto_app2abap": "node .github/app2abap/trans2abap.js",
     "app2abap": "npm --prefix app run format && npm run auto_app2abap && npm run auto_abaplint",
     "auto_abaplint": "npx abaplint .github/abaplint/auto_abaplint_fix.jsonc --fix",
-    "auto_transpile": "rm -rf node/output && cp node/srv/*.abap node/downport && abap_transpile ./node/setup/abap_transpile.json",
+    "auto_transpile": "rm -rf node/output && cp node/srv/*.abap node/srv/*.clas.xml node/downport && abap_transpile ./node/setup/abap_transpile.json",
     "rename": "npm ci && abaplint .github/abaplint/rename_test.jsonc --rename",
     "express": "node node/srv/express.mjs",
     "unit": "echo RUNNING && node node/output/index.mjs",

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -322,12 +322,11 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
   METHOD request_app_start_draft.
     TRY.
         DATA(lv_hash) = hash_get_app_part( iv_hash ).
-        " the app hash may carry a leading '/' ('#/z2ui5-xapp-state=...');
-        " url_param_get matches parameter names verbatim, so strip it
-        IF strlen( lv_hash ) > 0 AND lv_hash(1) = `/`.
-          lv_hash = substring( val = lv_hash
-                               off = 1 ).
-        ENDIF.
+        " the app hash may carry leading slashes ('#/z2ui5-xapp-state=...',
+        " or '#//...' from URLs written through the UI5 HashChanger before
+        " navTo stripped its slash); url_param_get matches parameter names
+        " verbatim, so strip them all
+        SHIFT lv_hash LEFT DELETING LEADING `/`.
         result = z2ui5_cl_a2ui5_context=>c_trim_upper(
             z2ui5_cl_a2ui5_context=>url_param_get( val = `z2ui5-xapp-state`
                                           url          = lv_hash ) ).
@@ -344,12 +343,12 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     " '#/app/X' and '#Z2UI5-display&/app/X' resolve identically.
     DATA(lv_hash) = hash_get_app_part( iv_hash ).
 
-    " the leading '/' is optional: the launchpad convention writes the app
-    " hash without it ('&/app/X'), our own routes carry it ('#/app/X')
-    IF strlen( lv_hash ) > 0 AND lv_hash(1) = `/`.
-      lv_hash = substring( val = lv_hash
-                           off = 1 ).
-    ENDIF.
+    " leading slashes are optional AND may stack: the launchpad convention
+    " writes the app hash without one ('&/app/X'), our own routes carry one
+    " ('#/app/X'), and URLs written through the UI5 HashChanger before navTo
+    " stripped its slash carry two ('#//app/X' - hasher prepends a '/' of its
+    " own); those live on in bookmarks and browser history, so strip them all
+    SHIFT lv_hash LEFT DELETING LEADING `/`.
 
     IF strlen( lv_hash ) < 4 OR lv_hash(4) <> `app/`.
       RETURN.

--- a/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.testclasses.abap
@@ -468,6 +468,16 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = ``
                                         act = lo_handler->request_app_start_route_draft( `#/app/ZCL_X` ) ).
 
+    " the double-slash form the UI5 HashChanger wrote before navTo stripped
+    " its slash (hasher prepends one of its own) - lives on in bookmarks and
+    " browser history entries, and Back/Forward sends exactly this
+    cl_abap_unit_assert=>assert_equals( exp = `ZCL_X`
+                                        act = lo_handler->request_app_start_route( `#//app/ZCL_X/D1` ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `D1`
+                                        act = lo_handler->request_app_start_route_draft( `#//app/ZCL_X/D1` ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `ZCL_X`
+                                        act = lo_handler->request_app_start_route( `#//app/ZCL_X` ) ).
+
   ENDMETHOD.
 
   METHOD test_route_launchpad.
@@ -522,6 +532,11 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = `ABC123`
         act = lo_handler->request_app_start_draft( `#Z2UI5-display&/z2ui5-xapp-state=ABC123` ) ).
+
+    " the double-slash form older HashChanger-written live URLs carry
+    cl_abap_unit_assert=>assert_equals(
+        exp = `ABC123`
+        act = lo_handler->request_app_start_draft( `#//z2ui5-xapp-state=ABC123` ) ).
 
   ENDMETHOD.
 

--- a/src/01/03/z2ui5_cl_app_router_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_router_js.clas.abap
@@ -99,9 +99,13 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `    // The app hash the browser currently stands on. Inside the FLP the` && |\n| &&
              `    // HashChanger is the shell's own and already returns the inner hash;` && |\n| &&
              `    // appHashOf normalizes the standalone case (and any release that hands` && |\n| &&
-             `    // back the full hash) to the same shape.` && |\n| &&
+             `    // back the full hash) to the same shape. Standalone, hasher trims the` && |\n| &&
+             `    // "/" it prepended on write; the FLP shell hands the inner hash back` && |\n| &&
+             `    // without one - re-add it so comparisons against the slash-prefixed` && |\n| &&
+             `    // routes this router builds hold on both stacks.` && |\n| &&
              `    function getHash() {` && |\n| &&
-             `      return appHashOf(hashChanger().getHash());` && |\n| &&
+             `      const app = appHashOf(hashChanger().getHash());` && |\n| &&
+             `      return app && !app.startsWith("/") ? ``/${app}`` : app;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Build an absolute URL for an app hash, keeping the FLP shell hash in` && |\n| &&
@@ -133,7 +137,9 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    function segmentsOf(sHash) {` && |\n| &&
-             `      const app = appHashOf(sHash).replace(/^\//, "");` && |\n| &&
+             `      // tolerate any number of leading slashes: routes written before navTo` && |\n| &&
+             `      // stripped its slash live on in bookmarks and history as "#//app/X"` && |\n| &&
+             `      const app = appHashOf(sHash).replace(/^\/+/, "");` && |\n| &&
              `      const marker = "app/";` && |\n| &&
              `      if (!app.startsWith(marker)) return null;` && |\n| &&
              `      // Stop at any route/query separator, then split class / draft id.` && |\n| &&
@@ -167,11 +173,22 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `    // returns to the current app), replaceHash updates the current one in` && |\n| &&
              `    // place and leaves the history depth alone. Both go through the` && |\n| &&
              `    // HashChanger, so inside the FLP only the app hash is rewritten.` && |\n| &&
+             `    //` && |\n| &&
+             `    // The hash is handed over WITHOUT its leading slash: standalone, the` && |\n| &&
+             `    // HashChanger's engine (hasher, prependHash "/") unconditionally prepends` && |\n| &&
+             `    // one more - a slash-prefixed route would put "#//app/X" into the URL.` && |\n| &&
+             `    // Reads through the HashChanger come back trimmed, so the frontend never` && |\n| &&
+             `    // noticed, but the backend parses window.location.hash raw: the double` && |\n| &&
+             `    // slash hid the route from it and every browser Back/Forward/reload fell` && |\n| &&
+             `    // back to the "?app_start=" boot query (the app restarted instead of the` && |\n| &&
+             `    // routed one being restored). Inside the FLP the shell appends the hash` && |\n| &&
+             `    // after "&/" - the canonical launchpad spelling is slash-less anyway.` && |\n| &&
              `    function navTo(sRoute, bReplace) {` && |\n| &&
+             `      const sHash = String(sRoute || "").replace(/^\/+/, "");` && |\n| &&
              `      if (bReplace) {` && |\n| &&
-             `        hashChanger().replaceHash(sRoute);` && |\n| &&
+             `        hashChanger().replaceHash(sHash);` && |\n| &&
              `      } else {` && |\n| &&
-             `        hashChanger().setHash(sRoute);` && |\n| &&
+             `        hashChanger().setHash(sHash);` && |\n| &&
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
@@ -333,13 +350,13 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `          const newUrl = ``${window.location.pathname}${window.location.search}#${getRawHash()}${PARAMS.SET_PUSH_STATE}``;` && |\n| &&
              `          history.pushState(null, "", newUrl);` && |\n| &&
              `        }` && |\n| &&
-             `        // Keep the leading "/" so the live URL matches the format the copy` && |\n| &&
-             `        // link (FrontendAction.evClipboardAppState) writes and the backend` && |\n| &&
-             `        // restore path expects: the app-state id is read as a URL parameter` && |\n| &&
-             `        // of the app hash, i.e. after exactly one "/". Without the slash the` && |\n| &&
-             `        // live hash is "#z2ui5-xapp-state=..." and the historic "+2" parser` && |\n| &&
-             `        // ate the leading "z", so bookmarking/reloading the live URL never` && |\n| &&
-             `        // restored the app state (only the explicitly copied link did).` && |\n| &&
+             `        // The live URL must match the format the copy link` && |\n| &&
+             `        // (FrontendAction.evClipboardAppState) writes and the backend restore` && |\n| &&
+             `        // path expects: the app-state id is read as a URL parameter of the` && |\n| &&
+             `        // app hash, i.e. after exactly one "/". navTo strips the leading` && |\n| &&
+             `        // slash and standalone hasher prepends exactly one again; inside the` && |\n| &&
+             `        // FLP the shell appends the slash-less hash after "&/" - both end up` && |\n| &&
+             `        // in the canonical single-slash form.` && |\n| &&
              `        const newHash = PARAMS.SET_APP_STATE_ACTIVE` && |\n| &&
              `          ? ``/z2ui5-xapp-state=${ID || ""}``` && |\n| &&
              `          : "";` && |\n| &&
@@ -400,7 +417,8 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `    };` && |\n| &&
              `  },` && |\n| &&
              `);` && |\n| &&
-             `` && |\n| &&
+             `` && |\n|.
+    result = result &&
               ``.
 
   ENDMETHOD.


### PR DESCRIPTION
## Description

Fixes a regression in browser Back/Forward navigation where routes were being written to the URL with doubled slashes (`#//app/X` instead of `#/app/X`). This caused the backend's raw `window.location.hash` parser to fail matching routes, falling back to the boot query and restarting the app instead of restoring the routed state.

### Root Cause

The UI5 HashChanger's `hasher` engine unconditionally prepends a `/` to hashes. The router was passing slash-prefixed routes directly to the HashChanger, resulting in `#//app/X` in the live URL. Frontend reads came back trimmed (single slash), but the backend parses the raw hash and couldn't match the doubled-slash format.

### Solution

- **navTo()**: Strip leading slashes before passing routes to HashChanger. Hasher will add exactly one back.
- **getHash()**: Re-add the leading slash when reading from HashChanger so internal route comparisons work consistently.
- **segmentsOf()**: Tolerate multiple leading slashes to handle old bookmarks/history entries with `#//app/X`.
- **Backend hash parsing**: Use `SHIFT LEFT DELETING LEADING '/'` to strip any number of leading slashes.

### Changes

- **Router.js / z2ui5_cl_app_router_js.clas.abap**: Updated `navTo()`, `getHash()`, and `segmentsOf()` to handle slash normalization
- **z2ui5_cl_core_handler.clas.abap**: Updated hash parsing to strip multiple leading slashes
- **Unit tests**: Added tests for slash stripping in `navTo()` and parsing of stacked slashes
- **E2E test**: New `nav-back-forward.spec.js` covering FRESH-mode routing with browser Back/Forward
- **Test fixtures**: Added `zcl_tst_nav_hub` and `zcl_tst_nav_detail` ABAP classes for e2e testing

## How to test

1. Run unit tests: `npm run test` (covers slash normalization in Router)
2. Run e2e test: `npm run test:e2e -- nav-back-forward.spec.js` (covers Back/Forward cycle)
3. Verify ABAP unit tests pass in the transpiled backend

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated (Router.spec.js, z2ui5_cl_core_handler.clas.testclasses.abap, nav-back-forward.spec.js)
- [x] No manual edits under `src/00/` or `src/01/03/` (changes via abapGit)
- [x] Public API in `src/02/` unchanged
- [x] Changes made via abapGit: yes

https://claude.ai/code/session_016USY5fyCFzP56BZTFz6iTM