### PR TITLE
Normalize parameter names in context class to framework conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [abap2UI5](https://github.com/abap2UI5/abap2UI5) | Core framework (this repo) |
 | [samples](https://github.com/abap2UI5/samples) | Sample applications and usage examples |
 | [docs](https://github.com/abap2UI5/docs) | Project documentation |
-| [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of the vendored copies in `src/00/03/` (see "Vendored Utility Classes") |
+| [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of `src/00/03/` (see "Utilities") |
 
 > **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle, deprecated controls — see the single canonical guide at <https://abap2ui5.github.io/docs/advanced/agent.html>.
 
@@ -114,36 +114,45 @@ src/
 └── 99/   FROZEN - do not change. XML view builder (z2ui5_cl_xml_view / _cc, top level, pending replacement by ai-demokit) + retired z2ui5_cl_util* classes (99/01) and built-in popups (99/02). Kept for downstream compatibility only
 ```
 
-- **Layer 0 (`src/00/`)** — Self-contained utility libraries. AJSON (`src/00/01/`) handles JSON; S-RTTI (`src/00/02/`) provides runtime type reflection — both are mirrored from external projects, DO NOT MODIFY. `src/00/03/` holds the context/HTTP abstractions (`z2ui5_cl_a2ui5_context`, `z2ui5_cl_a2ui5_http`, `z2ui5_cl_a2ui5_json_fltr`, `z2ui5_cx_a2ui5_error`), all but `_json_fltr` vendored from abap-util (see "Vendored Utility Classes"). The `noIssues` flag in `abaplint.jsonc` suppresses lint warnings for all of `src/00`.
+- **Layer 0 (`src/00/`)** — Self-contained utility libraries. AJSON (`src/00/01/`) handles JSON; S-RTTI (`src/00/02/`) provides runtime type reflection — both are mirrored from external projects, DO NOT MODIFY. `src/00/03/` holds the context/HTTP abstractions (`z2ui5_cl_a2ui5_context`, `z2ui5_cl_a2ui5_http`, `z2ui5_cl_a2ui5_json_fltr`, `z2ui5_cx_a2ui5_error`), all but `_json_fltr` vendored from abap-util (see "Utilities"). The `noIssues` flag in `abaplint.jsonc` suppresses lint warnings for all of `src/00`.
 - **Layer 1 (`src/01/`)** — Core engine. Session drafts (`src/01/01/`), request processing, event routing, data binding, model management, app lifecycle (`src/01/02/`). Embedded UI5 frontend resources as ABAP string constants (`src/01/03/` — auto-generated, never manually edit).
 - **Layer 2 (`src/02/`)** — Public API. The stable contract for app developers. Includes the exit/customization framework.
 - **Package `src/99/` — frozen in its entirety. Do not change anything under `src/99/`.** Everything here exists only so downstream apps keep compiling:
   - **Package top level** — the fluent XML view builder (`z2ui5_cl_xml_view`, `z2ui5_cl_xml_view_cc`). Still the API every app calls, so it stays readable and installed, but it is **frozen pending replacement** by the builder from [ai-demokit](https://github.com/abap2UI5/ai-demokit), which becomes the new standard. Do **not** add wrapper methods, controls or parameters to it, and do not refactor it — that work goes into the replacement, not here.
-  - `src/99/01/` — retired utility classes (`z2ui5_cl_util`, `_db`, `_ext`, `_http`, `_log`, `_msg`, `_range`, `_xml`, `z2ui5_cx_util_error`, table `z2ui5_t_91`), replaced by the `z2ui5_cl_a2ui5_*` classes in `src/00/03/`.
-  - `src/99/02/` — the built-in popup/dialog apps (`z2ui5_cl_pop_*`, formerly `src/02/01/`).
+  - `src/99/01/` — the legacy utility classes (see "Utilities").
+  - `src/99/02/` — the built-in popup/dialog apps (`z2ui5_cl_pop_*`, formerly `src/02/01/`), obsolete and to be replaced by the [popups addon](https://github.com/abap2UI5-addons/popups).
 
   Do not add new consumers of anything under `src/99/`. All of it is covered by the `noIssues` lint exemption and is out of scope for reviews and audits.
 
-### Vendored Utility Classes (`src/00/03/` ← abap-util)
+### Utilities — the context class is the only door
 
-Platform-abstraction utilities (RTTI, conversions, UUID, messages, HTTP, environment detection, …) come from the **[abap-util](https://github.com/abap-util/abap-util) master catalog**, which contains all utility classes with all methods. abap2UI5 does **not** depend on abap-util at install time — abapGit has no dependency management, and abap2UI5 must stay "clone and go". Instead, `src/00/03/` contains a **renamed copy** of the classes the framework needs; the context class is additionally **trimmed to the methods the framework actually uses**:
+**This section is the single source of truth for how the framework reaches system and platform functionality. Everything about utilities is settled here; nowhere else in this file repeats it.**
 
-| Copy in this repo (`src/00/03/`) | Master in abap-util |
+**Rule: every system- and environment-specific function is called through a method of `z2ui5_cl_a2ui5_context` (`src/00/03/`).** RTTI, conversions, UUID, messages, XML/transformations, timestamps, base64, database rollback, environment detection — framework code never calls `cl_abap_*`, a function module, or an environment-specific API directly. The dependency on every SAP standard object lives in exactly one class, which is what makes the framework portable across NW 7.02 / Standard ABAP / ABAP Cloud and transpilable to JS. Environment branching happens inside that class via `check_abap_cloud( )` and dynamic calls, so the framework compiles on every target.
+
+**When the function you need is missing, in this order:**
+
+1. **Look in [abap-util](https://github.com/abap-util/abap-util) first.** It is the master catalog and holds all utility methods, unit-tested and linted for all three targets.
+2. **If it exists there: copy it into `z2ui5_cl_a2ui5_context`** — with its private helper closure, renamed to this repo's namespace. Do not re-implement what the catalog already has.
+3. **If it does not exist: write a new method** directly in `z2ui5_cl_a2ui5_context`. There is no upstream-first step and nothing to coordinate — this copy leads, abap-util follows.
+4. **Separately and periodically, an AI syncs back:** it compares the context class against abap-util and merges what was added or fixed here into the catalog, so the master stays the superset for every other project. It diffs method *bodies*, not just names — see [abap-util's AGENTS.md](https://github.com/abap-util/abap-util/blob/main/AGENTS.md).
+
+**Consequences of that process:**
+- **`z2ui5_cl_a2ui5_context` is not a read-only mirror — edit it freely.** Add methods, change existing ones, extract helpers, refactor. (Only the AJSON/S-RTTI mirrors in `src/00/01` and `src/00/02` are off-limits.)
+- **Keep what you add generic.** Framework-specific logic belongs in the core `z2ui5_cl_core_*` classes; the sync harvests this class into a catalog other projects consume.
+- **Symbols marked `FROZEN-ONLY`** in the class have no caller in `src/00`–`src/02`. They exist only because `src/99` still calls them and go when `src/99` goes — do not add new callers on them.
+
+**What is vendored, and what is legacy:**
+
+| Class | Status |
 |---|---|
-| `z2ui5_cl_a2ui5_context` | `zabaputil_cl_util_context` (trimmed to the used methods) |
-| `z2ui5_cl_a2ui5_http` | `zabaputil_cl_util_http` (copied as-is) |
-| `z2ui5_cx_a2ui5_error` | `zabaputil_cx_error` (copied as-is) |
+| `src/00/03/z2ui5_cl_a2ui5_context` | Vendored from `zabaputil_cl_util_context`, trimmed to the methods used here. **The one class to use and to extend** |
+| `src/00/03/z2ui5_cl_a2ui5_http` | Vendored from `zabaputil_cl_util_http`, copied as-is — leave it alone unless a fix is genuinely needed |
+| `src/00/03/z2ui5_cx_a2ui5_error` | Vendored from `zabaputil_cx_error`, copied as-is — same |
+| `src/00/03/z2ui5_cl_a2ui5_json_fltr` | Framework-owned, no abap-util master |
+| `src/99/01/z2ui5_cl_util*`, `z2ui5_cx_util_error`, `z2ui5_t_91` | **Legacy.** Superseded by the classes above. They must stay so downstream apps keep compiling, but must never be used, called from new code, or changed |
 
-(`z2ui5_cl_a2ui5_json_fltr` is framework-owned and has no abap-util master.)
-
-**How the copies are maintained:**
-- **`z2ui5_cl_a2ui5_context` is not a read-only mirror — edit it directly.** Add methods, change existing ones, extract private helpers, refactor: all here, with no upstream-first step. The direction is local → upstream; the master catalog harvests your changes **from** this copy. (Only the AJSON/S-RTTI mirrors in `src/00/01` and `src/00/02` are off-limits.) If a method you need already exists in abap-util, copy it from there with its helper closure instead of re-implementing it.
-- **Class-level selection, method-level trimming for the context class only.** The other vendored classes are copied as-is; leave `z2ui5_cl_a2ui5_http` / `z2ui5_cx_a2ui5_error` alone unless a fix is genuinely needed.
-- **Keep what you add generic.** Framework-specific logic belongs in the core `z2ui5_cl_core_*` classes — the sync harvests this class into a catalog other projects consume.
-- **Periodic AI sync-back:** every few weeks an AI merges what was added or fixed here back into abap-util. It diffs method *bodies*, not just names — see the sync rules in [abap-util's AGENTS.md](https://github.com/abap-util/abap-util/blob/main/AGENTS.md).
-- **The trim is not driven by the core engine alone.** Symbols marked `FROZEN-ONLY` in the class have no caller in `src/00`–`src/02` and exist only because the frozen `src/99` still calls them; they go when `src/99` goes. The class header explains it — do not add new callers on them.
-
-The same pattern is used elsewhere in the ecosystem (e.g. [popups](https://github.com/abap2UI5-addons/popups) with `z2ui5_cl_popup_context`), each with its own namespace and method subset.
+abap2UI5 does **not** depend on abap-util at install time: abapGit has no dependency management, and abap2UI5 must stay "clone and go". Hence renamed copies instead of a dependency. The same principle applies in the other repos of the ecosystem — [abap2UI5-addons/popups](https://github.com/abap2UI5-addons/popups) has its own `z2ui5_cl_popup_context` with its own namespace and method subset, and is the designated successor of the obsolete built-in popups in `src/99/02/`.
 
 ### Data Binding
 
@@ -305,7 +314,7 @@ This project follows the [SAP Clean ABAP styleguide](https://github.com/SAP/styl
   CATCH cx_root ##NO_HANDLER.
   ```
 - **API parameter types:** Use `TYPE clike` for string/char input parameters in public API methods (allows both string and char literals without conversion)
-- **Utility access:** Framework utilities live in `z2ui5_cl_a2ui5_context` (`src/00/03/`; see "Vendored Utility Classes"). Environment-specific behavior (ABAP Cloud vs. standard ABAP) is branched inside this class via `check_abap_cloud( )` and dynamic calls, so it compiles on all targets. The former utility classes (`z2ui5_cl_util`, `z2ui5_cl_util_ext`, …) are retired in `src/99/` — do not use them in framework code
+- **Utility access:** every system- and environment-specific call goes through `z2ui5_cl_a2ui5_context` — never directly to `cl_abap_*` or a function module. Full rules in "Utilities — the context class is the only door"
   ```abap
   z2ui5_cl_a2ui5_context=>uuid_get_c32( ).
   ```
@@ -413,7 +422,7 @@ Config files: `eslint.config.mjs`, `ui5lint.config.mjs`, `.prettierrc`, `.editor
 | `src/01/02/z2ui5_cl_core_srv_model.clas.abap` | JSON model management |
 | `src/01/02/z2ui5_cl_core_srv_event.clas.abap` | Event registration and payload assembly |
 | `src/01/01/z2ui5_cl_core_srv_draft.clas.abap` | Draft/session persistence |
-| `src/00/03/z2ui5_cl_a2ui5_context.clas.abap` | Framework utility/context class (RTTI, conversions, UUID, messages, environment detection) — see "Vendored Utility Classes" |
+| `src/00/03/z2ui5_cl_a2ui5_context.clas.abap` | The single door to system/platform functionality — see "Utilities" |
 | `app/webapp/core/AppState.js` | Owner of the shared frontend state + `z2ui5.*` globals inventory |
 | `app/webapp/core/ViewSlots.js` | View-slot access layer (get/set/byId/destroy per slot) |
 | `app/webapp/core/Lib.js` | Shared frontend helpers |
@@ -444,7 +453,7 @@ test: add unit tests for utility class
 
 These rules apply to AI assistants **modifying the framework** (this repo). For AI assistants **building apps**, see <https://abap2ui5.github.io/docs/advanced/agent.html> instead.
 
-1. **Do not modify `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI)** — mirrored from external projects, synced by automated workflows. **`src/00/03/z2ui5_cl_a2ui5_context` is a different case: edit it directly** — it is vendored but leads its upstream, so there is no upstream-first step (see "Vendored Utility Classes"). **Do not touch `src/99/` — the entire package is frozen**, including the `z2ui5_cl_xml_view` / `_cc` builders at its top level. Read them to answer questions; never change, extend or refactor them, and never add new consumers. The builder is being replaced by the ai-demokit version; that work does not happen in this repository.
+1. **Do not modify `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI)** — mirrored from external projects, synced by automated workflows. `src/00/03/` is the opposite case: see "Utilities — the context class is the only door", which settles everything about utilities. **Do not touch `src/99/` — the entire package is frozen**, including the `z2ui5_cl_xml_view` / `_cc` builders at its top level. Read them to answer questions; never change, extend or refactor them, and never add new consumers. The builder is being replaced by the ai-demokit version; that work does not happen in this repository.
 2. **NEVER manually edit any ABAP file under `src/01/03/`.** These files are the embedded frontend (auto-generated from `app/webapp/` via the `app2abap` job — see `.github/app2abap/trans2abap.js` and the `create_app2abap.yaml` workflow). The **only** allowed way to update them is:
    - Change the source under `app/webapp/`
    - Run **`npm run app2abap`** locally (or trigger the `create_app2abap.yaml` workflow). This single command runs the full pipeline in the correct order — `npm --prefix app run format` (Prettier) → `npm run auto_app2abap` (generate) → `npm run auto_abaplint` (normalize) — exactly as CI does. Running `auto_app2abap` on its own produces **un-normalized** ABAP that differs from the committed form in *every* `src/01/03/` file (alignment/whitespace drift); the `auto_abaplint` step reverts that drift so only the files whose `app/webapp/` source actually changed remain modified.
@@ -492,7 +501,7 @@ The following items may look like gaps but are intentional design choices:
 
 When reviewing, auditing, or proposing improvements to this repository, treat the following as **out of scope** — do not report findings in them, refactor them, or otherwise invest in them:
 
-- **All of `src/99/` — the whole package, without exception.** The retired `z2ui5_cl_util*` classes (`src/99/01/`), the built-in popups (`src/99/02/`) and the XML view builder at the package top level (`z2ui5_cl_xml_view` / `_cc`) are all **frozen**: the first two are scheduled for removal, the builder is pending replacement by the ai-demokit version. They exist only so downstream apps keep compiling. Do **not** report, harden, refactor or extend anything under `src/99/`. For example, the unescaped single quote in the dynamic `WHERE` builders of `z2ui5_cl_util_ext` (`tab_get_where_by_dfies`, `changdoc_read`, the `tr_*` helpers) is a **non-issue** here, and the ~16K-line size of `z2ui5_cl_xml_view` is not a finding either.
+- **All of `src/99/` — the whole package, without exception.** The legacy `z2ui5_cl_util*` classes (`src/99/01/`), the built-in popups (`src/99/02/`) and the XML view builder at the package top level (`z2ui5_cl_xml_view` / `_cc`) are all **frozen**. They exist only so downstream apps keep compiling: the utility classes stay indefinitely for that reason (see "Utilities"), the popups are to be replaced by the [popups addon](https://github.com/abap2UI5-addons/popups), the builder by the ai-demokit version. Do **not** report, harden, refactor or extend anything under `src/99/`. For example, the unescaped single quote in the dynamic `WHERE` builders of `z2ui5_cl_util_ext` (`tab_get_where_by_dfies`, `changdoc_read`, the `tr_*` helpers) is a **non-issue** here, and the ~16K-line size of `z2ui5_cl_xml_view` is not a finding either.
 - **The `_bind` / `_bind_edit` "mass assignment" question** — two-way binding was **intentionally unified** (see "Data Binding" above): `_bind` and `_bind_edit` behave identically and every bound attribute is writable from the client `MODEL`. `_bind_edit` is a **compatibility-only alias of `_bind`** and is slated for **removal (~1 year out)**. A proposal to split them again — a separate "editable" flag so `_bind` becomes display-only while only `_bind_edit` writes back — is explicitly **rejected**: it would reintroduce exactly the distinction that was deliberately removed and break the many apps that rely on `_bind` round-tripping. Treat "an attribute exposed via `_bind` is writable from the client model" as **by design**, not a vulnerability.
 - **A secondary index on `Z2UI5_T_01-TIMESTAMPL`** — see the draft-cleanup entry above: rejected as not worth the per-write index-maintenance cost.
 - **The "no app-start authorization" question** — see the app-start entry under "Design Decisions" above. That any authenticated user reaching the ICF node can instantiate any `z2ui5_if_app` class is **by design**: authorization lives in the app's own `z2ui5_if_app~main` (like a transaction guarding itself), not in a framework `AUTHORITY-CHECK` or a `check_app_start_allowed` exit. Do not report the missing central hook as a vulnerability, and do not add one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [abap2UI5](https://github.com/abap2UI5/abap2UI5) | Core framework (this repo) |
 | [samples](https://github.com/abap2UI5/samples) | Sample applications and usage examples |
 | [docs](https://github.com/abap2UI5/docs) | Project documentation |
-| [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities (all classes, all methods) — `src/00/03/` holds renamed copies of the classes the framework needs, with the context class trimmed to the used methods (see "Vendored utility classes" below) |
+| [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of the vendored copies in `src/00/03/` (see "Vendored Utility Classes") |
 
 > **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle, deprecated controls — see the single canonical guide at <https://abap2ui5.github.io/docs/advanced/agent.html>.
 
@@ -114,7 +114,7 @@ src/
 └── 99/   FROZEN - do not change. XML view builder (z2ui5_cl_xml_view / _cc, top level, pending replacement by ai-demokit) + retired z2ui5_cl_util* classes (99/01) and built-in popups (99/02). Kept for downstream compatibility only
 ```
 
-- **Layer 0 (`src/00/`)** — Self-contained utility libraries. AJSON (`src/00/01/`) handles JSON; S-RTTI (`src/00/02/`) provides runtime type reflection — both are mirrored from external projects, DO NOT MODIFY. `src/00/03/` holds the context/HTTP abstractions (`z2ui5_cl_a2ui5_context`, `z2ui5_cl_a2ui5_http`, `z2ui5_cl_a2ui5_json_fltr`, `z2ui5_cx_a2ui5_error`) — `z2ui5_cl_a2ui5_context`, `z2ui5_cl_a2ui5_http` and `z2ui5_cx_a2ui5_error` are **vendored copies** from the [abap-util](https://github.com/abap-util/abap-util) master catalog (see "Vendored utility classes" below). The `noIssues` flag in `abaplint.jsonc` suppresses lint warnings for all of `src/00`.
+- **Layer 0 (`src/00/`)** — Self-contained utility libraries. AJSON (`src/00/01/`) handles JSON; S-RTTI (`src/00/02/`) provides runtime type reflection — both are mirrored from external projects, DO NOT MODIFY. `src/00/03/` holds the context/HTTP abstractions (`z2ui5_cl_a2ui5_context`, `z2ui5_cl_a2ui5_http`, `z2ui5_cl_a2ui5_json_fltr`, `z2ui5_cx_a2ui5_error`), all but `_json_fltr` vendored from abap-util (see "Vendored Utility Classes"). The `noIssues` flag in `abaplint.jsonc` suppresses lint warnings for all of `src/00`.
 - **Layer 1 (`src/01/`)** — Core engine. Session drafts (`src/01/01/`), request processing, event routing, data binding, model management, app lifecycle (`src/01/02/`). Embedded UI5 frontend resources as ABAP string constants (`src/01/03/` — auto-generated, never manually edit).
 - **Layer 2 (`src/02/`)** — Public API. The stable contract for app developers. Includes the exit/customization framework.
 - **Package `src/99/` — frozen in its entirety. Do not change anything under `src/99/`.** Everything here exists only so downstream apps keep compiling:
@@ -137,13 +137,13 @@ Platform-abstraction utilities (RTTI, conversions, UUID, messages, HTTP, environ
 (`z2ui5_cl_a2ui5_json_fltr` is framework-owned and has no abap-util master.)
 
 **How the copies are maintained:**
-- **Editing `z2ui5_cl_a2ui5_context` is safe and problem-free — do it without hesitation.** It is *not* a read-only mirror: add new methods, change existing ones, extract private helpers, refactor duplicated blocks — all directly in this copy, with no upstream-first step and nothing to coordinate. The master catalog pulls your changes **from** here (local → upstream), so this copy leads and abap-util follows. (Only the AJSON/S-RTTI mirrors in `src/00/01` and `src/00/02` are truly off-limits.)
-- **Class-level selection, method-level trimming for the context class only.** The framework vendors just the classes it needs; `z2ui5_cl_a2ui5_context` carries only the methods the framework uses (plus the private helpers those methods need), while the other vendored classes are copied as-is.
-- **New methods are added locally.** When the framework needs a utility method the context class doesn't have yet, write it directly into `z2ui5_cl_a2ui5_context`. If the method already exists in abap-util, copy it from there (with its helper closure) instead of re-implementing it.
-- **Periodic AI sync-back:** every few weeks an AI compares abap-util with all consumers and merges methods that were added locally back into abap-util, so the master catalog stays the superset of all methods and other projects can reuse them.
-- **Framework-specific logic does not belong in the context class.** Only generic, reusable utilities go there (they will be harvested into abap-util by the sync); abap2UI5-specific helpers live in the appropriate core class instead.
+- **`z2ui5_cl_a2ui5_context` is not a read-only mirror — edit it directly.** Add methods, change existing ones, extract private helpers, refactor: all here, with no upstream-first step. The direction is local → upstream; the master catalog harvests your changes **from** this copy. (Only the AJSON/S-RTTI mirrors in `src/00/01` and `src/00/02` are off-limits.) If a method you need already exists in abap-util, copy it from there with its helper closure instead of re-implementing it.
+- **Class-level selection, method-level trimming for the context class only.** The other vendored classes are copied as-is; leave `z2ui5_cl_a2ui5_http` / `z2ui5_cx_a2ui5_error` alone unless a fix is genuinely needed.
+- **Keep what you add generic.** Framework-specific logic belongs in the core `z2ui5_cl_core_*` classes — the sync harvests this class into a catalog other projects consume.
+- **Periodic AI sync-back:** every few weeks an AI merges what was added or fixed here back into abap-util. It diffs method *bodies*, not just names — see the sync rules in [abap-util's AGENTS.md](https://github.com/abap-util/abap-util/blob/main/AGENTS.md).
+- **The trim is not driven by the core engine alone.** Symbols marked `FROZEN-ONLY` in the class have no caller in `src/00`–`src/02` and exist only because the frozen `src/99` still calls them; they go when `src/99` goes. The class header explains it — do not add new callers on them.
 
-The same pattern is used by other projects in the ecosystem (e.g. [popups](https://github.com/abap2UI5-addons/popups) with `z2ui5_cl_popup_context`), each with its own namespace and its own method subset.
+The same pattern is used elsewhere in the ecosystem (e.g. [popups](https://github.com/abap2UI5-addons/popups) with `z2ui5_cl_popup_context`), each with its own namespace and method subset.
 
 ### Data Binding
 
@@ -305,7 +305,7 @@ This project follows the [SAP Clean ABAP styleguide](https://github.com/SAP/styl
   CATCH cx_root ##NO_HANDLER.
   ```
 - **API parameter types:** Use `TYPE clike` for string/char input parameters in public API methods (allows both string and char literals without conversion)
-- **Utility access:** Framework utilities live in `z2ui5_cl_a2ui5_context` (`src/00/03/`) — a vendored copy of `zabaputil_cl_util_context` from [abap-util](https://github.com/abap-util/abap-util), trimmed to the methods the framework uses (see "Vendored Utility Classes" in the Architecture section). Environment-specific behavior (ABAP Cloud vs. standard ABAP) is branched inside this class via `z2ui5_cl_a2ui5_context=>context_check_abap_cloud( )` using dynamic calls, so it compiles on all targets. The former utility classes (`z2ui5_cl_util`, `z2ui5_cl_util_ext`, …) are retired in `src/99/` — do not use them in framework code
+- **Utility access:** Framework utilities live in `z2ui5_cl_a2ui5_context` (`src/00/03/`; see "Vendored Utility Classes"). Environment-specific behavior (ABAP Cloud vs. standard ABAP) is branched inside this class via `check_abap_cloud( )` and dynamic calls, so it compiles on all targets. The former utility classes (`z2ui5_cl_util`, `z2ui5_cl_util_ext`, …) are retired in `src/99/` — do not use them in framework code
   ```abap
   z2ui5_cl_a2ui5_context=>uuid_get_c32( ).
   ```
@@ -413,7 +413,7 @@ Config files: `eslint.config.mjs`, `ui5lint.config.mjs`, `.prettierrc`, `.editor
 | `src/01/02/z2ui5_cl_core_srv_model.clas.abap` | JSON model management |
 | `src/01/02/z2ui5_cl_core_srv_event.clas.abap` | Event registration and payload assembly |
 | `src/01/01/z2ui5_cl_core_srv_draft.clas.abap` | Draft/session persistence |
-| `src/00/03/z2ui5_cl_a2ui5_context.clas.abap` | Framework utility/context class (RTTI, conversions, UUID, messages, environment detection) — vendored copy from [abap-util](https://github.com/abap-util/abap-util), trimmed to used methods; new methods may be added locally and are periodically synced back to abap-util |
+| `src/00/03/z2ui5_cl_a2ui5_context.clas.abap` | Framework utility/context class (RTTI, conversions, UUID, messages, environment detection) — see "Vendored Utility Classes" |
 | `app/webapp/core/AppState.js` | Owner of the shared frontend state + `z2ui5.*` globals inventory |
 | `app/webapp/core/ViewSlots.js` | View-slot access layer (get/set/byId/destroy per slot) |
 | `app/webapp/core/Lib.js` | Shared frontend helpers |
@@ -444,7 +444,7 @@ test: add unit tests for utility class
 
 These rules apply to AI assistants **modifying the framework** (this repo). For AI assistants **building apps**, see <https://abap2ui5.github.io/docs/advanced/agent.html> instead.
 
-1. **Do not modify `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI)** — mirrored from external projects, synced by automated workflows. **`src/00/03/z2ui5_cl_a2ui5_context` is NOT read-only, though — edit it freely: add new methods and change existing ones directly, right here, whenever the framework needs a utility. This is safe and expected; there is NO upstream-first step and NO problem doing so.** The direction is the reverse of what "vendored" might suggest: the abap-util master **harvests** new/changed methods **from** this copy (local → upstream), so your local edits are the source of truth until the periodic sync-back picks them up (see "Vendored Utility Classes"). The only rules for the context class: keep what you add **generic and reusable** (framework-specific logic belongs in the core `z2ui5_cl_core_*` classes, not here), and leave the as-copied `z2ui5_cl_a2ui5_http` / `z2ui5_cx_a2ui5_error` untouched unless a fix is genuinely needed. **Do not touch `src/99/` — the entire package is frozen**, including the `z2ui5_cl_xml_view` / `_cc` builders at its top level. Read them to answer questions; never change, extend or refactor them, and never add new consumers. The builder is being replaced by the ai-demokit version; that work does not happen in this repository.
+1. **Do not modify `src/00/01/` (AJSON) and `src/00/02/` (S-RTTI)** — mirrored from external projects, synced by automated workflows. **`src/00/03/z2ui5_cl_a2ui5_context` is a different case: edit it directly** — it is vendored but leads its upstream, so there is no upstream-first step (see "Vendored Utility Classes"). **Do not touch `src/99/` — the entire package is frozen**, including the `z2ui5_cl_xml_view` / `_cc` builders at its top level. Read them to answer questions; never change, extend or refactor them, and never add new consumers. The builder is being replaced by the ai-demokit version; that work does not happen in this repository.
 2. **NEVER manually edit any ABAP file under `src/01/03/`.** These files are the embedded frontend (auto-generated from `app/webapp/` via the `app2abap` job — see `.github/app2abap/trans2abap.js` and the `create_app2abap.yaml` workflow). The **only** allowed way to update them is:
    - Change the source under `app/webapp/`
    - Run **`npm run app2abap`** locally (or trigger the `create_app2abap.yaml` workflow). This single command runs the full pipeline in the correct order — `npm --prefix app run format` (Prettier) → `npm run auto_app2abap` (generate) → `npm run auto_abaplint` (normalize) — exactly as CI does. Running `auto_app2abap` on its own produces **un-normalized** ABAP that differs from the committed form in *every* `src/01/03/` file (alignment/whitespace drift); the `auto_abaplint` step reverts that drift so only the files whose `app/webapp/` source actually changed remain modified.

--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
@@ -9,6 +9,19 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
     " origin: https://github.com/oblomov-dev/abap-toolkit
     " author: https://github.com/oblomov-dev
     " license: MIT.
+    "
+    " Vendored copy of zabaputil_cl_util_context (abap-util), trimmed to the
+    " methods this repository uses. Editing it here is the normal way to work:
+    " add or change methods directly, the master catalog harvests them back.
+    "
+    " The trim is NOT driven by the core engine alone. The symbols marked
+    " `FROZEN-ONLY` below have no caller in src/00 - src/02; they survive
+    " purely because the frozen src/99 package (z2ui5_cl_xml_view, the retired
+    " z2ui5_cl_util* classes, the built-in popups) still calls them. They are
+    " not dead code and must not be trimmed away while src/99 ships, but they
+    " are also not part of the framework's own utility surface: when src/99 is
+    " finally removed, every FROZEN-ONLY symbol goes with it. Do not build new
+    " callers on them.
     CONSTANTS:
       BEGIN OF cs_ui5_msg_type,
         e TYPE string VALUE `Error` ##NO_TEXT,
@@ -28,8 +41,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     CLASS-DATA cv_char_util_horizontal_tab TYPE c LENGTH 1 READ-ONLY.
 
-    CLASS-DATA cv_char_util_charsize       TYPE i          READ-ONLY.
-
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-DATA cv_format_e_xml_attr        TYPE i          READ-ONLY.
 
     " RTTI type-kind / kind / visibility constants, so callers can branch on
@@ -147,6 +159,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE ty_t_msg.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_get_data_element_text_l
       IMPORTING
         !val          TYPE any
@@ -156,6 +169,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
     " Extracts the DDIC data element name (`\TYPE=...` part of the absolute
     " name) from a component's elementary type, so callers do not reference
     " cl_abap_elemdescr directly.
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_get_ddic_type_name
       IMPORTING
         type          TYPE REF TO cl_abap_datadescr
@@ -190,6 +204,12 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
     " flag column named sel_field_name (default `ZZSELKZ`) is inserted.
     " Keeps the dynamic RTTI type construction (describe_by_data / create) in
     " one place so it can be ported once for non-ABAP runtimes.
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
+    " `ir_tab` keeps its Hungarian name against the `val` convention used by
+    " the rest of this class: z2ui5_cl_pop_to_select (src/99/02) passes it as
+    " a NAMED argument, and src/99 is frozen, so renaming the parameter would
+    " break a package this repository is not allowed to edit. Rename it only
+    " together with the removal of src/99.
     CLASS-METHODS rtti_create_sel_tab_type
       IMPORTING
         ir_tab         TYPE REF TO data
@@ -197,13 +217,6 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
         sel_field_name TYPE clike     DEFAULT `ZZSELKZ`
       RETURNING
         VALUE(result)  TYPE ty_s_sel_tab_type.
-
-    CLASS-METHODS msg_get
-      IMPORTING
-        !val          TYPE any
-        !val2         TYPE any OPTIONAL
-      RETURNING
-        VALUE(result) TYPE ty_s_msg.
 
     CLASS-METHODS rtti_get_t_attri_by_include
       IMPORTING
@@ -213,7 +226,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     CLASS-METHODS expand_components
       IMPORTING
-        it_comps      TYPE abap_component_tab
+        val           TYPE abap_component_tab
       RETURNING
         VALUE(result) TYPE abap_component_tab.
 
@@ -262,13 +275,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     CLASS-METHODS rtti_get_classname_by_ref
       IMPORTING
-        !in           TYPE REF TO object
-      RETURNING
-        VALUE(result) TYPE string.
-
-    CLASS-METHODS rtti_get_intfname_by_ref
-      IMPORTING
-        !in           TYPE any
+        val           TYPE REF TO object
       RETURNING
         VALUE(result) TYPE string.
 
@@ -286,12 +293,14 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RAISING
         cx_xslt_serialization_error.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS boolean_check_by_data
       IMPORTING
         val           TYPE any
       RETURNING
         VALUE(result) TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS boolean_abap_2_json
       IMPORTING
         val           TYPE any
@@ -341,9 +350,9 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     CLASS-METHODS url_param_get_tab
       IMPORTING
-        i_val            TYPE clike
+        val           TYPE clike
       RETURNING
-        VALUE(rt_params) TYPE ty_t_name_value.
+        VALUE(result) TYPE ty_t_name_value.
 
     CLASS-METHODS rtti_get_t_attri_by_oref
       IMPORTING
@@ -375,28 +384,33 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS boolean_check_by_name
       IMPORTING
         val           TYPE string
       RETURNING
         VALUE(result) TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS filter_get_token_t_by_range_t
       IMPORTING
         val           TYPE ANY TABLE
       RETURNING
         VALUE(result) TYPE ty_t_token ##NEEDED.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS filter_get_token_range_mapping
       RETURNING
         VALUE(result) TYPE ty_t_name_value.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS itab_corresponding
       IMPORTING
         val  TYPE STANDARD TABLE
       CHANGING
         !tab TYPE STANDARD TABLE.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS itab_filter_by_val
       IMPORTING
         val         TYPE clike
@@ -405,6 +419,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       CHANGING
         !tab        TYPE STANDARD TABLE.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS itab_get_by_struc
       IMPORTING
         val           TYPE any
@@ -417,6 +432,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE REF TO data.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS conv_get_xstring_by_data_uri
       IMPORTING
         val           TYPE clike
@@ -429,12 +445,14 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_check_table
       IMPORTING
         val           TYPE any
       RETURNING
         VALUE(result) TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_check_structure
       IMPORTING
         val           TYPE any
@@ -467,7 +485,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     TYPES ty_t_classes TYPE STANDARD TABLE OF ty_s_class_descr WITH EMPTY KEY.
 
-    CLASS-METHODS context_check_abap_cloud
+    CLASS-METHODS check_abap_cloud
       RETURNING
         VALUE(result) TYPE abap_bool.
 
@@ -475,30 +493,35 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE string.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_get_data_element_texts
       IMPORTING
         val           TYPE clike
       RETURNING
         VALUE(result) TYPE ty_s_data_element_text.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS conv_decode_x_base64
       IMPORTING
         val           TYPE string
       RETURNING
         VALUE(result) TYPE xstring.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS conv_encode_x_base64
       IMPORTING
         val           TYPE xstring
       RETURNING
         VALUE(result) TYPE string.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS conv_get_string_by_xstring
       IMPORTING
         val           TYPE xstring
       RETURNING
         VALUE(result) TYPE string.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS conv_get_xstring_by_string
       IMPORTING
         val           TYPE string
@@ -515,7 +538,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
 
     CLASS-METHODS rtti_get_class_descr_on_cloud
       IMPORTING
-        i_classname   TYPE clike
+        classname     TYPE clike
       RETURNING
         VALUE(result) TYPE string.
 
@@ -527,6 +550,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
         is_bool   TYPE abap_bool,
       END OF ty_s_bool_cache.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-DATA mt_bool_cache TYPE HASHED TABLE OF ty_s_bool_cache WITH UNIQUE KEY typedescr.
 
     TYPES:
@@ -558,6 +582,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       RETURNING
         VALUE(result) TYPE ty_t_classes.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_get_dtel_texts_by_ddic
       IMPORTING
         name        TYPE string
@@ -565,6 +590,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
         texts       TYPE ty_s_data_element_text
         do_fallback TYPE abap_bool.
 
+    " FROZEN-ONLY: no caller in src/00 - src/02, kept for src/99
     CLASS-METHODS rtti_get_dtel_texts_by_xco
       IMPORTING
         name        TYPE string
@@ -577,7 +603,7 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
       IMPORTING
         name          TYPE clike
         val           TYPE data
-        is_msg        TYPE ty_s_msg
+        msg           TYPE ty_s_msg
       RETURNING
         VALUE(result) TYPE ty_s_msg.
 
@@ -623,14 +649,14 @@ CLASS z2ui5_cl_a2ui5_context DEFINITION
     CLASS-METHODS get_comp_str
       IMPORTING
         val           TYPE any
-        iv_comp       TYPE clike
+        comp          TYPE clike
       RETURNING
         VALUE(result) TYPE string.
 
     CLASS-METHODS scan_flag_prefix
       IMPORTING
         val           TYPE any
-        iv_prefix     TYPE clike
+        prefix        TYPE clike
       RETURNING
         VALUE(result) TYPE string_table.
 
@@ -692,7 +718,6 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
     cv_char_util_newline        = cl_abap_char_utilities=>newline.
     cv_char_util_cr_lf          = cl_abap_char_utilities=>cr_lf.
     cv_char_util_horizontal_tab = cl_abap_char_utilities=>horizontal_tab.
-    cv_char_util_charsize       = cl_abap_char_utilities=>charsize.
     cv_format_e_xml_attr        = cl_abap_format=>e_xml_attr.
 
     cv_typedescr_typekind_table      = cl_abap_typedescr=>typekind_table.
@@ -981,19 +1006,9 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD rtti_get_classname_by_ref.
 
-    DATA(lv_classname) = cl_abap_classdescr=>get_class_name( in ).
+    DATA(lv_classname) = cl_abap_classdescr=>get_class_name( val ).
     result = substring_after( val = lv_classname
                               sub = `\CLASS=` ).
-
-  ENDMETHOD.
-
-  METHOD rtti_get_intfname_by_ref.
-
-    DATA(rtti) = cl_abap_typedescr=>describe_by_data( in ).
-    DATA(ref) = CAST cl_abap_refdescr( rtti ).
-    DATA(name) = ref->get_referenced_type( )->absolute_name.
-    result = substring_after( val = name
-                              sub = `\INTERFACE=` ).
 
   ENDMETHOD.
 
@@ -1024,7 +1039,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD expand_components.
 
-    LOOP AT it_comps REFERENCE INTO DATA(lr_comp).
+    LOOP AT val REFERENCE INTO DATA(lr_comp).
       IF lr_comp->as_include = abap_true.
         DATA(lt_incl) = rtti_get_t_attri_by_include( lr_comp->type ).
         APPEND LINES OF lt_incl TO result.
@@ -1142,7 +1157,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD url_param_get_tab.
 
-    DATA(lv_search) = replace( val  = i_val
+    DATA(lv_search) = replace( val  = val
                                sub  = `%3D`
                                with = `=`
                                occ  = 0 ).
@@ -1179,7 +1194,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
       " shape (with or without a leading path/question mark) - the value
       " keeps its original case
       INSERT VALUE #( n = c_trim_lower( lv_name )
-                      v = lv_value ) INTO TABLE rt_params.
+                      v = lv_value ) INTO TABLE result.
     ENDLOOP.
 
   ENDMETHOD.
@@ -1334,14 +1349,6 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
       WHEN OTHERS.
         result = cs_ui5_msg_type-i.
     ENDCASE.
-
-  ENDMETHOD.
-
-  METHOD msg_get.
-
-    DATA(lt_msg) = msg_get_t( val  = val
-                              val2 = val2 ).
-    result = VALUE #( lt_msg[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
 
@@ -1503,7 +1510,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD context_check_abap_cloud.
+  METHOD check_abap_cloud.
 
     IF gv_check_cloud_cached = abap_true.
       result = gv_check_cloud.
@@ -1649,7 +1656,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD rtti_get_classes_impl_intf.
 
-    IF context_check_abap_cloud( ).
+    IF check_abap_cloud( ).
       result = rtti_get_classes_intf_cloud( val ).
     ELSE.
       result = rtti_get_classes_intf_std( val ).
@@ -1976,7 +1983,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
         DATA lv_classname TYPE c LENGTH 30.
         DATA xco_cp_abap  TYPE c LENGTH 11.
 
-        lv_classname = i_classname.
+        lv_classname = classname.
 
         xco_cp_abap = `XCO_CP_ABAP`.
         CALL METHOD (xco_cp_abap)=>(`CLASS`)
@@ -2038,7 +2045,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
           ELSE.
             ls_result = msg_map( name   = ls_attri->name
                                  val    = <comp>
-                                 is_msg = ls_result ).
+                                 msg = ls_result ).
           ENDIF.
 
         ENDLOOP.
@@ -2082,7 +2089,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
           ENDIF.
           ls_result = msg_map( name   = ls_attri_o->name
                                val    = <comp>
-                               is_msg = ls_result ).
+                               msg = ls_result ).
         ENDLOOP.
         INSERT ls_result INTO TABLE result.
       CATCH cx_root.
@@ -2129,7 +2136,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
                   ENDIF.
                   ls_result = msg_map( name   = ls_attri_o->name
                                        val    = <comp>
-                                       is_msg = ls_result ).
+                                       msg = ls_result ).
                 ENDLOOP.
                 INSERT ls_result INTO TABLE result.
 
@@ -2141,7 +2148,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD msg_map.
 
-    result = is_msg.
+    result = msg.
     CASE name.
       WHEN `ID` OR `MSGID`.
         result-id = val.
@@ -2285,7 +2292,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
   METHOD msg_get_rap_element.
 
     DATA(lt_suffix) = scan_flag_prefix( val       = val
-                                        iv_prefix = `%ELEMENT-` ).
+                                        prefix = `%ELEMENT-` ).
     result = concat_lines_of( table = lt_suffix
                               sep   = `, ` ).
 
@@ -2293,7 +2300,7 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD get_comp_str.
 
-    ASSIGN COMPONENT iv_comp OF STRUCTURE val TO FIELD-SYMBOL(<comp>).
+    ASSIGN COMPONENT comp OF STRUCTURE val TO FIELD-SYMBOL(<comp>).
     IF sy-subrc = 0.
       result = <comp>.
     ENDIF.
@@ -2302,11 +2309,11 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
 
   METHOD scan_flag_prefix.
 
-    DATA(lv_len) = strlen( iv_prefix ).
+    DATA(lv_len) = strlen( prefix ).
     DATA(lt_attri) = rtti_get_t_attri_by_any( val ).
     LOOP AT lt_attri REFERENCE INTO DATA(ls_attri).
       CHECK strlen( ls_attri->name ) > lv_len.
-      CHECK ls_attri->name(lv_len) = iv_prefix.
+      CHECK ls_attri->name(lv_len) = prefix.
       ASSIGN COMPONENT ls_attri->name OF STRUCTURE val TO FIELD-SYMBOL(<flag>).
       CHECK sy-subrc = 0.
       CHECK <flag> IS NOT INITIAL.
@@ -2318,14 +2325,14 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
   METHOD msg_get_rap_state_area.
 
     result = get_comp_str( val     = val
-                           iv_comp = `%STATE_AREA` ).
+                           comp = `%STATE_AREA` ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_action.
 
     DATA(lt_suffix) = scan_flag_prefix( val       = val
-                                        iv_prefix = `%OP-%ACTION-` ).
+                                        prefix = `%OP-%ACTION-` ).
     result = VALUE #( lt_suffix[ 1 ] OPTIONAL ).
 
   ENDMETHOD.
@@ -2333,14 +2340,14 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
   METHOD msg_get_rap_pid.
 
     result = get_comp_str( val     = val
-                           iv_comp = `%PID` ).
+                           comp = `%PID` ).
 
   ENDMETHOD.
 
   METHOD msg_get_rap_cid.
 
     result = get_comp_str( val     = val
-                           iv_comp = `%CID` ).
+                           comp = `%CID` ).
 
   ENDMETHOD.
 

--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
@@ -415,8 +415,8 @@ CLASS ltcl_rtti IMPLEMENTATION.
     ls_flags-flag_b = abap_false.
     ls_flags-other  = abap_true.
 
-    DATA(lt_found) = z2ui5_cl_a2ui5_context=>scan_flag_prefix( val       = ls_flags
-                                                               iv_prefix = `FLAG_` ).
+    DATA(lt_found) = z2ui5_cl_a2ui5_context=>scan_flag_prefix( val    = ls_flags
+                                                               prefix = `FLAG_` ).
 
     cl_abap_unit_assert=>assert_equals( exp = 1
                                         act = lines( lt_found ) ).

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -316,7 +316,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     form->toolbar( )->title( `Backend` ).
     form->label( `ABAP for Cloud` ).
     form->checkbox( enabled  = abap_false
-                    selected = z2ui5_cl_a2ui5_context=>context_check_abap_cloud( ) ).
+                    selected = z2ui5_cl_a2ui5_context=>check_abap_cloud( ) ).
     form->label( `User Exit` ).
     form->text( z2ui5_cl_exit=>get_user_exit_class( ) ).
 


### PR DESCRIPTION
## Description

Standardizes parameter naming across `z2ui5_cl_a2ui5_context` to follow the framework's naming conventions:

- **Input parameters:** renamed from Hungarian notation (`i_*`, `iv_*`, `in`) and inconsistent prefixes to the framework standard `val` (or domain-specific names like `classname`, `comp`, `prefix`)
- **Output parameters:** renamed from `rt_*` / `is_msg` to `result` / `msg`
- **Method names:** `context_check_abap_cloud()` → `check_abap_cloud()` for consistency

Also removes unused/dead code:
- Deleted `cv_char_util_charsize` constant (never referenced)
- Deleted `msg_get()` method (superseded by `msg_get_t()`)
- Deleted `rtti_get_intfname_by_ref()` method (no callers in framework)

Adds comprehensive documentation in the class header explaining the "FROZEN-ONLY" marker for methods that exist solely to support the frozen `src/99` package and will be removed when that package is retired.

Updates `AGENTS.md` with clearer guidance on the utilities architecture: the context class is the single door through which all system/platform calls flow, making the framework portable across NW 7.02 / Standard ABAP / ABAP Cloud and transpilable to JavaScript. Explains the sync-back process with abap-util and clarifies which symbols are legacy vs. active.

## How to test

- `npx abaplint` passes with 0 issues
- Existing unit tests pass (parameter names updated in test calls)
- Framework compiles and runs (all callers of renamed methods updated)

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests updated where parameter names changed
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively (one method rename in startup class)
- [x] Changes made via abapGit: yes

https://claude.ai/code/session_013Cj6GtXZwiSS8XouJ1GRmY