### PR TITLE
Add node/open-abap-core to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ downport
 node_modules
 output
 node/output
+node/open-abap-core
 .github/out
 .github/abaplint/rename_run.jsonc
 .github/abaplint/downport_run.jsonc


### PR DESCRIPTION
# Description

This PR adds `node/open-abap-core` to the `.gitignore` file to prevent the directory from being tracked in version control. This is consistent with the existing pattern of ignoring generated output directories like `node/output`.

## How to test

N/A - This is a configuration change to `.gitignore` with no functional impact.

## Checklist

- [x] No source code changes
- [x] Configuration-only update

https://claude.ai/code/session_014REDEd3YtULLyCHk11oMh4