### PR TITLE
Apply the custom-control resourceRoot after the manifest, not from the page

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -39,6 +39,22 @@ sap.ui.define(
         // a fully initialized global from here on.
         AppState.initGlobal();
 
+        // A custom-control BSP is normally found through the reserved
+        // resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/"), a sibling
+        // of THIS BSP. In the standalone HTTP service there is no BSP for it
+        // to be a sibling of, so the backend hands the absolute path over on
+        // the global instead (z2ui5_cl_http_handler=>_http_get).
+        //
+        // It has to be applied HERE and not in the page: the manifest
+        // registers its own value while the component is being created, which
+        // is after everything the shell can run, so a registration made there
+        // is overwritten again. init() runs after manifest processing.
+        // Absent in BSP and Launchpad mode, where the manifest entry is right.
+        const ccResourceRoot = AppState.getGlobal("ccResourceRoot");
+        if (ccResourceRoot) {
+          sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });
+        }
+
         UIComponent.prototype.init.call(this);
 
         AppState.getGlobal("oConfig").ComponentData = this.getComponentData();

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -66,6 +66,22 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        // a fully initialized global from here on.` && |\n| &&
              `        AppState.initGlobal();` && |\n| &&
              `` && |\n| &&
+             `        // A custom-control BSP is normally found through the reserved` && |\n| &&
+             `        // resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/"), a sibling` && |\n| &&
+             `        // of THIS BSP. In the standalone HTTP service there is no BSP for it` && |\n| &&
+             `        // to be a sibling of, so the backend hands the absolute path over on` && |\n| &&
+             `        // the global instead (z2ui5_cl_http_handler=>_http_get).` && |\n| &&
+             `        //` && |\n| &&
+             `        // It has to be applied HERE and not in the page: the manifest` && |\n| &&
+             `        // registers its own value while the component is being created, which` && |\n| &&
+             `        // is after everything the shell can run, so a registration made there` && |\n| &&
+             `        // is overwritten again. init() runs after manifest processing.` && |\n| &&
+             `        // Absent in BSP and Launchpad mode, where the manifest entry is right.` && |\n| &&
+             `        const ccResourceRoot = AppState.getGlobal("ccResourceRoot");` && |\n| &&
+             `        if (ccResourceRoot) {` && |\n| &&
+             `          sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });` && |\n| &&
+             `        }` && |\n| &&
+             `` && |\n| &&
              `        UIComponent.prototype.init.call(this);` && |\n| &&
              `` && |\n| &&
              `        AppState.getGlobal("oConfig").ComponentData = this.getComponentData();` && |\n| &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -232,28 +232,6 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
       lv_style_css = ls_config-styles_css.
     ENDIF.
 
-    " Custom controls live in their own BSP, which the frontend finds through
-    " the reserved resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/").
-    " That path is a sibling of the FRONTEND BSP and is therefore only correct
-    " when the app is served from it. Here the component base is this ICF node,
-    " so the very same relative path resolves next to /sap/bc/ and nothing is
-    " there - the module fails to load with a plausible-looking URL.
-    "
-    " Register the absolute BSP path instead, so the standalone HTTP service
-    " reaches the same control BSP as the frontend one. Two constraints decide
-    " where this can go:
-    "   - it must be absolute, because there is no relative path from this ICF
-    "     node to the BSP tree that also holds when the node is renamed. The
-    "     manifest cannot carry it: Manifest~defineResourceRoots drops absolute
-    "     paths. sap.ui.loader.config has no such restriction.
-    "   - it must run AFTER the manifest, which registers the relative path
-    "     during component creation and would otherwise win. The Component.js
-    "     module body is evaluated after that step, and custom_js is injected
-    "     exactly there - hence prepending rather than a separate <script>.
-    " Registration is lazy: without a Z2UI5CC BSP nothing is ever requested.
-    DATA(lv_cc_resource_root) =
-        |sap.ui.loader.config(\{paths:\{"z2ui5cc":"/sap/bc/ui5_ui5/sap/z2ui5cc"\}\});|.
-
     result-body = |<!DOCTYPE html>| && |\n| &&
                |<html lang="en">| && |\n| &&
                |<head>| && |\n| &&
@@ -272,10 +250,25 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
              " generated preload mapping (see .github/app2abap/trans2abap.js),
              " so the list can never run out of sync with app/webapp.
              z2ui5_cl_app_preload=>get( styles_css = lv_style_css
-                                        custom_js  = |{ lv_cc_resource_root }{ ls_config-custom_js }| ) &&
+                                        custom_js  = ls_config-custom_js ) &&
              |    \});| && |\n| &&
              |    sap.ui.require(["sap/ui/core/ComponentSupport"], function(ComponentSupport)\{| && |\n| &&
-             |     window.z2ui5 = \{ checkLocal : true \}; ComponentSupport.run();| && |\n| &&
+             " Custom controls live in their own BSP, which the frontend finds
+             " through the reserved resourceRoot in manifest.json
+             " ("z2ui5cc": "../z2ui5cc/"). That path is a sibling of the
+             " FRONTEND BSP, so it is only correct when the app is served from
+             " it. Here the component base is this ICF node and the same
+             " relative path resolves next to /sap/bc/, where nothing is.
+             "
+             " Hand the absolute BSP path to the frontend instead. It cannot be
+             " applied here: the manifest registers its own value during
+             " component creation, which happens after everything this page can
+             " run, so it would win. Component.js applies the field in init( ),
+             " after manifest processing. AppState~initGlobal keeps fields that
+             " are already on the global when checkLocal is true, so it
+             " survives the component start. In BSP and Launchpad mode the
+             " field is absent and the manifest entry stands.
+             |     window.z2ui5 = \{ checkLocal : true, ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" \}; ComponentSupport.run();| && |\n| &&
              |    \});| && |\n| &&
              |  \}| && |\n| &&
              |</script>| && |\n| &&


### PR DESCRIPTION
Replaces #2515, which is merged but **does not work**. This is the corrected implementation, verified before opening.

## What was wrong with #2515

It registered the absolute BSP path from the GET page, prepended to `custom_js`, on the assumption that `Manifest~defineResourceRoots` runs before the `Component.js` module body. It runs after. The headless run says so plainly — the module is still fetched from the manifest-derived path:

```
REQ    http://localhost:3000/z2ui5cc/cc/Counter.js
toUrl  z2ui5cc/cc/Counter.js
```

The `sap.ui.loader.config` line is present in the served HTML; the manifest simply overwrites it afterwards. UI5's `Manifest.js` states this directly — *"if not loaded via manifest first approach the resource roots will be registered too late for the AMD modules of the Component controller"* — and I read it as applying to the other case. The merged code is inert, not harmful: it registers a path that is immediately replaced.

## The fix

Hand the path to the frontend instead of registering it in the page, and apply it where nothing overwrites it again:

- `_http_get` puts it on the global it already emits:
  `window.z2ui5 = { checkLocal : true, ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" }`
- `Component~init` reads it and calls `sap.ui.loader.config`

`init( )` runs after manifest processing and long before the first view is built, so it is both late enough to win and early enough to matter. `AppState~initGlobal` keeps fields already on the global when `checkLocal` is true, so the value survives the component start. In BSP and Launchpad mode the field is absent and the manifest entry from #2514 stands untouched — which is what those modes need, since there the relative sibling path is correct.

The backend states the path and the frontend only applies it, so no path is hardcoded in the frontend and the protocol is unchanged. Registration stays lazy: without a `Z2UI5CC` BSP nothing is ever requested.

`src/01/03` regenerated with `npm run app2abap`.

## Verification

Headless against the transpiled backend, standalone shell, with the `Z2UI5CC` BSP stood in for at the absolute path and a catch-all that records any request to the manifest-derived path as a failure:

```
LAUNCH     SignaturePad demo rendered
CC HITS    ["/sap/bc/ui5_ui5/sap/z2ui5cc/cc/SignaturePad.js"]
```

The module now comes from the BSP path, and nothing hits the manifest-derived one. The served shell was checked separately:

```
window.z2ui5 = { checkLocal : true, ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" }
```

`abaplint`: 0 issues, 213 files.

## Related

- [abap2UI5/test-cc#3](https://github.com/abap2UI5/test-cc/pull/3) — the control library this resolves against

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB

---
_Generated by [Claude Code](https://claude.ai/code/session_016r9zVGngYysMWrQVsPVMcB)_