### PR TITLE
Fix ATC/SLIN extended-check violations and document pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,30 @@ This project follows the [SAP Clean ABAP styleguide](https://github.com/SAP/styl
 - No Yoda conditions
 - `forbidden_void_type` blocks SAP standard types — use `abap_bool`, `i`, `string` etc.
 
+### Extended-check (SLIN/ATC) pitfalls — not caught by abaplint
+
+The sources are also run through the extended program check in real systems,
+which flags things `npm run check` cannot see. Known traps — avoid them up
+front, a green abaplint does not prove their absence:
+
+- **POSIX regex is deprecated.** `FIND/REPLACE ... REGEX` uses the POSIX
+  standard; the PCRE replacement (`FIND PCRE`) only exists on >= 7.55 and this
+  repo targets v750/7.02. Prefer plain string logic over regex where feasible;
+  when a regex is genuinely needed, add the `##REGEX_POSIX` pragma to the
+  statement (the established convention — the vendored AJSON code does the same).
+- **No redundant conversions.** Do not wrap a value in `CONV string( ... )`
+  (or `CONV #( ... )`) when the source already has the target type — assign it
+  directly (bit us in `z2ui5_cl_core_action=>factory_first_start`, where
+  `s_control-app_start` is already a `string`).
+- **ABAP Doc (`"!`) position:** a doc comment must sit directly before the one
+  declaration it documents. In a chained statement (`CONSTANTS: BEGIN OF ...`)
+  that means *inside* the chain, directly before the element — a `"!` block
+  before the chain keyword is "in the wrong position" (bit us on
+  `z2ui5_if_client=>cs_nav_mode`).
+- **ABAP Doc is parsed as HTML:** a literal `<`/`>`/`&` must be escaped as
+  `&lt;`/`&gt;`/`&amp;` — a placeholder like `#/app/<CLASS>` is otherwise read
+  as an unsupported, unclosed HTML tag; write `#/app/&lt;CLASS&gt;`.
+
 ## Build & Validation
 
 Install dependencies: `npm install` (frontend gates additionally need

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -118,8 +118,8 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
         " characters before reflecting it into the error text - a real typo
         " still shows for diagnostics, but a crafted value cannot smuggle
         " markup/script into the response body.
-        DATA(lv_app_name) = CONV string( mo_http_post->ms_request-s_control-app_start ).
-        REPLACE ALL OCCURRENCES OF REGEX `[^A-Za-z0-9_/]` IN lv_app_name WITH ``.
+        DATA(lv_app_name) = mo_http_post->ms_request-s_control-app_start.
+        REPLACE ALL OCCURRENCES OF REGEX `[^A-Za-z0-9_/]` IN lv_app_name WITH `` ##REGEX_POSIX.
         RAISE EXCEPTION TYPE z2ui5_cx_a2ui5_error
           EXPORTING
             val      = |The app '{ lv_app_name }' does not exist in the system.|

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -263,7 +263,7 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
       " bindings/object literals like {/PATH} or {..}. {0/field} (relative
       " binding) keeps a `/` after the digits and is therefore not matched, so
       " it stays raw as before.
-      FIND REGEX `^\{[0-9]+[?}]` IN lv_new.
+      FIND REGEX `^\{[0-9]+[?}]` IN lv_new ##REGEX_POSIX.
       DATA(lv_is_placeholder) = xsdbool( sy-subrc = 0 ).
       IF (     lv_new(1) <> `$`
            AND lv_new(1) <> `{`

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -73,17 +73,17 @@ INTERFACE z2ui5_if_client
       popover TYPE string VALUE `POPOVER`,
     END OF cs_view.
 
-  "! Hash-based app routing modes (see set_nav_routing). The mode decides how
-  "! much of the running app the URL hash carries, and therefore what the
-  "! browser Back/Forward buttons (and a reload / bookmark) restore:
-  "!  default - no routing: the hash is left untouched, exactly as before this
-  "!            feature. Back/Forward leave the abap2UI5 page (framework default).
-  "!  fresh   - route '#/app/<CLASS>' (class only): Back/Forward/reload/bookmark
-  "!            start the app FRESH (a clean instance, no preserved input).
-  "!  keep    - route '#/app/<CLASS>/<DRAFT>' (class + server draft): the exact
-  "!            preserved state is restored (all user input), falling back to a
-  "!            fresh start once the draft has expired.
   CONSTANTS:
+    "! Hash-based app routing modes (see set_nav_routing). The mode decides how
+    "! much of the running app the URL hash carries, and therefore what the
+    "! browser Back/Forward buttons (and a reload / bookmark) restore:
+    "!  default - no routing: the hash is left untouched, exactly as before this
+    "!            feature. Back/Forward leave the abap2UI5 page (framework default).
+    "!  fresh   - route '#/app/&lt;CLASS&gt;' (class only): Back/Forward/reload/bookmark
+    "!            start the app FRESH (a clean instance, no preserved input).
+    "!  keep    - route '#/app/&lt;CLASS&gt;/&lt;DRAFT&gt;' (class + server draft): the exact
+    "!            preserved state is restored (all user input), falling back to a
+    "!            fresh start once the draft has expired.
     BEGIN OF cs_nav_mode,
       default TYPE string VALUE `DEFAULT`,
       fresh   TYPE string VALUE `FRESH`,
@@ -137,8 +137,8 @@ INTERFACE z2ui5_if_client
   "!
   "! The mode (see cs_nav_mode) decides what Back/Forward/reload/bookmark
   "! restore: keep (default) restores the exact preserved state via a draft id
-  "! in the route '#/app/<CLASS>/<DRAFT>'; fresh routes by class only
-  "! '#/app/<CLASS>' and always starts the app fresh; default disables routing
+  "! in the route '#/app/&lt;CLASS&gt;/&lt;DRAFT&gt;'; fresh routes by class only
+  "! '#/app/&lt;CLASS&gt;' and always starts the app fresh; default disables routing
   "! (framework behaviour as before this feature).
   "!
   "! In keep mode the calling app's route entry is advanced to the draft saved


### PR DESCRIPTION
# Description

This PR addresses extended-check (SLIN/ATC) violations that `abaplint` cannot detect and documents known pitfalls to avoid them upfront.

## Changes

1. **AGENTS.md**: Added new section "Extended-check (SLIN/ATC) pitfalls — not caught by abaplint" documenting four common traps:
   - POSIX regex deprecation and the `##REGEX_POSIX` pragma convention
   - Redundant type conversions (e.g., `CONV string(...)` when source is already `string`)
   - ABAP Doc (`"!`) positioning in chained statements
   - HTML escaping in ABAP Doc comments (`<`/`>`/`&` must be escaped)

2. **z2ui5_if_client.intf.abap**: 
   - Moved ABAP Doc comments inside the `CONSTANTS:` chain (directly before `BEGIN OF cs_nav_mode`) to fix positioning violation
   - Escaped angle brackets in doc comments: `<CLASS>` → `&lt;CLASS&gt;`, `<DRAFT>` → `&lt;DRAFT&gt;`

3. **z2ui5_cl_core_action.clas.abap**:
   - Removed redundant `CONV string(...)` conversion; `s_control-app_start` is already a `string`
   - Added `##REGEX_POSIX` pragma to the `REPLACE ... REGEX` statement

4. **z2ui5_cl_core_srv_event.clas.abap**:
   - Added `##REGEX_POSIX` pragma to the `FIND REGEX` statement

## How to test

Run extended program check in a real SAP system or verify via ATC. The changes eliminate known violations while maintaining identical runtime behavior.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] No unit tests needed (documentation and pragma additions)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively (doc comments only)
- [x] Changes made via abapGit: no (manual edits to fix violations)

https://claude.ai/code/session_01CTdyZoxkHYW3AYo3rfxQRW