### PR TITLE
fix syntax errors + fix unit tests

### DIFF
--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.testclasses.abap
@@ -331,6 +331,9 @@ CLASS ltcl_rtti DEFINITION FINAL
 ENDCLASS.
 
 
+CLASS z2ui5_cl_a2ui5_context DEFINITION LOCAL FRIENDS ltcl_rtti.
+
+
 CLASS ltcl_rtti IMPLEMENTATION.
 
   METHOD test_check_clike.

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -264,9 +264,11 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = abap_true
                                         act = lo_result->ms_next-s_set-s_popup-check_destroy ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popup-xml ).
-    " popovers are carried across the app stack
-    cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
-                                        act = lo_result->ms_next-s_set-s_popover-xml ).
+    " a popover is destroyed on navigation just like a popup - the XML of the
+    " calling app must not leak into the called app
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_result->ms_next-s_set-s_popover-check_destroy ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popover-xml ).
 
     " the frontend is told to push a route entry for the called app, and where
     " the CALLING app was just saved - it repoints the caller's history entry at
@@ -370,9 +372,10 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = abap_true
                                         act = lo_result->ms_next-s_set-s_popup-check_destroy ).
     cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popup-xml ).
-    " popovers are carried across the app stack
-    cl_abap_unit_assert=>assert_equals( exp = `<popover/>`
-                                        act = lo_result->ms_next-s_set-s_popover-xml ).
+    " a popover is destroyed on leave as well, for the same reason
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_result->ms_next-s_set-s_popover-check_destroy ).
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-s_set-s_popover-xml ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
fixes these errors:
<img width="2281" height="510" alt="image" src="https://github.com/user-attachments/assets/c09aa805-ff2b-4ba0-9ddd-f917ce58f99b" />
<img width="2262" height="1025" alt="image" src="https://github.com/user-attachments/assets/4f8c1e29-d261-451f-b400-71abacfa208a" />

z2ui5_cl_a2ui5_context: ltcl_rtti calls the private scan_flag_prefix( )
without a LOCAL FRIENDS declaration. abaplint accepts this, the ABAP
compiler rejects the whole class pool, aborting 50 test classes.

z2ui5_cl_core_action: 14f4e7a0 (#2496) made prepare_app_stack( ) destroy
popovers alongside popups; test_stack_call / test_stack_leave still
expected the popover XML to survive navigation.
