### PR TITLE
Update abap2UI5-linter repository URL to shorter alias

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -28,7 +28,7 @@ Quick orientation while it loads:
   frontend). UI5 1.71 is the compatibility floor — check "available since".
 - The app checks its own authorizations at the top of `main`.
 - Validate with the abap2UI5-linter
-  (`npx --yes github:abap2UI5/abap2UI5-linter <file>`); iterate without a SAP
+  (`npx --yes github:abap2UI5/linter <file>`); iterate without a SAP
   system via the ai-mcp server (`deploy_app` → `build_backend` → `run_app`).
 - The API contract is `src/02/z2ui5_if_client.intf.abap` — when unsure about
   a method or a `cs_event` action, read it there; the `follow_up_action`

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -262,15 +262,15 @@ ships for existing apps but is **frozen** — new apps and new code use
   [abap2UI5/app-template](https://github.com/abap2UI5/app-template)** — it
   ships the starter app, abaplint + linter CI, this guide as its AGENTS.md
   and the agent permission setup preconfigured.
-- **[abap2UI5-linter](https://github.com/abap2UI5/abap2UI5-linter)** checks
+- **[abap2UI5-linter](https://github.com/abap2UI5/linter)** checks
   app classes statically (unknown/deprecated/too-new controls and members,
   binding mistakes, builder-tree defects) and can render the view headless:
-  `npx --yes github:abap2UI5/abap2UI5-linter my_app.clas.abap` — also
+  `npx --yes github:abap2UI5/linter my_app.clas.abap` — also
   available as a GitHub Action and inside the VS Code extension.
 - **[ai-mcp](https://github.com/abap2UI5/ai-mcp)** gives MCP-capable agents
   the full loop without a SAP system: `capabilities` → `deploy_app` →
   `build_backend` → `run_app` (headless screenshot + errors).
-- **[vscode-extension](https://github.com/abap2UI5-addons/vscode-extension)**:
+- **[vscode-extension](https://github.com/abap2UI5/vscode-extension)**:
   F9 launches the class in an embedded preview against a real system.
 - **Worked examples**: ~280 gate-verified sample apps in
   [ai-demokit](https://github.com/abap2UI5/ai-demokit) (`src/`), curated

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Two audiences, two entry points:
 - [ai-demokit](https://github.com/abap2UI5/ai-demokit): ~280 gate-verified
   ports of the official UI5 demo kit samples, plus CAPABILITIES.md (what
   abap2UI5 can express)
-- [abap2UI5-linter](https://github.com/abap2UI5/abap2UI5-linter): static +
+- [abap2UI5-linter](https://github.com/abap2UI5/linter): static +
   headless-render checks for app view code (CLI, GitHub Action, VS Code)
 - [ai-mcp](https://github.com/abap2UI5/ai-mcp): MCP server with the
   deploy -> build -> run -> screenshot loop, no SAP system needed


### PR DESCRIPTION
# Description

Updates all references to the abap2UI5-linter repository from `abap2UI5/abap2UI5-linter` to the shorter alias `abap2UI5/linter` across documentation and skill guides. This reflects a repository rename/alias that makes the GitHub URL more concise while maintaining the same functionality.

Changes made:
- Updated npm command examples in docs/agents/building-apps.md
- Updated linter reference in .claude/skills/build-an-app/SKILL.md
- Updated repository link in llms.txt
- Also corrected vscode-extension repository path from `abap2UI5-addons/vscode-extension` to `abap2UI5/vscode-extension`

## How to test

No testing needed — these are documentation-only changes updating external repository URLs and CLI command examples.

## Checklist

- [ ] `npx abaplint` passes (0 issues)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: no (documentation only)

https://claude.ai/code/session_01PHp9RQdudtTNA31uPmiG2Z