### PR TITLE
Resolve the custom-control resourceRoot in the standalone HTTP service too

### DIFF
--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -232,6 +232,28 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
       lv_style_css = ls_config-styles_css.
     ENDIF.
 
+    " Custom controls live in their own BSP, which the frontend finds through
+    " the reserved resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/").
+    " That path is a sibling of the FRONTEND BSP and is therefore only correct
+    " when the app is served from it. Here the component base is this ICF node,
+    " so the very same relative path resolves next to /sap/bc/ and nothing is
+    " there - the module fails to load with a plausible-looking URL.
+    "
+    " Register the absolute BSP path instead, so the standalone HTTP service
+    " reaches the same control BSP as the frontend one. Two constraints decide
+    " where this can go:
+    "   - it must be absolute, because there is no relative path from this ICF
+    "     node to the BSP tree that also holds when the node is renamed. The
+    "     manifest cannot carry it: Manifest~defineResourceRoots drops absolute
+    "     paths. sap.ui.loader.config has no such restriction.
+    "   - it must run AFTER the manifest, which registers the relative path
+    "     during component creation and would otherwise win. The Component.js
+    "     module body is evaluated after that step, and custom_js is injected
+    "     exactly there - hence prepending rather than a separate <script>.
+    " Registration is lazy: without a Z2UI5CC BSP nothing is ever requested.
+    DATA(lv_cc_resource_root) =
+        |sap.ui.loader.config(\{paths:\{"z2ui5cc":"/sap/bc/ui5_ui5/sap/z2ui5cc"\}\});|.
+
     result-body = |<!DOCTYPE html>| && |\n| &&
                |<html lang="en">| && |\n| &&
                |<head>| && |\n| &&
@@ -250,7 +272,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
              " generated preload mapping (see .github/app2abap/trans2abap.js),
              " so the list can never run out of sync with app/webapp.
              z2ui5_cl_app_preload=>get( styles_css = lv_style_css
-                                        custom_js  = ls_config-custom_js ) &&
+                                        custom_js  = |{ lv_cc_resource_root }{ ls_config-custom_js }| ) &&
              |    \});| && |\n| &&
              |    sap.ui.require(["sap/ui/core/ComponentSupport"], function(ComponentSupport)\{| && |\n| &&
              |     window.z2ui5 = \{ checkLocal : true \}; ComponentSupport.run();| && |\n| &&


### PR DESCRIPTION
Follow-up to #2514, which reserved `"z2ui5cc": "../z2ui5cc/"` in the manifest so custom controls can ship in their own BSP.

## Problem

That path is a sibling of the **frontend BSP**, so it is only correct when the app is served from it. Reported from a live system: with the frontend BSP the control loads, but calling the ICF node directly fails.

```
http://<host>/sap/bc/z2ui5?sap-client=100&app_start=zcl_z2ui5cc_demo

ModuleError: failed to load 'z2ui5cc/cc/Counter.js' from ../z2ui5cc/cc/Counter.js
```

In the standalone HTTP service the component base is the ICF node, so the same relative path resolves next to `/sap/bc/` — where nothing is. Worse than not working: the URL looks plausible, so the failure reads like a deployment problem.

## Change

`_http_get` registers the absolute BSP path, so both modes reach the same control BSP with no configuration. Two constraints decide where that can happen:

- **It has to be absolute.** No relative path from the ICF node to the BSP tree survives a renamed node. The manifest cannot carry an absolute one: `Manifest~defineResourceRoots` drops absolute paths (`isAbsolute() || plainUrl[0] === "/"` → logged and skipped). `sap.ui.loader.config` has no such restriction.
- **It has to run after the manifest.** `defineResourceRoots()` registers the relative path during component creation (`Component.js`, on the manifest promise) and would win over anything registered in the bootstrap. The `Component.js` module body is evaluated after that step, and `custom_js` is injected exactly there — hence prepending to `custom_js` rather than emitting a separate `<script>`.

The user-facing `custom_js` field keeps its meaning: the framework line is only prepended, so an exit that sets it still runs and can override the path if a system needs a different one. Registration is lazy, so without a `Z2UI5CC` BSP nothing is ever requested.

## Verification

A headless run against the transpiled backend is in flight — the standalone shell, with the `Z2UI5CC` BSP stood in for at the absolute path, checking that the module is fetched from `/sap/bc/ui5_ui5/sap/z2ui5cc/` and **not** from the manifest-derived path, and that a drawn signature round-trips into ABAP and back into an `sap.m.Image`. I will post the result here.

What is already established: `defineResourceRoots` runs on all three component-creation paths, absolute paths are rejected there, and the BSP-mode chain was verified end to end for #2514.

## Related

- [abap2UI5/test-cc#3](https://github.com/abap2UI5/test-cc/pull/3) — the control library this resolves against (`?app_start=zcl_z2ui5cc_demo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB

---
_Generated by [Claude Code](https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB)_