### PR TITLE
fix(frontend): MessageBox onclose action was dropped before reaching the backend

### DIFF
--- a/app/webapp/core/Messages.js
+++ b/app/webapp/core/Messages.js
@@ -96,7 +96,12 @@ sap.ui.define(
       if (msg.TITLE) oParams.title = msg.TITLE;
       if (msg.STYLECLASS) oParams.styleClass = msg.STYLECLASS;
       if (msg.ONCLOSE) {
-        oParams.onClose = (sAction) => oController.eB([msg.ONCLOSE, sAction]);
+        // the pressed action must ride OUTSIDE the event array: eB treats
+        // args[0] as the event array (name + flags) and Server.roundtrip
+        // shifts the WHOLE array away, so anything placed inside it never
+        // reaches T_EVENT_ARG - the action then has to be the first
+        // positional argument, like evImageEditorPopupClose's eB(["SAVE"], image)
+        oParams.onClose = (sAction) => oController.eB([msg.ONCLOSE], sAction);
       }
       if (msg.ACTIONS) oParams.actions = msg.ACTIONS;
       if (msg.EMPHASIZEDACTION) oParams.emphasizedAction = msg.EMPHASIZEDACTION;

--- a/src/01/03/z2ui5_cl_app_messages_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messages_js.clas.abap
@@ -116,7 +116,12 @@ CLASS z2ui5_cl_app_messages_js IMPLEMENTATION.
              `      if (msg.TITLE) oParams.title = msg.TITLE;` && |\n| &&
              `      if (msg.STYLECLASS) oParams.styleClass = msg.STYLECLASS;` && |\n| &&
              `      if (msg.ONCLOSE) {` && |\n| &&
-             `        oParams.onClose = (sAction) => oController.eB([msg.ONCLOSE, sAction]);` && |\n| &&
+             `        // the pressed action must ride OUTSIDE the event array: eB treats` && |\n| &&
+             `        // args[0] as the event array (name + flags) and Server.roundtrip` && |\n| &&
+             `        // shifts the WHOLE array away, so anything placed inside it never` && |\n| &&
+             `        // reaches T_EVENT_ARG - the action then has to be the first` && |\n| &&
+             `        // positional argument, like evImageEditorPopupClose's eB(["SAVE"], image)` && |\n| &&
+             `        oParams.onClose = (sAction) => oController.eB([msg.ONCLOSE], sAction);` && |\n| &&
              `      }` && |\n| &&
              `      if (msg.ACTIONS) oParams.actions = msg.ACTIONS;` && |\n| &&
              `      if (msg.EMPHASIZEDACTION) oParams.emphasizedAction = msg.EMPHASIZEDACTION;` && |\n| &&


### PR DESCRIPTION
# Description

Since #2441, `Messages.js` passed the pressed MessageBox action INSIDE the event array (`eB([msg.ONCLOSE, sAction])`). `Server.roundtrip` reads the event name from `ARGUMENTS[0][0]` and then shifts the **whole array** away, so the action never landed in `T_EVENT_ARG` — `get_event_arg( )` after an `onclose` event always returned initial, and a confirm dialog's OK/YES was silently indistinguishable from Cancel.

The action now rides as the first positional argument (`eB([msg.ONCLOSE], sAction)`), the same shape `evImageEditorPopupClose` already uses. The ABAP mirror was regenerated via `npm run app2abap` (no hand edits under `src/01/03/`).

Found by the ai-demokit e2e interaction for the TabContainer close-confirm flow (app 093); it also repairs the Wizard sample's cancel/submit confirm (ai-demokit app 101). Both flows run green end to end against the transpiled framework with this fix.

## How to test

1. In any app, raise a confirm box with a named onclose event and read the action:
   ```abap
   client->message_box_display( text = `Close?` type = `confirm` onclose = `DECIDE` ).
   " in on_event, WHEN `DECIDE`:
   IF client->get_event_arg( ) = `OK`. " arrives again with this fix
   ```
2. Without the fix, `get_event_arg( )` is always initial; with it, the pressed action (`OK`/`CANCEL`/`YES`/`NO`) arrives.
3. Automated proof: the ai-demokit e2e interaction `z2ui5_cl_ai_app_093` (close icon → confirm → OK → bound row removed + toast) runs green against the transpiled framework.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — none added; the covering test lives in the ai-demokit e2e harness (app 093 interaction)
- [x] No manual edits under `src/00/` or `src/01/03/` (mirror regenerated via `app2abap`)
- [x] Public API in `src/02/` only changed additively (no API change)
- [x] Changes were made via abapGit: no (JS source + generated mirror)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTNL9KYD3SwJ9Ci3jHzK3G

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTNL9KYD3SwJ9Ci3jHzK3G)_