### PR TITLE
Reserve a resourceRoot so custom controls can ship in their own BSP

### DIFF
--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -73,6 +73,9 @@
       "viewName": "z2ui5.view.App",
       "type": "XML",
       "id": "App"
+    },
+    "resourceRoots": {
+      "z2ui5cc": "../z2ui5cc/"
     }
   },
   "sap.cloud": {

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -100,6 +100,9 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "viewName": "z2ui5.view.App",` &&
              `      "type": "XML",` &&
              `      "id": "App"` &&
+             `    },` &&
+             `    "resourceRoots": {` &&
+             `      "z2ui5cc": "../z2ui5cc/"` &&
              `    }` &&
              `  },` &&
              `  "sap.cloud": {` &&


### PR DESCRIPTION
## Problem

A custom control cannot currently be delivered separately from the framework. Adding one touches four places:

1. `app/webapp/cc/<Name>.js`
2. the mirrored ABAP holder class `src/01/03/z2ui5_cl_app_<name>_js.clas.abap`
3. its entry in `z2ui5_cl_app_preload`
4. a wrapper method in `z2ui5_cl_xml_view_cc` plus an entry in the hardcoded namespace map in `z2ui5_cl_xml_view` (`st_ns_map`)

So every customer-specific control needs a pull request against this repository, and the framework carries JavaScript nobody else uses — the embedded `cc` holder classes alone are ~2,800 lines of ABAP.

The obvious workaround does not work where it matters. `cs_config-custom_js` is only consumed in `z2ui5_cl_http_handler=>_http_get`, and `main( )` routes `HEAD` and `POST` separately — `_http_get` is reached only in the `WHEN OTHERS` branch. An installation running the frontend BSP loads `index.html` from that BSP and only ever `POST`s to the abap2UI5 endpoint, so the preload never runs at all.

## Change

One reserved resourceRoot in `app/webapp/manifest.json`:

```json
"sap.ui5": {
  "resourceRoots": { "z2ui5cc": "../z2ui5cc/" }
}
```

The path is a sibling of the frontend BSP, so a control BSP deployed as `Z2UI5CC` is served from `/sap/bc/ui5_ui5/sap/z2ui5cc/` and every module under `z2ui5cc/…` resolves there — in the standalone BSP and inside the Fiori Launchpad alike, since both load the component from the same base URL.

`Manifest.defineResourceRoots` rejects only *absolute* paths; a relative one is resolved against the component with `resolveUri` and registered via `sap.ui.loader.config({paths})`, before any view is created.

Nothing is needed on the ABAP side: `z2ui5_cl_ai_xml` already declares arbitrary XML namespaces, so a foreign control needs neither an entry in `st_ns_map` nor a method in `z2ui5_cl_xml_view_cc`. A consumer writes:

```abap
view->a( n = `xmlns:z2ui5cc` v = `z2ui5cc.cc` ).      " once, on the root
```

`src/01/03/z2ui5_cl_app_manifest_json.clas.abap` is regenerated with `npm run app2abap`; the diff is 3 + 3 lines.

## Cost for installations without custom controls

None. resourceRoot registration is lazy — no module under `z2ui5cc/` is ever required, so nothing is requested and the entry has no runtime effect.

## Verification

Checked headless against the transpiled backend (ai-demokit `node:build` + `node:serve`), with a `Z2UI5CC` BSP stood in for by serving the control at whatever URL UI5 derives from the manifest entry — so the run fails if the entry is ignored, resolved to the wrong place, or applied after the first view is built:

```
RENDERED   "presses0"
BSP HITS   ["/z2ui5cc/cc/Counter.js"]
CLICK 1-3  control="presses1/2/3"
INFO       OK - control count 3 matches 3 roundtrip(s) handled in ABAP.
ERRORS     none
RESULT     PASS  (loaded from resourceRoot: true)
```

`BSP HITS` is the load-bearing line: UI5 derived the path from this manifest entry and fetched the control from there rather than from the framework. Property binding, two-way write-back from the control into the model, and event dispatch back into ABAP then behave exactly as for a built-in control.

The reference control used for the run lives in [abap2UI5/test-cc](https://github.com/abap2UI5/test-cc/pull/1) (`?app_start=zcl_z2ui5cc_demo`).

## Scope

One reserved name, one control BSP. That covers the common case — a customer collects their controls in `Z2UI5CC`.

Not covered: several independently deployed control BSPs, and freely named ones. Both would need the loader configuration to travel over the protocol — a `t_resource_roots` in `ty_s_next_frontend` applied in the frontend's `core/Server.js` via `sap.ui.loader.config({ paths })` before `XMLView.create`. That can be layered on top of this convention later without breaking it.

In the standalone HTTP-service setup the sibling path points next to the ICF node rather than at a BSP, so the entry is inert there unless something is actually served at that path; `cs_config-custom_js` remains the way to inject control JavaScript in that mode.

## Follow-up not in this PR

`docs/advanced/extensibility/custom_control.md` still describes the old flow ("add the JS to the frontend, add a method to `z2ui5_cl_xml_view_cc`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB

---
_Generated by [Claude Code](https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB)_