### PR TITLE
Fix filter rendering, URL parsing, type checking, and view lifecycle

### DIFF
--- a/app/webapp/cc/MessageManager.js
+++ b/app/webapp/cc/MessageManager.js
@@ -64,7 +64,7 @@ sap.ui.define(
         if (this.getProperty("checkInit")) return;
         const messaging = Lib.getMessaging?.();
         if (!messaging) return;
-        this.setProperty("checkInit", true);
+        this.setProperty("checkInit", true, true);
         this._messaging = messaging;
         const view = ViewSlots.getView(
           ViewSlots.containingSlotKey(this) ?? "MAIN",

--- a/app/webapp/cc/MultiInputExt.js
+++ b/app/webapp/cc/MultiInputExt.js
@@ -60,7 +60,7 @@ sap.ui.define(
           this.getProperty("MultiInputId"),
         );
         if (!input || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true);
+        this.setProperty("checkInit", true, true);
         try {
           input.attachTokenUpdate(this.onTokenUpdate.bind(this));
           // Custom validator: turn any free-text entry into a Token where

--- a/app/webapp/cc/SmartMultiInputExt.js
+++ b/app/webapp/cc/SmartMultiInputExt.js
@@ -116,7 +116,7 @@ sap.ui.define(
           this.getProperty("multiInputId"),
         );
         if (!input || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true);
+        this.setProperty("checkInit", true, true);
         try {
           input.attachTokenUpdate(this.onTokenUpdate.bind(this));
           input.attachInnerControlsCreated(

--- a/app/webapp/cc/UploadSetExt.js
+++ b/app/webapp/cc/UploadSetExt.js
@@ -91,7 +91,7 @@ sap.ui.define(
           this.getProperty("uploadSetId"),
         );
         if (!uploadSet || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true);
+        this.setProperty("checkInit", true, true);
         try {
           uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));
           uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -88,8 +88,14 @@ sap.ui.define(
       // named phases: display pending fragments/views, then update the
       // browser history/hash.
       async _processAfterRendering() {
+        // Hoisted out of the try block: the finally below must run the
+        // follow-up JS of exactly THIS response. Re-reading the shared
+        // AppState.state.oResponse there would - after a parallel request
+        // replaced it during the awaits - consume (and clear) the newer
+        // response's snippets before its own render.
+        let oResponse;
         try {
-          const oResponse = AppState.state.oResponse;
+          oResponse = AppState.state.oResponse;
           if (oResponse._processed) return;
           oResponse._processed = true;
 
@@ -121,7 +127,7 @@ sap.ui.define(
           // run the follow-up JS snippets the backend asked for. Doing it here
           // - rather than as an early microtask - guarantees render-dependent
           // actions like SET_FOCUS find their target control in the DOM.
-          this._runPendingCustomJs(AppState.state.oResponse);
+          this._runPendingCustomJs(oResponse);
         }
       },
 
@@ -582,9 +588,12 @@ sap.ui.define(
         });
 
         // Guard against the app being destroyed during the await above.
+        // oModel covers oViewModel too when they are the same object (no
+        // switchPath); with an OData default model both must go.
         if (!Lib.isAlive(AppState.state.oApp)) {
           oView.destroy();
-          if (switchPath) oModel.destroy();
+          oModel.destroy();
+          if (switchPath) oViewModel.destroy();
           return;
         }
 
@@ -602,7 +611,8 @@ sap.ui.define(
           ViewSlots.getView("MAIN")
         ) {
           oView.destroy();
-          if (switchPath) oModel.destroy();
+          oModel.destroy();
+          if (switchPath) oViewModel.destroy();
           return;
         }
 

--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -388,7 +388,10 @@ sap.ui.define(
           "VIEW MODEL",
           json(() => jsonSources.MODEL()),
         );
-        if (getResponseXml("S_POPUP")) {
+        // gate on the live slot too - the response only carries the XML in
+        // the roundtrip that opened the popup/popover, but the live model is
+        // exportable for as long as one is open
+        if (getResponseXml("S_POPUP") || ViewSlots.getView("POPUP")) {
           push(
             "POPUP",
             xml(() => xmlSources.POPUP().xml),
@@ -398,7 +401,7 @@ sap.ui.define(
             json(() => jsonSources.POPUP_MODEL()),
           );
         }
-        if (getResponseXml("S_POPOVER")) {
+        if (getResponseXml("S_POPOVER") || ViewSlots.getView("POPOVER")) {
           push(
             "POPOVER",
             xml(() => xmlSources.POPOVER().xml),
@@ -691,8 +694,15 @@ sap.ui.define(
             templatingSource: false,
             activeNest1: Boolean(getViewContent(ViewSlots.getView("NEST"))),
             activeNest2: Boolean(getViewContent(ViewSlots.getView("NEST2"))),
-            activePopup: Boolean(getResponseXml("S_POPUP")),
-            activePopover: Boolean(getResponseXml("S_POPOVER")),
+            // The response only carries the fragment XML in the roundtrip
+            // that opened the popup/popover - also check the live slot so
+            // the tabs stay usable while one is open after later roundtrips.
+            activePopup: Boolean(
+              getResponseXml("S_POPUP") || ViewSlots.getView("POPUP"),
+            ),
+            activePopover: Boolean(
+              getResponseXml("S_POPOVER") || ViewSlots.getView("POPOVER"),
+            ),
           };
 
           const oModel = new JSONModel(oData);

--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -311,7 +311,17 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
   // for network/timeout failures, where the request may never have reached
   // the server and app state is still intact).
   function show(response, title, options = {}) {
-    const full = response?.stack ? String(response.stack) : String(response);
+    // V8 stacks start with "Error: <message>", but Firefox/SpiderMonkey
+    // stacks are frame lines only - prepend the message when the stack does
+    // not already carry it, so the overlay never shows a stack without the
+    // actual error text.
+    const stack = response?.stack ? String(response.stack) : "";
+    const message = String(response);
+    const full = stack
+      ? stack.includes(message)
+        ? stack
+        : `${message}\n${stack}`
+      : message;
     // Rendered via textContent, so the truncation marker is plain text (an
     // HTML comment would show up literally).
     const errorMessage =

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -792,8 +792,9 @@ sap.ui.define(
         return;
       }
 
-      const separator = path.includes("?") ? "&" : "?";
-      const bspKill = `${path}${separator}sap-sessioncmd=logoff`;
+      // location.pathname never contains a query string, so "?" always starts
+      // the sap-sessioncmd parameter
+      const bspKill = `${path}?sap-sessioncmd=logoff`;
       let done = false;
       let frame;
       const finish = () => {

--- a/app/webapp/core/Router.js
+++ b/app/webapp/core/Router.js
@@ -329,6 +329,12 @@ sap.ui.define(
           // launchpad.
           const newUrl = `${window.location.pathname}${window.location.search}#${getRawHash()}${PARAMS.SET_PUSH_STATE}`;
           history.pushState(null, "", newUrl);
+          // The pushed hash IS the desired URL - stop here. The cleanup below
+          // is a no-op while hasher's cached hash is empty (legacy mode), but
+          // with routing on the cache holds the app route, so replaceHash("")
+          // would count as a change and wipe both the route and the suffix
+          // pushed one line above.
+          return;
         }
         // The live URL must match the format the copy link
         // (FrontendAction.evClipboardAppState) writes and the backend restore

--- a/node/tests/router.spec.js
+++ b/node/tests/router.spec.js
@@ -371,6 +371,24 @@ test("set_push_state keeps the FLP shell hash in the pushed URL", () => {
   expect(standalone.pushes).toEqual(["/sap/z2ui5#/app/X/D1?pos=42"]);
 });
 
+test("set_push_state survives the app-state cleanup when routing is on", () => {
+  // with routing enabled hasher's cached hash holds the app route, so the
+  // trailing replaceHash("") cleanup would count as a change and wipe both
+  // the route and the suffix pushed a moment earlier - sync must stop after
+  // the push
+  const { Router, writes, pushes } = loadRouter({
+    state: { navRouting: true, navMode: "KEEP", currentApp: CALLER },
+    hash: `app/${CALLER}/D1`,
+    href: `https://host/sap/z2ui5#/app/${CALLER}/D1`,
+  });
+  Router.sync(
+    { SET_PUSH_STATE: "?pos=42", APP: CALLER, SET_NAV_ROUTING: "KEEP" },
+    "D1",
+  );
+  expect(pushes).toEqual([`/sap/z2ui5#/app/${CALLER}/D1?pos=42`]);
+  expect(writes.filter((w) => w.hash === "")).toEqual([]);
+});
+
 test("the app-state hash reaches the HashChanger slash-less too", () => {
   // hasher prepends the one canonical "/" - the live URL becomes
   // "#/z2ui5-xapp-state=ABC", exactly the format the copy link writes

--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
@@ -885,6 +885,12 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
       REPLACE `{LOW}`  IN lv_value WITH lr_row->low.
       REPLACE `{HIGH}` IN lv_value WITH lr_row->high.
 
+      " an excluding row must not render like its including twin - negate the
+      " token so the MultiInput shows the filter's real meaning
+      IF lr_row->sign = `E`.
+        lv_value = |!({ lv_value })|.
+      ENDIF.
+
       INSERT VALUE #( key      = lv_value
                       text     = lv_value
                       visible  = abap_true
@@ -894,10 +900,10 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD itab_filter_by_val.
-    " TRANSPILER NOTE: ABAP CS operator is ALWAYS case-insensitive regardless
-    " of the ignore_case flag. The flag only pre-converts to uppercase for
-    " consistency, but CS itself never does case-sensitive matching.
-    " JS equivalent: always use toLowerCase().includes(toLowerCase()).
+    " TRANSPILER NOTE: ABAP CS is always case-insensitive, so the two match
+    " branches below differ deliberately: ignore_case = abap_true uses
+    " to_upper + CS (JS: toLowerCase().includes(toLowerCase())), the default
+    " uses find( ) for a genuinely case-sensitive match (JS: plain includes()).
     FIELD-SYMBOLS <row>   TYPE any.
     FIELD-SYMBOLS <field> TYPE any.
 
@@ -915,7 +921,13 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
         IF fields IS INITIAL.
           ASSIGN COMPONENT lv_index OF STRUCTURE <row> TO <field>.
           IF sy-subrc <> 0.
-            EXIT.
+            IF lv_index = 1.
+              " elementary line type (e.g. string_table) has no components -
+              " match against the whole line instead of deleting every row
+              ASSIGN <row> TO <field>.
+            ELSE.
+              EXIT.
+            ENDIF.
           ENDIF.
         ELSE.
           IF lv_index > lv_field_count.
@@ -1109,6 +1121,9 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
     FIELD-SYMBOLS <unassign> TYPE any.
 
     ASSIGN val->* TO <unassign>.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
     result = <unassign>.
 
   ENDMETHOD.
@@ -1118,6 +1133,9 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
     FIELD-SYMBOLS <unassign> TYPE any.
 
     ASSIGN val->* TO <unassign>.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
     result = <unassign>.
 
   ENDMETHOD.
@@ -1147,6 +1165,13 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
                                with = `=`
                                occ  = 0 ).
 
+    " RFC 3986 allows lowercase hex digits in percent-encodings, so decode
+    " %3d the same way as %3D (%26 contains no letters and needs no twin)
+    lv_search = replace( val  = lv_search
+                         sub  = `%3d`
+                         with = `=`
+                         occ  = 0 ).
+
     lv_search = replace( val  = lv_search
                          sub  = `%26`
                          with = `&`
@@ -1155,7 +1180,9 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
     lv_search = shift_left( val = lv_search
                             sub = `?` ).
 
-    DATA(lv_search2) = substring_after( val = lv_search
+    " prepend & before searching so sap-startup-params is also unwrapped
+    " when it is the first/only query parameter (typical FLP target mapping)
+    DATA(lv_search2) = substring_after( val = |&{ lv_search }|
                                         sub = `&sap-startup-params=` ).
     lv_search = COND #( WHEN lv_search2 IS NOT INITIAL THEN lv_search2 ELSE lv_search ).
 
@@ -1287,7 +1314,14 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
       CASE rtti_get_type_kind( <component> ).
 
-        WHEN cl_abap_typedescr=>typekind_table.
+        " skip components that cannot be moved into the string value: tables,
+        " nested structures and references would raise an unhandled move
+        " error at runtime
+        WHEN cl_abap_typedescr=>typekind_table OR
+             cl_abap_typedescr=>typekind_struct1 OR
+             cl_abap_typedescr=>typekind_struct2 OR
+             cl_abap_typedescr=>typekind_dref OR
+             cl_abap_typedescr=>typekind_oref.
 
         WHEN OTHERS.
           INSERT VALUE #(
@@ -1313,10 +1347,14 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
     DATA(lv_type) = rtti_get_type_kind( val ).
     CASE lv_type.
+      " typekind_clike/_csequence are generic kinds of formal parameters and
+      " can never be returned for a concrete data object - list the concrete
+      " character-like kinds (c, string, n, d, t) instead
       WHEN cl_abap_datadescr=>typekind_char OR
-          cl_abap_datadescr=>typekind_clike OR
-          cl_abap_datadescr=>typekind_csequence OR
-          cl_abap_datadescr=>typekind_string.
+          cl_abap_datadescr=>typekind_string OR
+          cl_abap_datadescr=>typekind_num OR
+          cl_abap_datadescr=>typekind_date OR
+          cl_abap_datadescr=>typekind_time.
         result = abap_true.
     ENDCASE.
 
@@ -2074,7 +2112,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
         DATA(ls_result) = VALUE ty_s_msg( type = `E` text = lx->get_text( ) ).
         DATA(lt_attri_o) = rtti_get_t_attri_by_oref( val ).
         LOOP AT lt_attri_o REFERENCE INTO DATA(ls_attri_o)
-             WHERE visibility = `U`.
+             WHERE visibility = cv_objectdescr_public.
           DATA(lv_name) = ls_attri_o->name.
           ASSIGN lx->(lv_name) TO <comp>.
           IF sy-subrc <> 0.
@@ -2121,7 +2159,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
                 lt_attri_o = rtti_get_t_attri_by_oref( val ).
                 LOOP AT lt_attri_o REFERENCE INTO ls_attri_o
-                     WHERE visibility = `U`.
+                     WHERE visibility = cv_objectdescr_public.
                   lv_name = ls_attri_o->name.
                   ASSIGN obj->(lv_name) TO <comp>.
                   IF sy-subrc <> 0.

--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
@@ -12,6 +12,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_bool_cache_hit       FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_case       FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_no_phantom FOR TESTING RAISING cx_static_check.
+    METHODS test_url_param_startup    FOR TESTING RAISING cx_static_check.
     METHODS test_app_url_hash_app     FOR TESTING RAISING cx_static_check.
     METHODS test_app_url_hash_shell   FOR TESTING RAISING cx_static_check.
 
@@ -135,6 +136,31 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = 1
         act = lines( z2ui5_cl_a2ui5_context=>url_param_get_tab( `?a=1&` ) ) ).
+
+  ENDMETHOD.
+
+  METHOD test_url_param_startup.
+
+    " sap-startup-params is unwrapped wherever it sits in the query string -
+    " as a later parameter, as the first/only parameter (typical FLP target
+    " mapping), and with lowercase percent-encoding
+    cl_abap_unit_assert=>assert_equals(
+        exp = `foo`
+        act = z2ui5_cl_a2ui5_context=>url_param_get(
+                  val = `app_start`
+                  url = `?x=1&sap-startup-params=app_start%3Dfoo` ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `foo`
+        act = z2ui5_cl_a2ui5_context=>url_param_get(
+                  val = `app_start`
+                  url = `?sap-startup-params=app_start%3Dfoo` ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `foo`
+        act = z2ui5_cl_a2ui5_context=>url_param_get(
+                  val = `app_start`
+                  url = `?sap-startup-params=app_start%3dfoo` ) ).
 
   ENDMETHOD.
 
@@ -311,10 +337,15 @@ CLASS ltcl_rtti IMPLEMENTATION.
 
     DATA lv_int  TYPE i VALUE 5.
     DATA lv_char TYPE c LENGTH 4.
+    DATA lv_numc TYPE n LENGTH 4.
+    DATA lv_date TYPE d.
     DATA ls_row  TYPE ty_s_row.
 
     cl_abap_unit_assert=>assert_true( z2ui5_cl_a2ui5_context=>rtti_check_clike( `abc` ) ).
     cl_abap_unit_assert=>assert_true( z2ui5_cl_a2ui5_context=>rtti_check_clike( lv_char ) ).
+    " n, d and t are character-like too and must be accepted
+    cl_abap_unit_assert=>assert_true( z2ui5_cl_a2ui5_context=>rtti_check_clike( lv_numc ) ).
+    cl_abap_unit_assert=>assert_true( z2ui5_cl_a2ui5_context=>rtti_check_clike( lv_date ) ).
 
     cl_abap_unit_assert=>assert_false( z2ui5_cl_a2ui5_context=>rtti_check_clike( lv_int ) ).
     cl_abap_unit_assert=>assert_false( z2ui5_cl_a2ui5_context=>rtti_check_clike( ls_row ) ).
@@ -445,6 +476,7 @@ CLASS ltcl_itab DEFINITION FINAL
     METHODS test_filter_ignore_case FOR TESTING RAISING cx_static_check.
     METHODS test_filter_named_field FOR TESTING RAISING cx_static_check.
     METHODS test_filter_no_match    FOR TESTING RAISING cx_static_check.
+    METHODS test_filter_elementary  FOR TESTING RAISING cx_static_check.
     METHODS test_corresponding      FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
@@ -516,6 +548,24 @@ CLASS ltcl_itab IMPLEMENTATION.
                                                 CHANGING  tab = lt_row ).
 
     cl_abap_unit_assert=>assert_initial( lt_row ).
+
+  ENDMETHOD.
+
+  METHOD test_filter_elementary.
+
+    " a table with an elementary line type has no components - the filter
+    " matches against the whole line instead of deleting every row
+    DATA lt_str TYPE string_table.
+
+    lt_str = VALUE #( ( `London` ) ( `Wilmslow` ) ( `New York` ) ).
+
+    z2ui5_cl_a2ui5_context=>itab_filter_by_val( EXPORTING val = `London`
+                                                CHANGING  tab = lt_str ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 1
+                                        act = lines( lt_str ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `London`
+                                        act = lt_str[ 1 ] ).
 
   ENDMETHOD.
 
@@ -636,14 +686,17 @@ CLASS ltcl_msg IMPLEMENTATION.
 
     lt_range = VALUE #( ( sign = `I` option = `EQ` low = `X` )
                         ( sign = `I` option = `BT` low = `1` high = `9` )
-                        ( sign = `I` option = `CP` low = `A` ) ).
+                        ( sign = `I` option = `CP` low = `A` )
+                        ( sign = `E` option = `EQ` low = `Y` ) ).
 
     DATA(lt_token) = z2ui5_cl_a2ui5_context=>filter_get_token_t_by_range_t( lt_range ).
 
-    cl_abap_unit_assert=>assert_equals( exp = 3 act = lines( lt_token ) ).
+    cl_abap_unit_assert=>assert_equals( exp = 4 act = lines( lt_token ) ).
     cl_abap_unit_assert=>assert_equals( exp = `=X`    act = lt_token[ 1 ]-key ).
     cl_abap_unit_assert=>assert_equals( exp = `1...9` act = lt_token[ 2 ]-key ).
     cl_abap_unit_assert=>assert_equals( exp = `*A*`   act = lt_token[ 3 ]-key ).
+    " an excluding row renders negated, not like its including twin
+    cl_abap_unit_assert=>assert_equals( exp = `!(=Y)` act = lt_token[ 4 ]-key ).
 
     " tokens come back visible and editable so the UI5 MultiInput can render
     " and remove them

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -249,13 +249,18 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest2_view_destroy.
 
-    mo_action->ms_next-s_set-s_view_nest2-check_destroy = abap_true.
+    " wipe the whole slot (like popup_destroy) so a display( ) queued earlier
+    " in the same roundtrip does not resurrect the view after the destroy
+    mo_action->ms_next-s_set-s_view_nest2 = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
 
 
   METHOD z2ui5_if_client~nest2_view_display.
 
+    " like popup_display/popover_display: displaying cancels a destroy
+    " queued earlier in the same roundtrip
+    mo_action->ms_next-s_set-s_view_nest2-check_destroy  = abap_false.
     mo_action->ms_next-s_set-s_view_nest2-xml            = val.
     mo_action->ms_next-s_set-s_view_nest2-id             = id.
     mo_action->ms_next-s_set-s_view_nest2-method_destroy = method_destroy.
@@ -273,13 +278,18 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest_view_destroy.
 
-    mo_action->ms_next-s_set-s_view_nest-check_destroy = abap_true.
+    " wipe the whole slot (like popup_destroy) so a display( ) queued earlier
+    " in the same roundtrip does not resurrect the view after the destroy
+    mo_action->ms_next-s_set-s_view_nest = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
 
 
   METHOD z2ui5_if_client~nest_view_display.
 
+    " like popup_display/popover_display: displaying cancels a destroy
+    " queued earlier in the same roundtrip
+    mo_action->ms_next-s_set-s_view_nest-check_destroy  = abap_false.
     mo_action->ms_next-s_set-s_view_nest-xml            = val.
     mo_action->ms_next-s_set-s_view_nest-id             = id.
     mo_action->ms_next-s_set-s_view_nest-method_destroy = method_destroy.
@@ -297,7 +307,10 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~popover_destroy.
 
-    mo_action->ms_next-s_set-s_popover-check_destroy = abap_true.
+    " wipe the whole slot (like popup_destroy) - a plain flag would leave the
+    " xml of a popover_display( ) from the same roundtrip in place and the
+    " frontend would destroy and then re-open the popover
+    mo_action->ms_next-s_set-s_popover = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
 
@@ -349,6 +362,9 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~view_display.
 
+    " like popup_display/popover_display: displaying cancels a destroy
+    " queued earlier in the same roundtrip
+    mo_action->ms_next-s_set-s_view-check_destroy = abap_false.
     mo_action->ms_next-s_set-s_view-xml = val.
     mo_action->ms_next-s_set-s_view-switchdefaultmodelannouri = switch_default_model_anno_uri.
     mo_action->ms_next-s_set-s_view-switch_default_model_path = switch_default_model_path.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -196,10 +196,16 @@ CLASS ltcl_test_client IMPLEMENTATION.
     temp8 ?= mo_client.
 
     li_client = temp8.
+    li_client->popover_display( xml   = `<Popover/>`
+                                by_id = `btn1` ).
     li_client->popover_destroy( ).
 
     cl_abap_unit_assert=>assert_equals( exp = abap_true
                                         act = mo_action->ms_next-s_set-s_popover-check_destroy ).
+    " destroy after display in the same roundtrip wipes the slot - otherwise
+    " the frontend would destroy and then re-open the popover
+    cl_abap_unit_assert=>assert_initial( mo_action->ms_next-s_set-s_popover-xml ).
+    cl_abap_unit_assert=>assert_initial( mo_action->ms_next-s_set-s_popover-open_by_id ).
 
   ENDMETHOD.
 
@@ -224,6 +230,7 @@ CLASS ltcl_test_client IMPLEMENTATION.
     temp10 ?= mo_client.
 
     li_client = temp10.
+    li_client->nest_view_destroy( ).
     li_client->nest_view_display( val            = `<NestView/>`
                                   id             = `nest1`
                                   method_insert  = `addMidColumnPage`
@@ -235,6 +242,9 @@ CLASS ltcl_test_client IMPLEMENTATION.
                                         act = mo_action->ms_next-s_set-s_view_nest-id ).
     cl_abap_unit_assert=>assert_equals( exp = `addMidColumnPage`
                                         act = mo_action->ms_next-s_set-s_view_nest-method_insert ).
+    " display after destroy in the same roundtrip cancels the destroy
+    cl_abap_unit_assert=>assert_equals( exp = abap_false
+                                        act = mo_action->ms_next-s_set-s_view_nest-check_destroy ).
 
   ENDMETHOD.
 
@@ -245,10 +255,15 @@ CLASS ltcl_test_client IMPLEMENTATION.
     temp11 ?= mo_client.
 
     li_client = temp11.
+    li_client->nest_view_display( val           = `<NestView/>`
+                                  id            = `nest1`
+                                  method_insert = `addMidColumnPage` ).
     li_client->nest_view_destroy( ).
 
     cl_abap_unit_assert=>assert_equals( exp = abap_true
                                         act = mo_action->ms_next-s_set-s_view_nest-check_destroy ).
+    " destroy after display in the same roundtrip wipes the slot
+    cl_abap_unit_assert=>assert_initial( mo_action->ms_next-s_set-s_view_nest-xml ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_bind.clas.abap
@@ -231,6 +231,12 @@ CLASS z2ui5_cl_core_srv_bind IMPLEMENTATION.
     result = bind_tab_cell( iv_name = result
                             iv_val  = val ).
 
+    " same model-switch handling as in main( ) - otherwise a cell bind with
+    " switch_default_model = abap_true silently targets the default model
+    IF ms_config-switch_default_model = abap_true.
+      result = |http>{ result }|.
+    ENDIF.
+
     IF ms_config-path_only = abap_false.
       result = |\{{ result }\}|.
     ENDIF.

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -389,18 +389,10 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
       IF sy-subrc <> 0.
         CONTINUE.
       ENDIF.
+      " clearing the ref detaches the target data object from serialization;
+      " dereferencing and clearing the target itself is unnecessary (and was
+      " unreachable here anyway once the ref is cleared)
       CLEAR <dref>.
-
-      IF lr_attri2->name_ref IS NOT INITIAL.
-        CONTINUE.
-      ENDIF.
-
-      DATA(lv_path_dref_deref) = |MO_APP->{ lr_attri2->name }->*|.
-      ASSIGN (lv_path_dref_deref) TO FIELD-SYMBOL(<dref_deref>).
-      IF sy-subrc <> 0.
-        CONTINUE.
-      ENDIF.
-      CLEAR <dref_deref>.
     ENDLOOP.
 
   ENDMETHOD.
@@ -608,7 +600,9 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     WHILE line_exists( mt_attri->*[ check_dissolved = abap_false ] ) OR mt_attri->* IS INITIAL. "#EC CI_SORTSEQ
 
       lv_depth = lv_depth + 1.
-      IF lv_depth >= max_dissolve_depth.
+      " > not >=, so the pass with lv_depth = max_dissolve_depth still runs
+      " and the constant means what it says (5 dissolve passes, not 4)
+      IF lv_depth > max_dissolve_depth.
         " EXIT, not RETURN - attri_update_entry_refs must still run for the
         " already dissolved rows, otherwise name_ref stays empty and the
         " serialize/deserialize ref de-duplication silently breaks
@@ -776,8 +770,15 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
     LOOP AT mt_attri->* REFERENCE INTO DATA(lr_attri).
       READ TABLE lt_attri REFERENCE INTO DATA(lr_old) WITH KEY name = lr_attri->name. "#EC CI_SORTSEQ
       IF sy-subrc = 0.
-        lr_attri->bind        = lr_old->bind.
-        lr_attri->name_client = lr_old->name_client.
+        " restore everything update_model_attri stored on the bound attribute -
+        " dropping the mapper/filter refs here would silently serialize the
+        " attribute unmapped after a refresh
+        lr_attri->bind               = lr_old->bind.
+        lr_attri->name_client        = lr_old->name_client.
+        lr_attri->custom_mapper      = lr_old->custom_mapper.
+        lr_attri->custom_mapper_back = lr_old->custom_mapper_back.
+        lr_attri->custom_filter      = lr_old->custom_filter.
+        lr_attri->custom_filter_back = lr_old->custom_filter_back.
       ENDIF.
     ENDLOOP.
 

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -408,18 +408,21 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `          "VIEW MODEL",` && |\n| &&
              `          json(() => jsonSources.MODEL()),` && |\n| &&
              `        );` && |\n| &&
-             `        if (getResponseXml("S_POPUP")) {` && |\n| &&
+             `        // gate on the live slot too - the response only carries the XML in` && |\n| &&
+             `        // the roundtrip that opened the popup/popover, but the live model is` && |\n| &&
+             `        // exportable for as long as one is open` && |\n| &&
+             `        if (getResponseXml("S_POPUP") || ViewSlots.getView("POPUP")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "POPUP",` && |\n| &&
              `            xml(() => xmlSources.POPUP().xml),` && |\n| &&
              `          );` && |\n| &&
              `          push(` && |\n| &&
-             `            "POPUP MODEL",` && |\n| &&
+             `            "POPUP MODEL",` && |\n|.
+    result = result &&
              `            json(() => jsonSources.POPUP_MODEL()),` && |\n| &&
              `          );` && |\n| &&
-             `        }` && |\n|.
-    result = result &&
-             `        if (getResponseXml("S_POPOVER")) {` && |\n| &&
+             `        }` && |\n| &&
+             `        if (getResponseXml("S_POPOVER") || ViewSlots.getView("POPOVER")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "POPOVER",` && |\n| &&
              `            xml(() => xmlSources.POPOVER().xml),` && |\n| &&
@@ -712,8 +715,15 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `            templatingSource: false,` && |\n| &&
              `            activeNest1: Boolean(getViewContent(ViewSlots.getView("NEST"))),` && |\n| &&
              `            activeNest2: Boolean(getViewContent(ViewSlots.getView("NEST2"))),` && |\n| &&
-             `            activePopup: Boolean(getResponseXml("S_POPUP")),` && |\n| &&
-             `            activePopover: Boolean(getResponseXml("S_POPOVER")),` && |\n| &&
+             `            // The response only carries the fragment XML in the roundtrip` && |\n| &&
+             `            // that opened the popup/popover - also check the live slot so` && |\n| &&
+             `            // the tabs stay usable while one is open after later roundtrips.` && |\n| &&
+             `            activePopup: Boolean(` && |\n| &&
+             `              getResponseXml("S_POPUP") || ViewSlots.getView("POPUP"),` && |\n| &&
+             `            ),` && |\n| &&
+             `            activePopover: Boolean(` && |\n| &&
+             `              getResponseXml("S_POPOVER") || ViewSlots.getView("POPOVER"),` && |\n| &&
+             `            ),` && |\n| &&
              `          };` && |\n| &&
              `` && |\n| &&
              `          const oModel = new JSONModel(oData);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -331,7 +331,17 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `  // for network/timeout failures, where the request may never have reached` && |\n| &&
              `  // the server and app state is still intact).` && |\n| &&
              `  function show(response, title, options = {}) {` && |\n| &&
-             `    const full = response?.stack ? String(response.stack) : String(response);` && |\n| &&
+             `    // V8 stacks start with "Error: <message>", but Firefox/SpiderMonkey` && |\n| &&
+             `    // stacks are frame lines only - prepend the message when the stack does` && |\n| &&
+             `    // not already carry it, so the overlay never shows a stack without the` && |\n| &&
+             `    // actual error text.` && |\n| &&
+             `    const stack = response?.stack ? String(response.stack) : "";` && |\n| &&
+             `    const message = String(response);` && |\n| &&
+             `    const full = stack` && |\n| &&
+             `      ? stack.includes(message)` && |\n| &&
+             `        ? stack` && |\n| &&
+             `        : ``${message}\n${stack}``` && |\n| &&
+             `      : message;` && |\n| &&
              `    // Rendered via textContent, so the truncation marker is plain text (an` && |\n| &&
              `    // HTML comment would show up literally).` && |\n| &&
              `    const errorMessage =` && |\n| &&
@@ -407,7 +417,8 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    actionsDiv.appendChild(refreshBtn);` && |\n| &&
              `` && |\n| &&
              `    const logoutBtn = document.createElement("button");` && |\n| &&
-             `    logoutBtn.type = "button";` && |\n| &&
+             `    logoutBtn.type = "button";` && |\n|.
+    result = result &&
              `    logoutBtn.textContent = "Logout";` && |\n| &&
              `    logoutBtn.style.cssText = btnStyle;` && |\n| &&
              `    logoutBtn.addEventListener("click", () => handleLogout());` && |\n| &&
@@ -417,8 +428,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    errorContainer.appendChild(headerDiv);` && |\n| &&
              `` && |\n| &&
              `    // Keep keyboard focus inside the overlay: Tab cycles through the action` && |\n| &&
-             `    // buttons instead of escaping into the broken page behind it. The button` && |\n|.
-    result = result &&
+             `    // buttons instead of escaping into the broken page behind it. The button` && |\n| &&
              `    // set is complete here (all appended above), so resolve first/last once` && |\n| &&
              `    // rather than re-querying the DOM on every Tab press.` && |\n| &&
              `    const trapButtons = actionsDiv.querySelectorAll("button");` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -813,13 +813,14 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        return;` && |\n| &&
              `      }` && |\n| &&
              `` && |\n| &&
-             `      const separator = path.includes("?") ? "&" : "?";` && |\n| &&
-             `      const bspKill = ``${path}${separator}sap-sessioncmd=logoff``;` && |\n| &&
+             `      // location.pathname never contains a query string, so "?" always starts` && |\n| &&
+             `      // the sap-sessioncmd parameter` && |\n| &&
+             `      const bspKill = ``${path}?sap-sessioncmd=logoff``;` && |\n| &&
              `      let done = false;` && |\n| &&
              `      let frame;` && |\n| &&
-             `      const finish = () => {` && |\n| &&
-             `        if (done) return;` && |\n|.
+             `      const finish = () => {` && |\n|.
     result = result &&
+             `        if (done) return;` && |\n| &&
              `        done = true;` && |\n| &&
              `        // Remove the hidden BSP-kill iframe. On a successful logout the page` && |\n| &&
              `        // navigates away and unload cleans up anyway; but if redirectToLogout` && |\n| &&
@@ -1218,9 +1219,9 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const editor = ViewSlots.byId("POPUP", "imageEditor");` && |\n| &&
              `        if (editor) image = editor.getImagePngDataURL();` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n| &&
-             `      }` && |\n|.
+             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n|.
     result = result &&
+             `      }` && |\n| &&
              `      ViewSlots.destroy("POPUP");` && |\n| &&
              `      oController.eB(["SAVE"], image);` && |\n| &&
              `    }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_messagemanager_js.clas.abap
@@ -84,7 +84,7 @@ CLASS z2ui5_cl_app_messagemanager_js IMPLEMENTATION.
              `        if (this.getProperty("checkInit")) return;` && |\n| &&
              `        const messaging = Lib.getMessaging?.();` && |\n| &&
              `        if (!messaging) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
+             `        this.setProperty("checkInit", true, true);` && |\n| &&
              `        this._messaging = messaging;` && |\n| &&
              `        const view = ViewSlots.getView(` && |\n| &&
              `          ViewSlots.containingSlotKey(this) ?? "MAIN",` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_multiinputext_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_multiinputext_js.clas.abap
@@ -80,7 +80,7 @@ CLASS z2ui5_cl_app_multiinputext_js IMPLEMENTATION.
              `          this.getProperty("MultiInputId"),` && |\n| &&
              `        );` && |\n| &&
              `        if (!input || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
+             `        this.setProperty("checkInit", true, true);` && |\n| &&
              `        try {` && |\n| &&
              `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
              `          // Custom validator: turn any free-text entry into a Token where` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_router_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_router_js.clas.abap
@@ -349,6 +349,12 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `          // launchpad.` && |\n| &&
              `          const newUrl = ``${window.location.pathname}${window.location.search}#${getRawHash()}${PARAMS.SET_PUSH_STATE}``;` && |\n| &&
              `          history.pushState(null, "", newUrl);` && |\n| &&
+             `          // The pushed hash IS the desired URL - stop here. The cleanup below` && |\n| &&
+             `          // is a no-op while hasher's cached hash is empty (legacy mode), but` && |\n| &&
+             `          // with routing on the cache holds the app route, so replaceHash("")` && |\n| &&
+             `          // would count as a change and wipe both the route and the suffix` && |\n| &&
+             `          // pushed one line above.` && |\n| &&
+             `          return;` && |\n| &&
              `        }` && |\n| &&
              `        // The live URL must match the format the copy link` && |\n| &&
              `        // (FrontendAction.evClipboardAppState) writes and the backend restore` && |\n| &&
@@ -411,14 +417,14 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `      appOf,` && |\n| &&
              `      draftOf,` && |\n| &&
              `      navTo,` && |\n| &&
-             `      navToApp,` && |\n| &&
+             `      navToApp,` && |\n|.
+    result = result &&
              `      onHashChanged,` && |\n| &&
              `      sync,` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&
              `);` && |\n| &&
-             `` && |\n|.
-    result = result &&
+             `` && |\n| &&
               ``.
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_app_smartmultiinpu_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_smartmultiinpu_js.clas.abap
@@ -136,7 +136,7 @@ CLASS z2ui5_cl_app_smartmultiinpu_js IMPLEMENTATION.
              `          this.getProperty("multiInputId"),` && |\n| &&
              `        );` && |\n| &&
              `        if (!input || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
+             `        this.setProperty("checkInit", true, true);` && |\n| &&
              `        try {` && |\n| &&
              `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
              `          input.attachInnerControlsCreated(` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_uploadsetext_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_uploadsetext_js.clas.abap
@@ -111,7 +111,7 @@ CLASS z2ui5_cl_app_uploadsetext_js IMPLEMENTATION.
              `          this.getProperty("uploadSetId"),` && |\n| &&
              `        );` && |\n| &&
              `        if (!uploadSet || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true);` && |\n| &&
+             `        this.setProperty("checkInit", true, true);` && |\n| &&
              `        try {` && |\n| &&
              `          uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));` && |\n| &&
              `          uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -108,8 +108,14 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      // named phases: display pending fragments/views, then update the` && |\n| &&
              `      // browser history/hash.` && |\n| &&
              `      async _processAfterRendering() {` && |\n| &&
+             `        // Hoisted out of the try block: the finally below must run the` && |\n| &&
+             `        // follow-up JS of exactly THIS response. Re-reading the shared` && |\n| &&
+             `        // AppState.state.oResponse there would - after a parallel request` && |\n| &&
+             `        // replaced it during the awaits - consume (and clear) the newer` && |\n| &&
+             `        // response's snippets before its own render.` && |\n| &&
+             `        let oResponse;` && |\n| &&
              `        try {` && |\n| &&
-             `          const oResponse = AppState.state.oResponse;` && |\n| &&
+             `          oResponse = AppState.state.oResponse;` && |\n| &&
              `          if (oResponse._processed) return;` && |\n| &&
              `          oResponse._processed = true;` && |\n| &&
              `` && |\n| &&
@@ -141,7 +147,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          // run the follow-up JS snippets the backend asked for. Doing it here` && |\n| &&
              `          // - rather than as an early microtask - guarantees render-dependent` && |\n| &&
              `          // actions like SET_FOCUS find their target control in the DOM.` && |\n| &&
-             `          this._runPendingCustomJs(AppState.state.oResponse);` && |\n| &&
+             `          this._runPendingCustomJs(oResponse);` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -411,14 +417,14 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      // it; the separator defaults to " > ".` && |\n| &&
              `      textPath(oControl, sSeparator) {` && |\n| &&
              `        return Lib.getTextPath(oControl, sSeparator);` && |\n| &&
-             `      },` && |\n| &&
+             `      },` && |\n|.
+    result = result &&
              `` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&
              `      // eB = "event backend": triggers a backend roundtrip with arguments.` && |\n| &&
              `      // The name is part of the protocol - backend-generated view XML binds` && |\n| &&
              `      // events to eB/eF - and must not be renamed.` && |\n| &&
-             `      //` && |\n|.
-    result = result &&
+             `      //` && |\n| &&
              `      // args[0] is the event array built by the backend (get_event):` && |\n| &&
              `      //   [0] event name` && |\n| &&
              `      //   [1] reserved placeholder, always false` && |\n| &&
@@ -603,9 +609,12 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        });` && |\n| &&
              `` && |\n| &&
              `        // Guard against the app being destroyed during the await above.` && |\n| &&
+             `        // oModel covers oViewModel too when they are the same object (no` && |\n| &&
+             `        // switchPath); with an OData default model both must go.` && |\n| &&
              `        if (!Lib.isAlive(AppState.state.oApp)) {` && |\n| &&
              `          oView.destroy();` && |\n| &&
-             `          if (switchPath) oModel.destroy();` && |\n| &&
+             `          oModel.destroy();` && |\n| &&
+             `          if (switchPath) oViewModel.destroy();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
@@ -623,7 +632,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          ViewSlots.getView("MAIN")` && |\n| &&
              `        ) {` && |\n| &&
              `          oView.destroy();` && |\n| &&
-             `          if (switchPath) oModel.destroy();` && |\n| &&
+             `          oModel.destroy();` && |\n| &&
+             `          if (switchPath) oViewModel.destroy();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -299,7 +299,9 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result)        TYPE string.
 
-  "! obsolete - behaves like _bind (both two-way), please use _bind
+  "! obsolete - behaves like _bind (both two-way), please use _bind;
+  "! note: _bind has no custom_mapper_back/custom_filter_back parameters -
+  "! keep using _bind_edit while you pass those
   METHODS _bind_edit
     IMPORTING
       val                  TYPE data


### PR DESCRIPTION
# Description

This PR contains multiple small bug fixes and improvements across the codebase:

### Filter & Table Handling
- **Excluding filter rows**: Now render with negation syntax `!(=Y)` instead of matching their including twin, making the filter's real meaning clear in the UI
- **Elementary line types**: Fixed `itab_filter_by_val` to match against whole lines for tables without components (e.g., `string_table`) instead of deleting every row
- **Stale transpiler note**: Rewrote the header comment that contradicted the case-sensitive match branch

### URL Parameter Parsing
- **Lowercase hex encoding**: Now correctly decodes `%3d` (lowercase) the same way as `%3D` per RFC 3986
- **sap-startup-params unwrapping**: Fixed to work when it's the first/only query parameter (typical FLP target mapping) by prepending `&` before searching

### Type Checking
- **Character-like types**: Fixed `rtti_check_clike` to properly recognize `n` (numeric), `d` (date), and `t` (time) types as character-like, not just `c` and `string`
- **Concrete type kinds**: Replaced generic formal parameter kinds (`typekind_clike`, `typekind_csequence`) with concrete kinds that can actually be returned for data objects
- **itab_get_by_struc**: Skip structure/reference components that cannot be moved into the string value (unhandled move error at runtime)

### View Lifecycle Management
- **Display/destroy ordering**: Fixed `view_display`, `nest_view_display`, `nest2_view_display` to cancel a destroy queued earlier in the same roundtrip by resetting `check_destroy = abap_false` (like popup/popover already did)
- **Slot wiping on destroy**: Changed `popover_destroy`, `nest_view_destroy`, `nest2_view_destroy` to wipe the entire slot (like `popup_destroy`) so a display queued earlier doesn't resurrect the view
- **Response processing**: Fixed `_processAfterRendering` to hoist `oResponse` out of the try block so the finally clause runs the follow-up JS of the correct response, not a newer one from a parallel request
- **View build discard**: Destroy the tracked JSON model too when a superseded or dead-app view build is discarded

### Model & Binding
- **Attribute restoration**: Fixed model refresh to restore the custom mapper/filter references too, not just bind and name_client, preventing silent unmapped serialization
- **Cell binding with model switch**: Added the same model-switch handling as the main binding path so cell binds with `switch_default_model = abap_true` no longer silently target the default model
- **Dissolve depth**: Fixed the off-by-one so `max_dissolve_depth` means 5 passes, not 4; removed an unreachable deref-clear block in the srtti save path
- **Reference safety**: `unassign_data`/`unassign_object` fail soft on an unbound ref instead of dumping

### Developer Tools & Error Handling
- **Popup/popover tabs and export**: Check the live view slots in addition to the response XML, so the model tabs and export sections stay usable while a popup/popover is open after later roundtrips
- **Error stack display**: Prepend the message to Firefox/SpiderMonkey stacks (which are frame-only) so the error text is always visible in the overlay, copy text and Error tab
- **Logout URL**: Dropped the dead `pathname.includes("?")` ternary (`location.pathname` never contains a query string)

### Router & Navigation
- **Push state cleanup**: `Router.sync` stops after applying `SET_PUSH_STATE` - with routing enabled the trailing `replaceHash("")` cleanup counted as a change and wiped both the app route and the just-pushed hash suffix (covered by a new spec)

### Code Quality
- Renderless custom controls set `checkInit` with the suppress-invalidate flag like every other internal flag write
- Replaced magic string `"U"` with constant `cv_objectdescr_public` for visibility checks
- `_bind_edit` abapdoc documents that `_bind` has no `*_back` parameters
- `src/01/03/` regenerated exclusively via `npm run app2abap`

## How to test

- `npm run verify` passes (abaplint, downport, transpile, ABAP unit tests)
- `npx playwright test -c node/playwright-unit.config.js` - all 333 JS specs pass (incl. new router push-state spec)
- ESLint and UI5 linter clean
- Unit tests added for: sap-startup-params positions and lowercase encoding, elementary line type filtering, n/d/t clike checks, excluding filter row negation, display/destroy ordering in the same roundtrip

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively (abapdoc comment only)
- [x] Changes were made via abapGit: no

https://claude.ai/code/session_0132odthfALtudrf5dfEaeuj