### PR TITLE
Serialize framework follow-up actions as JSON arrays instead of eF() calls

### DIFF
--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -152,7 +152,7 @@ sap.ui.define(
     //         "S_VIEW_NEST", "S_VIEW_NEST2", "S_POPUP", "S_POPOVER": same,
     //         "S_MSG_TOAST": { "TEXT": "...", ... },
     //         "S_MSG_BOX":   { "TEXT": "...", "TYPE": "error", ... },
-    //         "S_FOLLOW_UP_ACTION": { "CUSTOM_JS": ["eF('SET_FOCUS','id1')"] },
+    //         "S_FOLLOW_UP_ACTION": { "CUSTOM_JS": ["[\"SET_FOCUS\",\"id1\"]"] },
     //         "SET_PUSH_STATE": "", "SET_APP_STATE_ACTIVE": "",
     //         "SET_NAV_BACK": ""           // browser/history follow-ups
     //       }
@@ -664,9 +664,10 @@ sap.ui.define(
 
           if (sView?.CHECK_DESTROY) ViewSlots.destroy("MAIN");
 
-          // The backend can send small JS snippets to run after the response.
-          // Each snippet is either a literal expression or an "eF(...)" call
-          // whose arguments are wrapped in single quotes. They are stashed
+          // The backend can send follow-up actions to run after the response.
+          // Each entry is a JSON array ["EVENT", ...args] (framework actions,
+          // pure data), a legacy "eF(...)" call string, or a raw JS
+          // expression - see _runCustomJs. They are stashed
           // here and executed at the end of _processAfterRendering, i.e. once
           // the (possibly freshly built) view is actually rendered. Running
           // them earlier would break render-dependent actions such as
@@ -754,16 +755,37 @@ sap.ui.define(
         this.responseError(err);
       },
 
-      // Executes a single custom-JS snippet from the backend.
-      // Format A:  a raw expression such as alert(123) - needs a CSP that
+      // Executes a single follow-up action / custom-JS snippet from the backend.
+      // Format A:  a JSON array ["EVENT", ...args] - the structured form the
+      //            backend (z2ui5_cl_core_srv_event=>get_event_client_json)
+      //            emits for every framework follow-up action. Pure data,
+      //            serialized and escaped entirely in ABAP; dispatched via
+      //            oController.eF( ) after a single JSON.parse - no code is
+      //            parsed or evaluated on this path.
+      // Format B:  a structured eF( ) frontend-event call - the legacy wire
+      //            format, still produced by apps that pass raw "eF(...)"
+      //            strings to follow_up_action. Its argument list is parsed
+      //            manually (no eval / Function) so it runs under a strict
+      //            CSP while keeping object / array / string arguments intact.
+      // Format C:  a raw expression such as alert(123) - needs a CSP that
       //            allows unsafe-eval, otherwise it is a no-op.
-      // Format B:  a structured eF( ) frontend-event call - dispatched via
-      //            oController.eF( ). Its argument list is parsed manually
-      //            (no eval / Function) so it runs under a strict CSP while
-      //            keeping object / array / string arguments intact.
       _runCustomJs(item, oController) {
         try {
           const snippet = item.trim();
+          if (snippet.startsWith("[")) {
+            // JSON array -> structured follow-up action. A raw-JS expression
+            // that merely starts with "[" is no JSON array, so it fails the
+            // parse and falls through to the legacy formats below.
+            try {
+              const args = JSON.parse(snippet);
+              if (Array.isArray(args)) {
+                oController.eF(...args);
+                return;
+              }
+            } catch {
+              // not JSON - keep going with the legacy formats
+            }
+          }
           const match = /^\.?eF\s*\(([\s\S]*)\)\s*;?$/.exec(snippet);
           if (match) {
             oController.eF(...parseEfArgs(match[1]));

--- a/node/tests/serverCustomJs.spec.js
+++ b/node/tests/serverCustomJs.spec.js
@@ -3,11 +3,14 @@ const { test, expect } = require("@playwright/test");
 const { loadModule } = require("./loadModule");
 
 // Tests Server._runCustomJs - the follow-up-action path. A backend snippet is
-// either an eF( ) call, whose argument list is parsed WITHOUT eval so it runs
-// under a strict CSP, or a raw expression. The argument parser has to be the
-// exact counterpart of the backend's escaping
-// (z2ui5_cl_core_srv_event=>escape_js_string), which escapes backslash, the
-// single quote AND the line breaks it rewrites to \n / \r.
+// a JSON array ["EVENT", ...args] (the structured form every framework
+// follow-up action travels in - serialized and escaped entirely in ABAP by
+// z2ui5_cl_core_srv_event=>get_event_client_json), a legacy eF( ) call whose
+// argument list is parsed WITHOUT eval so it runs under a strict CSP, or a
+// raw expression. The legacy argument parser has to be the exact counterpart
+// of the backend's escaping (z2ui5_cl_core_srv_event=>escape_js_string),
+// which escapes backslash, the single quote AND the line breaks it rewrites
+// to \n / \r.
 
 function loadServer() {
   return loadModule("core/Server.js", {}).module;
@@ -18,6 +21,61 @@ function controllerStub() {
   const calls = [];
   return { calls, eF: (...args) => calls.push(args) };
 }
+
+test.describe("Server._runCustomJs structured JSON actions", () => {
+  test("dispatches a JSON array as an eF event", () => {
+    const Server = loadServer();
+    const oController = controllerStub();
+
+    // the structured form the backend emits for framework follow-up actions
+    // (z2ui5_cl_core_srv_event=>get_event_client_json): pure data, one
+    // JSON.parse, no code parsing
+    Server._runCustomJs('["SET_FOCUS","myInput"]', oController);
+
+    expect(oController.calls).toEqual([["SET_FOCUS", "myInput"]]);
+  });
+
+  test("keeps embedded objects and positional empties intact", () => {
+    const Server = loadServer();
+    const oController = controllerStub();
+
+    Server._runCustomJs(
+      '["CONTROL_BY_ID","tab","","setHiddenInPopin",{"A":1}]',
+      oController,
+    );
+
+    expect(oController.calls).toEqual([
+      ["CONTROL_BY_ID", "tab", "", "setHiddenInPopin", { A: 1 }],
+    ]);
+  });
+
+  test("special characters survive the JSON round trip", () => {
+    const Server = loadServer();
+    const oController = controllerStub();
+
+    // the backend JSON-escapes quotes, backslashes and line breaks - they
+    // must arrive as the original characters, decoded by JSON.parse alone
+    Server._runCustomJs(
+      '["CLIPBOARD_COPY","line1\\nline2 \\"quoted\\" C:\\\\dir"]',
+      oController,
+    );
+
+    expect(oController.calls).toEqual([
+      ["CLIPBOARD_COPY", 'line1\nline2 "quoted" C:\\dir'],
+    ]);
+  });
+
+  test("a raw JS expression starting with [ is not misread as an action", () => {
+    const Server = loadServer();
+    const oController = controllerStub();
+
+    // not a JSON array - JSON.parse fails, so the snippet takes the raw-JS
+    // path (Format C) instead of being dispatched as a structured action
+    Server._runCustomJs("[1, 2].concat([3]).length", oController);
+
+    expect(oController.calls).toEqual([]);
+  });
+});
 
 test.describe("Server._runCustomJs argument parsing", () => {
   test("passes a plain quoted argument through", () => {

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -46,9 +46,12 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
     IF val IS NOT INITIAL
         AND val CO `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_`.
-      lv_js = mo_srv_event->get_event_client( val   = val
-                                              view  = view
-                                              t_arg = t_arg ).
+      " a framework event travels as pure data - a JSON array serialized and
+      " escaped entirely in ABAP (get_event_client_json); only a raw JS
+      " expression passed by the app keeps the code form
+      lv_js = mo_srv_event->get_event_client_json( val   = val
+                                                   view  = view
+                                                   t_arg = t_arg ).
     ENDIF.
 
     INSERT lv_js INTO TABLE mo_action->ms_next-s_set-s_follow_up_action-custom_js.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -388,11 +388,13 @@ CLASS ltcl_test_client IMPLEMENTATION.
                                  t_arg = VALUE #( ( `My Title` ) ) ).
     li_client->follow_up_action( z2ui5_if_client=>cs_event-history_back ).
 
+    " framework events travel as pure data - a JSON array serialized in ABAP
+    " (get_event_client_json), not as an executable eF( ) JS snippet
     cl_abap_unit_assert=>assert_equals( exp = 2
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
-    cl_abap_unit_assert=>assert_equals( exp = `.eF('SET_TITLE', 'My Title')`
+    cl_abap_unit_assert=>assert_equals( exp = `["SET_TITLE","My Title"]`
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
-    cl_abap_unit_assert=>assert_equals( exp = `.eF('HISTORY_BACK')`
+    cl_abap_unit_assert=>assert_equals( exp = `["HISTORY_BACK"]`
                                         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
 
   ENDMETHOD.
@@ -412,10 +414,10 @@ CLASS ltcl_test_client IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = 2
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
     cl_abap_unit_assert=>assert_equals(
-        exp = `.eF('CONTROL_BY_ID', 'myContainer', 'MAIN', 'to', 'myPage')`
+        exp = `["CONTROL_BY_ID","myContainer","MAIN","to","myPage"]`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
     cl_abap_unit_assert=>assert_equals(
-        exp = `.eF('CONTROL_BY_ID', 'popContainer', 'POPUP', 'to', 'popPage')`
+        exp = `["CONTROL_BY_ID","popContainer","POPUP","to","popPage"]`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
 
   ENDMETHOD.
@@ -440,13 +442,13 @@ CLASS ltcl_test_client IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = 3
                                         act = lines( mo_action->ms_next-s_set-s_follow_up_action-custom_js ) ).
     cl_abap_unit_assert=>assert_equals(
-        exp = `.eF('CONTROL_GLOBAL', 'MESSAGE_TOAST', 'show', 'Hello')`
+        exp = `["CONTROL_GLOBAL","MESSAGE_TOAST","show","Hello"]`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 1 ] ).
     cl_abap_unit_assert=>assert_equals(
-        exp = `.eF('CONTROL_BY_ID', 'demoPanel', '', 'setExpanded', 'X')`
+        exp = `["CONTROL_BY_ID","demoPanel","","setExpanded","X"]`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 2 ] ).
     cl_abap_unit_assert=>assert_equals(
-        exp = `.eF('CONTROL_BY_ID', 'demoPanel', 'POPOVER', 'setExpanded', 'X')`
+        exp = `["CONTROL_BY_ID","demoPanel","POPOVER","setExpanded","X"]`
         act = mo_action->ms_next-s_set-s_follow_up_action-custom_js[ 3 ] ).
 
   ENDMETHOD.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -18,7 +18,29 @@ CLASS z2ui5_cl_core_srv_event DEFINITION PUBLIC FINAL.
       RETURNING
         VALUE(result) TYPE string.
 
+    METHODS get_event_client_json
+      IMPORTING
+        val           TYPE clike
+        view          TYPE clike        DEFAULT z2ui5_if_client=>cs_view-main
+        t_arg         TYPE string_table OPTIONAL
+      RETURNING
+        VALUE(result) TYPE string.
+
   PROTECTED SECTION.
+    TYPES:
+      BEGIN OF ty_s_client_event,
+        val   TYPE string,
+        t_arg TYPE string_table,
+      END OF ty_s_client_event.
+
+    METHODS map_client_event
+      IMPORTING
+        val           TYPE clike
+        view          TYPE clike
+        t_arg         TYPE string_table
+      RETURNING
+        VALUE(result) TYPE ty_s_client_event.
+
     METHODS get_t_arg
       IMPORTING
         val           TYPE string_table
@@ -70,6 +92,16 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
 
   METHOD get_event_client.
 
+    DATA(ls_event) = map_client_event( val   = val
+                                       view  = view
+                                       t_arg = t_arg ).
+
+    result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ escape_js_string( ls_event-val ) }'{ get_t_arg( ls_event-t_arg ) }|.
+
+  ENDMETHOD.
+
+  METHOD map_client_event.
+
     DATA(lv_val) = CONV string( val ).
     DATA(lt_arg) = t_arg.
 
@@ -120,7 +152,72 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
                         ( lv_bind_path ) ).
     ENDIF.
 
-    result = |{ z2ui5_if_core_types=>cs_ui5-event_frontend_function }('{ escape_js_string( lv_val ) }'{ get_t_arg( lt_arg ) }|.
+    result-val   = lv_val.
+    result-t_arg = lt_arg.
+
+  ENDMETHOD.
+
+  METHOD get_event_client_json.
+
+    " Serialize a framework follow-up action as DATA - a JSON array
+    " ["EVENT", arg1, ...] - instead of an executable eF( ) JS snippet. The
+    " backend owns the whole serialization including the escaping (via AJSON);
+    " the frontend only JSON-parses the array and dispatches it
+    " (Server._runCustomJs), so no JS string literal is built here or
+    " re-parsed there on this path. The XML-bound handler strings
+    " (get_event_client) keep the JS form - they live inside view XML, where
+    " UI5 itself parses the handler expression.
+    DATA(ls_event) = map_client_event( val   = val
+                                       view  = view
+                                       t_arg = t_arg ).
+
+    " same contract as get_t_arg: an empty argument between filled ones keeps
+    " its position, trailing empties are dropped - the frontend only casts the
+    " args that were sent, so a trailing `` would turn open() into open('')
+    DATA(lv_index) = lines( ls_event-t_arg ).
+    WHILE lv_index > 0.
+      IF ls_event-t_arg[ lv_index ] IS NOT INITIAL.
+        EXIT.
+      ENDIF.
+      DELETE ls_event-t_arg INDEX lv_index.
+      lv_index = lv_index - 1.
+    ENDWHILE.
+
+    TRY.
+        DATA(li_json) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty( ) ).
+        li_json->touch_array( `/` ).
+        li_json->push( iv_path = `/`
+                       iv_val  = ls_event-val ).
+
+        LOOP AT ls_event-t_arg INTO DATA(lv_arg).
+          DATA(lv_is_embedded) = abap_false.
+          IF lv_arg IS NOT INITIAL AND ( lv_arg(1) = `{` OR lv_arg(1) = `[` ).
+            " a JSON object/array argument (the STORE_DATA payload, the
+            " compound filter groups, ...) is embedded as real JSON so the
+            " frontend receives a ready-to-use object - the counterpart of
+            " the raw (unquoted) branch in get_t_arg. Values that only look
+            " like JSON ({0} message placeholders, {/PATH} bindings) fail to
+            " parse and stay plain strings, exactly what the frontend's own
+            " JSON.parse fallback produced for them before.
+            TRY.
+                li_json->push( iv_path = `/`
+                               iv_val  = z2ui5_cl_ajson=>parse( lv_arg ) ).
+                lv_is_embedded = abap_true.
+              CATCH cx_root ##NO_HANDLER.
+            ENDTRY.
+          ENDIF.
+          IF lv_is_embedded = abap_false.
+            li_json->push( iv_path = `/`
+                           iv_val  = lv_arg ).
+          ENDIF.
+        ENDLOOP.
+
+        result = li_json->stringify( ).
+      CATCH cx_root INTO DATA(lx_error).
+        RAISE EXCEPTION TYPE z2ui5_cx_a2ui5_error
+          EXPORTING
+            val = lx_error.
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.testclasses.abap
@@ -20,6 +20,14 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS event_backslash_escaped FOR TESTING.
     METHODS event_lone_cr_escaped FOR TESTING.
     METHODS event_placeholder_quoted FOR TESTING.
+    METHODS json_basic FOR TESTING.
+    METHODS json_no_args FOR TESTING.
+    METHODS json_nav_container FOR TESTING.
+    METHODS json_view_param FOR TESTING.
+    METHODS json_empty_args FOR TESTING.
+    METHODS json_object_arg FOR TESTING.
+    METHODS json_placeholder_stays_string FOR TESTING.
+    METHODS json_escaping FOR TESTING.
 
   PROTECTED SECTION.
 
@@ -399,6 +407,115 @@ CLASS ltcl_test IMPLEMENTATION.
     DATA(lv_cond) = lo_event->get_event( val   = `EVT`
                                          t_arg = VALUE #( ( `{0?Pressed:Unpressed}` ) ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_cond CS `'{0?Pressed:Unpressed}'` ) ).
+
+  ENDMETHOD.
+
+  METHOD json_basic.
+
+    " the structured follow-up form: a JSON array ["EVENT", ...args] built
+    " and escaped entirely in ABAP - data, not an executable eF( ) snippet
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["SET_TITLE","My Title"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-set_title
+                                               t_arg = VALUE #( ( `My Title` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_no_args.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["HISTORY_BACK"]`
+        act = lo_event->get_event_client_json( z2ui5_if_client=>cs_event-history_back ) ).
+
+  ENDMETHOD.
+
+  METHOD json_nav_container.
+
+    " the *_nav_container_to remap to the generic CONTROL_BY_ID call is shared
+    " with the JS path via map_client_event
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CONTROL_BY_ID","myContainer","MAIN","to","myPage"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-nav_container_to
+                                               t_arg = VALUE #( ( `myContainer` ) ( `myPage` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_view_param.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    " a concrete view fills the slot at position 2, the default main view
+    " keeps it empty (cross-view resolveById on the frontend)
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CONTROL_BY_ID","demoPanel","POPOVER","setExpanded","X"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-control_by_id
+                                               view  = z2ui5_if_client=>cs_view-popover
+                                               t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CONTROL_BY_ID","demoPanel","","setExpanded","X"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-control_by_id
+                                               t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `X` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_empty_args.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    " an empty argument between filled ones keeps its position, trailing
+    " empties are dropped - same contract as the JS form (get_t_arg)
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CONTROL_BY_ID","demoPanel","","setExpanded"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-control_by_id
+                                               t_arg = VALUE #( ( `demoPanel` ) ( `setExpanded` ) ( `` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_object_arg.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    " a JSON object argument (e.g. the STORE_DATA payload) is embedded as
+    " real JSON, so the frontend receives a ready-to-use object after one
+    " JSON.parse of the whole array
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["STORE_DATA",{"KEY":"K1"}]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-store_data
+                                               t_arg = VALUE #( ( `{"KEY":"K1"}` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_placeholder_stays_string.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    " a message-template placeholder only looks like JSON - it fails the
+    " parse and stays a plain string, like the frontend fallback produced
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CONTROL_GLOBAL","MESSAGE_TOAST","show","{0} Pressed"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-control_global
+                                               t_arg = VALUE #( ( `MESSAGE_TOAST` ) ( `show` ) ( `{0} Pressed` ) ) ) ).
+
+  ENDMETHOD.
+
+  METHOD json_escaping.
+
+    DATA(lo_event) = NEW z2ui5_cl_core_srv_event( ).
+
+    " quotes and backslashes in an argument are JSON-escaped by the ABAP
+    " serializer - no hand-written escaping, no JS string literal to break
+    " out of (the injection surface of the old eF( ) form)
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["CLIPBOARD_COPY","he said \"hi\" \\ bye"]`
+        act = lo_event->get_event_client_json( val   = z2ui5_if_client=>cs_event-clipboard_copy
+                                               t_arg = VALUE #( ( `he said "hi" \ bye` ) ) ) ).
 
   ENDMETHOD.
 

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -172,7 +172,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `    //         "S_VIEW_NEST", "S_VIEW_NEST2", "S_POPUP", "S_POPOVER": same,` && |\n| &&
              `    //         "S_MSG_TOAST": { "TEXT": "...", ... },` && |\n| &&
              `    //         "S_MSG_BOX":   { "TEXT": "...", "TYPE": "error", ... },` && |\n| &&
-             `    //         "S_FOLLOW_UP_ACTION": { "CUSTOM_JS": ["eF('SET_FOCUS','id1')"] },` && |\n| &&
+             `    //         "S_FOLLOW_UP_ACTION": { "CUSTOM_JS": ["[\"SET_FOCUS\",\"id1\"]"] },` && |\n| &&
              `    //         "SET_PUSH_STATE": "", "SET_APP_STATE_ACTIVE": "",` && |\n| &&
              `    //         "SET_NAV_BACK": ""           // browser/history follow-ups` && |\n| &&
              `    //       }` && |\n| &&
@@ -685,9 +685,10 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `` && |\n| &&
              `          if (sView?.CHECK_DESTROY) ViewSlots.destroy("MAIN");` && |\n| &&
              `` && |\n| &&
-             `          // The backend can send small JS snippets to run after the response.` && |\n| &&
-             `          // Each snippet is either a literal expression or an "eF(...)" call` && |\n| &&
-             `          // whose arguments are wrapped in single quotes. They are stashed` && |\n| &&
+             `          // The backend can send follow-up actions to run after the response.` && |\n| &&
+             `          // Each entry is a JSON array ["EVENT", ...args] (framework actions,` && |\n| &&
+             `          // pure data), a legacy "eF(...)" call string, or a raw JS` && |\n| &&
+             `          // expression - see _runCustomJs. They are stashed` && |\n| &&
              `          // here and executed at the end of _processAfterRendering, i.e. once` && |\n| &&
              `          // the (possibly freshly built) view is actually rendered. Running` && |\n| &&
              `          // them earlier would break render-dependent actions such as` && |\n| &&
@@ -775,16 +776,37 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `        this.responseError(err);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
-             `      // Executes a single custom-JS snippet from the backend.` && |\n| &&
-             `      // Format A:  a raw expression such as alert(123) - needs a CSP that` && |\n| &&
+             `      // Executes a single follow-up action / custom-JS snippet from the backend.` && |\n| &&
+             `      // Format A:  a JSON array ["EVENT", ...args] - the structured form the` && |\n| &&
+             `      //            backend (z2ui5_cl_core_srv_event=>get_event_client_json)` && |\n| &&
+             `      //            emits for every framework follow-up action. Pure data,` && |\n| &&
+             `      //            serialized and escaped entirely in ABAP; dispatched via` && |\n| &&
+             `      //            oController.eF( ) after a single JSON.parse - no code is` && |\n| &&
+             `      //            parsed or evaluated on this path.` && |\n| &&
+             `      // Format B:  a structured eF( ) frontend-event call - the legacy wire` && |\n| &&
+             `      //            format, still produced by apps that pass raw "eF(...)"` && |\n| &&
+             `      //            strings to follow_up_action. Its argument list is parsed` && |\n| &&
+             `      //            manually (no eval / Function) so it runs under a strict` && |\n| &&
+             `      //            CSP while keeping object / array / string arguments intact.` && |\n| &&
+             `      // Format C:  a raw expression such as alert(123) - needs a CSP that` && |\n| &&
              `      //            allows unsafe-eval, otherwise it is a no-op.` && |\n| &&
-             `      // Format B:  a structured eF( ) frontend-event call - dispatched via` && |\n| &&
-             `      //            oController.eF( ). Its argument list is parsed manually` && |\n| &&
-             `      //            (no eval / Function) so it runs under a strict CSP while` && |\n| &&
-             `      //            keeping object / array / string arguments intact.` && |\n| &&
              `      _runCustomJs(item, oController) {` && |\n| &&
              `        try {` && |\n| &&
              `          const snippet = item.trim();` && |\n| &&
+             `          if (snippet.startsWith("[")) {` && |\n| &&
+             `            // JSON array -> structured follow-up action. A raw-JS expression` && |\n| &&
+             `            // that merely starts with "[" is no JSON array, so it fails the` && |\n| &&
+             `            // parse and falls through to the legacy formats below.` && |\n| &&
+             `            try {` && |\n| &&
+             `              const args = JSON.parse(snippet);` && |\n| &&
+             `              if (Array.isArray(args)) {` && |\n| &&
+             `                oController.eF(...args);` && |\n| &&
+             `                return;` && |\n| &&
+             `              }` && |\n| &&
+             `            } catch {` && |\n| &&
+             `              // not JSON - keep going with the legacy formats` && |\n| &&
+             `            }` && |\n| &&
+             `          }` && |\n| &&
              `          const match = /^\.?eF\s*\(([\s\S]*)\)\s*;?$/.exec(snippet);` && |\n| &&
              `          if (match) {` && |\n| &&
              `            oController.eF(...parseEfArgs(match[1]));` && |\n| &&
@@ -796,7 +818,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          }` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          Lib.logError("customJs: execution failed", e);` && |\n| &&
-             `        }` && |\n| &&
+             `        }` && |\n|.
+    result = result &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // Terminate the roundtrip in an unrecoverable state: clear the busy` && |\n| &&


### PR DESCRIPTION
## Description

This PR changes how framework follow-up actions are serialized and transmitted from backend to frontend. Instead of generating executable JavaScript snippets like `eF('SET_TITLE', 'My Title')`, the backend now emits pure data in the form of JSON arrays like `["SET_TITLE", "My Title"]`.

### Key Changes

**Backend (ABAP):**
- Added `get_event_client_json()` method to `z2ui5_cl_core_srv_event` that serializes follow-up actions as JSON arrays
- Extracted common event mapping logic into `map_client_event()` to be shared between the legacy `get_event_client()` (for XML-bound handlers) and the new JSON serialization path
- The JSON serialization handles:
  - Embedded JSON objects/arrays (e.g., STORE_DATA payloads) as real JSON
  - Proper escaping of quotes and backslashes via ABAP's JSON serializer
  - Trailing empty arguments are dropped (same contract as the legacy form)
  - Message placeholders like `{0}` that look like JSON but fail to parse stay as plain strings
- Updated `z2ui5_cl_core_client` to use `get_event_client_json()` for framework events

**Frontend (JavaScript):**
- Enhanced `Server._runCustomJs()` to recognize and dispatch JSON array format (Format A)
- Maintains backward compatibility with legacy `eF(...)` call strings (Format B) and raw expressions (Format C)
- JSON arrays are parsed once and dispatched directly—no code parsing or evaluation on this path
- Raw JS expressions starting with `[` that fail JSON parsing correctly fall through to legacy formats

### Security & Correctness Benefits

- **No code injection surface**: Framework events are pure data, not executable code
- **Single parse point**: Frontend only calls `JSON.parse()` once; no string literal parsing
- **Automatic escaping**: Backend owns all serialization via ABAP's JSON serializer
- **Strict CSP compatible**: No `eval` or `Function` constructor needed for framework actions

### Backward Compatibility

- XML-bound event handlers continue to use the legacy `eF(...)` form via `get_event_client()`
- Apps that pass raw `eF(...)` strings to `follow_up_action()` still work via the legacy parser
- Raw JS expressions continue to work as before

## How to test

1. Run the new unit tests in `z2ui5_cl_core_srv_event.testclasses.abap`:
   - `json_basic`, `json_no_args`, `json_nav_container`, `json_view_param`
   - `json_empty_args`, `json_object_arg`, `json_placeholder_stays_string`, `json_escaping`

2. Run the new frontend tests in `node/tests/serverCustomJs.spec.js`:
   - "Server._runCustomJs structured JSON actions" test suite

3. Verify existing tests still pass:
   - `z2ui5_cl_core_client.testclasses.abap` (updated assertions for new JSON format)
   - All other unit tests

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_014rNLYjgVGZKMWpxvGkxKsT