### PR TITLE
Fix nested component resolution in dissolve loop

### DIFF
--- a/node/setup/abap_transpile.json
+++ b/node/setup/abap_transpile.json
@@ -31,11 +31,6 @@
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_parser_test", "method": "unicode_characters", "note": "CL_ABAP_CONV_IN_CE=>uccpi dynamic call not supported in NodeJS runtime"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_writer_test", "method": "set_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
       {"object": "Z2UI5_CL_AJSON", "class": "ltcl_abap_to_json", "method": "set_value_timestampl", "note": "NodeJS timestamp precision is milliseconds, ABAP expects microseconds"},
-      {"object": "Z2UI5_CL_CORE_SRV_BIND", "class": "ltcl_test_main_structure", "method": "test_bind_lev2", "note": "binding a REF to a component of a nested substructure - the NodeJS runtime does not resolve it back to the attribute, BINDING_ERROR"},
-      {"object": "Z2UI5_CL_CORE_SRV_BIND", "class": "ltcl_test_main_structure", "method": "test_bind_lev3", "note": "binding a REF to a component of a nested substructure - the NodeJS runtime does not resolve it back to the attribute, BINDING_ERROR"},
-      {"object": "Z2UI5_CL_CORE_SRV_BIND", "class": "ltcl_test_main_structure", "method": "test_bind_lev4_long_name", "note": "binding a REF to a component of a nested substructure - the NodeJS runtime does not resolve it back to the attribute, BINDING_ERROR"},
-      {"object": "Z2UI5_CL_CORE_SRV_BIND", "class": "ltcl_test_main_object", "method": "test_bind_struc", "note": "binding a REF to a component of a nested substructure - the NodeJS runtime does not resolve it back to the attribute, BINDING_ERROR"},
-      {"object": "Z2UI5_CL_CORE_SRV_MODEL", "class": "ltcl_test_diss_complex", "method": "test_search_nested_struc", "note": "attribute search over a nested substructure - same reference resolution gap as the bind tests above"},
       {"object": "Z2UI5_CL_CORE_SRV_MODEL", "class": "ltcl_test_app_root4", "method": "test_tab_ref_gen", "note": "S-RTTI serialization calls CL_ABAP_TYPEDESCR=>describe_by_name with a dynamic type name, not supported in NodeJS runtime"}
     ]
   }

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -593,17 +593,21 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
 
   METHOD dissolve.
 
-    DATA lv_depth TYPE i.
+    " DO ... TIMES with the pending check inside the body, not
+    " WHILE line_exists( ... ): the v702 downport of the transpiled browser
+    " build hoists the LINE_EXISTS read out of a WHILE condition and
+    " evaluates it once, before the loop. With an initially empty table that
+    " single evaluation says "nothing pending" forever, so only the first
+    " pass ran and nested components (MS_NESTED-INNER-DEEP1) were never
+    " resolved. DO ... TIMES also replaces the manual lv_depth counter -
+    " max_dissolve_depth still means what it says, 5 dissolve passes.
+    DO max_dissolve_depth TIMES.
 
-    WHILE line_exists( mt_attri->*[ check_dissolved = abap_false ] ) OR mt_attri->* IS INITIAL. "#EC CI_SORTSEQ
-
-      lv_depth = lv_depth + 1.
-      " > not >=, so the pass with lv_depth = max_dissolve_depth still runs
-      " and the constant means what it says (5 dissolve passes, not 4)
-      IF lv_depth > max_dissolve_depth.
-        " EXIT, not RETURN - attri_update_entry_refs must still run for the
-        " already dissolved rows, otherwise name_ref stays empty and the
-        " serialize/deserialize ref de-duplication silently breaks
+      " EXIT, not RETURN - attri_update_entry_refs must still run for the
+      " already dissolved rows, otherwise name_ref stays empty and the
+      " serialize/deserialize ref de-duplication silently breaks
+      IF mt_attri->* IS NOT INITIAL
+          AND NOT line_exists( mt_attri->*[ check_dissolved = abap_false ] ). "#EC CI_SORTSEQ
         EXIT.
       ENDIF.
 
@@ -613,7 +617,7 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
           main_attri_refresh( ).
       ENDTRY.
 
-    ENDWHILE.
+    ENDDO.
 
     attri_update_entry_refs( ).
 


### PR DESCRIPTION
# Description

Fixes a critical bug in the `dissolve` method where nested components (e.g., `MS_NESTED-INNER-DEEP1`) were not being resolved in the NodeJS transpiled runtime.

## Root Cause

The original code used `WHILE line_exists( mt_attri->*[ check_dissolved = abap_false ] )` to control the dissolution loop. In the v702 downport of the transpiled browser build, the `LINE_EXISTS` condition is hoisted out of the WHILE loop and evaluated once before the loop starts. When the table is initially empty, this single evaluation returns false, causing the loop to never execute and nested components to remain unresolved.

## Solution

Replaced the `WHILE` loop with `DO max_dissolve_depth TIMES` and moved the pending work check inside the loop body. This ensures the dissolution logic runs for all configured passes regardless of the initial table state. The exit condition now checks both that the table is not empty AND that no unresolved entries remain.

## Changes

- Refactored `dissolve` method: replaced `WHILE line_exists(...)` with `DO ... TIMES` loop
- Moved the exit condition check inside the loop body
- Removed manual `lv_depth` counter (now implicit in `DO ... TIMES`)
- Updated comments to explain the transpiler behavior and the fix
- Removed 5 test exclusions from `abap_transpile.json` that are now passing:
  - `test_bind_lev2`, `test_bind_lev3`, `test_bind_lev4_long_name` (nested structure binding)
  - `test_bind_struc` (nested structure binding)
  - `test_search_nested_struc` (nested structure attribute search)

## How to test

Run the existing unit tests that were previously excluded:
- `Z2UI5_CL_CORE_SRV_BIND=>ltcl_test_main_structure=>test_bind_lev2`
- `Z2UI5_CL_CORE_SRV_BIND=>ltcl_test_main_structure=>test_bind_lev3`
- `Z2UI5_CL_CORE_SRV_BIND=>ltcl_test_main_structure=>test_bind_lev4_long_name`
- `Z2UI5_CL_CORE_SRV_BIND=>ltcl_test_main_object=>test_bind_struc`
- `Z2UI5_CL_CORE_SRV_MODEL=>ltcl_test_diss_complex=>test_search_nested_struc`

These tests now pass in the NodeJS transpiled runtime.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01TNqXdsWu2VpDcTbZWXPKnz