### PR TITLE
Add POPUP.setWithinArea support for confining popups to controls

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -223,6 +223,14 @@ sap.ui.define(
         get: () => sap.ui.require("sap/ui/core/Theming"),
         methods: { setTheme: ["string"] },
       },
+      // sap/ui/core/Popup exists on every supported release, but
+      // setWithinArea is @since 1.89 - so resolve the module lazily like
+      // THEMING and let the "not available" guard below report the older
+      // runtime instead of failing the component load.
+      POPUP: {
+        get: () => sap.ui.require("sap/ui/core/Popup"),
+        methods: { setWithinArea: ["within"] },
+      },
     };
 
     // Cast one raw string argument to the kind the whitelist declared.
@@ -252,6 +260,19 @@ sap.ui.define(
           return (
             (view && ViewSlots.byId(view.toUpperCase(), raw)) ||
             ViewSlots.resolveById(raw)
+          );
+        case "within":
+          // sap.ui.core.Popup.setWithinArea: a control id confines every popup
+          // to that control, an EMPTY argument releases the restriction (the
+          // popup is bounded by the window again). Popup.convertWithin()
+          // accepts a sap.ui.core.Element and dereferences its DOM node when a
+          // popup opens, so handing over the CONTROL - not its DOM element -
+          // is what survives a re-render of the area in between.
+          if (raw === "" || raw === undefined || raw === null) return null;
+          return (
+            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||
+            ViewSlots.resolveById(raw) ||
+            null
           );
         case "object":
           try {

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -17,6 +17,7 @@ function load({ sandbox } = {}) {
   const MessageBox = { show: rec("box.show"), error: rec("box.error") };
   const BusyIndicator = { show: rec("busy.show"), hide: rec("busy.hide") };
   const Theming = { setTheme: rec("theme.set") };
+  const Popup = { setWithinArea: rec("popup.setWithinArea") };
   const controls = {};
   const views = {};
   const ViewSlots = {
@@ -66,6 +67,7 @@ function load({ sandbox } = {}) {
     controls,
     views,
     AppState,
+    Popup,
     ctx,
   };
 }
@@ -188,6 +190,45 @@ test.describe("CONTROL_GLOBAL (global objects)", () => {
       "0",
     ]);
     expect(calls).toEqual([["busy.show", 0]]);
+  });
+
+  test("POPUP.setWithinArea resolves a control id and hands over the CONTROL", () => {
+    const { FrontendAction, calls, controls, Popup, ctx } = load();
+    const area = { id: "withinArea" };
+    controls.withinArea = area;
+    ctx.sap.ui.require = (name) =>
+      name === "sap/ui/core/Popup" ? Popup : null;
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "POPUP",
+      "setWithinArea",
+      "withinArea",
+    ]);
+    // the control, not its DOM node: Popup dereferences it when a popup opens,
+    // so the area survives a re-render in between
+    expect(calls).toEqual([["popup.setWithinArea", area]]);
+  });
+
+  test("POPUP.setWithinArea releases the area on an empty argument", () => {
+    const { FrontendAction, calls, Popup, ctx } = load();
+    ctx.sap.ui.require = (name) =>
+      name === "sap/ui/core/Popup" ? Popup : null;
+    FrontendAction.execute(null, ["CONTROL_GLOBAL", "POPUP", "setWithinArea", ""]);
+    expect(calls).toEqual([["popup.setWithinArea", null]]);
+  });
+
+  test("POPUP.setWithinArea reports an older runtime instead of throwing", () => {
+    const { FrontendAction, calls, errors, ctx } = load();
+    // UI5 1.71 has sap/ui/core/Popup but not setWithinArea (@since 1.89)
+    ctx.sap.ui.require = () => ({});
+    FrontendAction.execute(null, [
+      "CONTROL_GLOBAL",
+      "POPUP",
+      "setWithinArea",
+      "withinArea",
+    ]);
+    expect(calls).toHaveLength(0);
+    expect(errors).toEqual(["CONTROL_GLOBAL: 'POPUP.setWithinArea' not available"]);
   });
 
   test("rejects a non-whitelisted object or method", () => {

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -250,6 +250,14 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        get: () => sap.ui.require("sap/ui/core/Theming"),` && |\n| &&
              `        methods: { setTheme: ["string"] },` && |\n| &&
              `      },` && |\n| &&
+             `      // sap/ui/core/Popup exists on every supported release, but` && |\n| &&
+             `      // setWithinArea is @since 1.89 - so resolve the module lazily like` && |\n| &&
+             `      // THEMING and let the "not available" guard below report the older` && |\n| &&
+             `      // runtime instead of failing the component load.` && |\n| &&
+             `      POPUP: {` && |\n| &&
+             `        get: () => sap.ui.require("sap/ui/core/Popup"),` && |\n| &&
+             `        methods: { setWithinArea: ["within"] },` && |\n| &&
+             `      },` && |\n| &&
              `    };` && |\n| &&
              `` && |\n| &&
              `    // Cast one raw string argument to the kind the whitelist declared.` && |\n| &&
@@ -279,6 +287,19 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          return (` && |\n| &&
              `            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||` && |\n| &&
              `            ViewSlots.resolveById(raw)` && |\n| &&
+             `          );` && |\n| &&
+             `        case "within":` && |\n| &&
+             `          // sap.ui.core.Popup.setWithinArea: a control id confines every popup` && |\n| &&
+             `          // to that control, an EMPTY argument releases the restriction (the` && |\n| &&
+             `          // popup is bounded by the window again). Popup.convertWithin()` && |\n| &&
+             `          // accepts a sap.ui.core.Element and dereferences its DOM node when a` && |\n| &&
+             `          // popup opens, so handing over the CONTROL - not its DOM element -` && |\n| &&
+             `          // is what survives a re-render of the area in between.` && |\n| &&
+             `          if (raw === "" || raw === undefined || raw === null) return null;` && |\n| &&
+             `          return (` && |\n| &&
+             `            (view && ViewSlots.byId(view.toUpperCase(), raw)) ||` && |\n| &&
+             `            ViewSlots.resolveById(raw) ||` && |\n| &&
+             `            null` && |\n| &&
              `          );` && |\n| &&
              `        case "object":` && |\n| &&
              `          try {` && |\n| &&
@@ -403,7 +424,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          Lib.logError(` && |\n| &&
              `            ``CONTROL_BY_ID: 'openBy' not callable on control '${id}'``,` && |\n| &&
              `          );` && |\n| &&
-             `          return;` && |\n| &&
+             `          return;` && |\n|.
+    result = result &&
              `        }` && |\n| &&
              `        const anchor = castArgs(kinds, args.slice(4), view)[0];` && |\n| &&
              `        // Same reason as toggleBy: wait for the anchor to render.` && |\n| &&
@@ -424,8 +446,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `` && |\n| &&
              `    // args: [_, object, method, ...params]` && |\n| &&
              `    function evControlCall(oController, args) {` && |\n| &&
-             `      const [, name, method] = args;` && |\n|.
-    result = result &&
+             `      const [, name, method] = args;` && |\n| &&
              `      const target = GLOBAL_TARGETS[name];` && |\n| &&
              `      const kinds = target?.methods[method];` && |\n| &&
              `      if (!kinds) {` && |\n| &&
@@ -804,7 +825,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        Lib.logError("SYSTEM_LOGOUT: ushell logout failed", e);` && |\n| &&
              `      }` && |\n| &&
              `      logoutViaBspTerminate(logoutUrl);` && |\n| &&
-             `    }` && |\n| &&
+             `    }` && |\n|.
+    result = result &&
              `` && |\n| &&
              `    // When abap2UI5 is hosted as a BSP application,` && |\n| &&
              `    // /sap/public/bc/icf/logoff alone does not terminate the stateful` && |\n| &&
@@ -825,8 +847,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      const bspKill = ``${path}?sap-sessioncmd=logoff``;` && |\n| &&
              `      let done = false;` && |\n| &&
              `      let frame;` && |\n| &&
-             `      const finish = () => {` && |\n|.
-    result = result &&
+             `      const finish = () => {` && |\n| &&
              `        if (done) return;` && |\n| &&
              `        done = true;` && |\n| &&
              `        // Remove the hidden BSP-kill iframe. On a successful logout the page` && |\n| &&
@@ -1205,7 +1226,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            params.SUBJECT,` && |\n| &&
              `            params.BODY,` && |\n| &&
              `            params.CC,` && |\n| &&
-             `            params.BCC,` && |\n| &&
+             `            params.BCC,` && |\n|.
+    result = result &&
              `            params.NEW_WINDOW,` && |\n| &&
              `          ),` && |\n| &&
              `        TRIGGER_SMS: () =>` && |\n| &&
@@ -1226,8 +1248,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const editor = ViewSlots.byId("POPUP", "imageEditor");` && |\n| &&
              `        if (editor) image = editor.getImagePngDataURL();` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n|.
-    result = result &&
+             `        Lib.logError("IMAGE_EDITOR_POPUP_CLOSE: getImagePngDataURL failed", e);` && |\n| &&
              `      }` && |\n| &&
              `      ViewSlots.destroy("POPUP");` && |\n| &&
              `      oController.eB(["SAVE"], image);` && |\n| &&
@@ -1606,7 +1627,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const handler = handlers[args[0]];` && |\n| &&
              `        if (handler) handler(oController, args);` && |\n| &&
              `      } catch (e) {` && |\n| &&
-             `        // Backstop: individual handlers already guard themselves, but a` && |\n| &&
+             `        // Backstop: individual handlers already guard themselves, but a` && |\n|.
+    result = result &&
              `        // malformed payload must never let an error escape into the caller.` && |\n| &&
              `        Lib.logError(``FrontendAction: handler '${args[0]}' failed``, e);` && |\n| &&
              `      }` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -331,8 +331,11 @@ INTERFACE z2ui5_if_client
   "! view parameter (default cs_view-main resolves the id across all open
   "! views; pass cs_view-popup/popover/... to scope the lookup to that view).
   "! cs_event-control_global - call a whitelisted method on a global object
-  "! (MESSAGE_TOAST, MESSAGE_BOX, BUSY_INDICATOR, THEMING):
+  "! (MESSAGE_TOAST, MESSAGE_BOX, BUSY_INDICATOR, THEMING, POPUP):
   "! t_arg = object, method, params.
+  "! POPUP-setWithinArea confines every popup to the control whose id is
+  "! passed (sap.ui.core.Popup.setWithinArea, needs UI5 &gt;= 1.89) instead of
+  "! to the window; an EMPTY argument releases the restriction again.
   "! cs_event-smart_variant_init - run the initialise( ) handshake sap.ui.comp
   "! variant management needs (a controller would call
   "! oSmartVariantManagement.initialise( fnCallback, oPersonalizableControl )).


### PR DESCRIPTION
# Description

This PR adds support for `sap.ui.core.Popup.setWithinArea()` (UI5 >= 1.89) as a whitelisted global control method, allowing popups to be confined to specific controls instead of the window.

## Changes

- **FrontendAction**: Added `POPUP` to the `GLOBAL_TARGETS` whitelist with `setWithinArea` method support
- **Argument casting**: Implemented `"within"` case to resolve control IDs and pass the control instance (not its DOM node) to `setWithinArea`, ensuring the area survives re-renders
- **Empty argument handling**: Empty/null/undefined arguments release the popup restriction by passing `null`
- **Lazy module loading**: `POPUP` module is resolved lazily (like `THEMING`) to gracefully handle older UI5 versions that lack `setWithinArea`
- **Documentation**: Updated interface documentation to describe the new `POPUP.setWithinArea` capability
- **Tests**: Added comprehensive unit tests covering control resolution, empty argument handling, and graceful degradation on older runtimes

## How to test

Run the new unit tests in `node/tests/frontendAction.spec.js`:
- `POPUP.setWithinArea resolves a control id and hands over the CONTROL`
- `POPUP.setWithinArea releases the area on an empty argument`
- `POPUP.setWithinArea reports an older runtime instead of throwing`

Verify that calling `CONTROL_GLOBAL` with `POPUP`, `setWithinArea`, and a control ID properly confines popups to that control on UI5 >= 1.89, and gracefully reports unavailability on older versions.

## Checklist

- [x] `npx abaplint` passes (0 issues)
- [x] Unit tests added/updated where it makes sense (node/tests/frontendAction.spec.js)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (changes via code generation)
- [x] Public API in `src/02/` only changed additively (added documentation for new capability)
- [x] Changes were made via abapGit: no (generated code)

https://claude.ai/code/session_01RR4Nm1BAVUsw6kVzCChHoW