### PR TITLE
Refactor: extract helper methods and improve code clarity

### DIFF
--- a/app/webapp/cc/Dirty.js
+++ b/app/webapp/cc/Dirty.js
@@ -32,8 +32,8 @@ sap.ui.define(
         },
       },
       setIsDirty(val) {
-        // Empty renderer -> suppress the no-op invalidation; the dirty state
-        // is applied explicitly below.
+        // Empty renderer -> suppress the no-op invalidation; the effect below
+        // (applying the dirty state) is what actually matters.
         this.setProperty("isDirty", val, true);
         if (val) {
           dirtyControls.add(this);

--- a/app/webapp/cc/Focus.js
+++ b/app/webapp/cc/Focus.js
@@ -45,22 +45,7 @@ sap.ui.define(
         // the user had typed past the (stale) captured position. Reading it
         // here - while the old, still-focused element is in the DOM - keeps the
         // guard working across a full view rebuild, not only an in-place patch.
-        this._liveCaret = null;
-        try {
-          const active = document.activeElement;
-          if (
-            active &&
-            (active.tagName === "INPUT" || active.tagName === "TEXTAREA")
-          ) {
-            const s = active.selectionStart;
-            const e = active.selectionEnd;
-            if (s != null && e != null) {
-              this._liveCaret = { start: s, end: e };
-            }
-          }
-        } catch {
-          this._liveCaret = null;
-        }
+        this._liveCaret = Lib.readCaret(document.activeElement);
       },
       onAfterRendering() {
         const liveCaret = this._liveCaret;

--- a/app/webapp/cc/History.js
+++ b/app/webapp/cc/History.js
@@ -13,8 +13,8 @@ sap.ui.define(["sap/ui/core/Control", "z2ui5/core/Lib"], (Control, Lib) => {
       },
     },
     setSearch(val) {
-      // Empty renderer -> suppress the no-op invalidation; the URL rewrite
-      // below is the actual effect.
+      // Empty renderer -> suppress the no-op invalidation; the effect below
+      // (rewriting the URL) is what actually matters.
       this.setProperty("search", val, true);
       try {
         const search = Lib.toText(val);

--- a/app/webapp/cc/LPTitle.js
+++ b/app/webapp/cc/LPTitle.js
@@ -18,8 +18,8 @@ sap.ui.define(
         },
       },
       setTitle(val) {
-        // Empty renderer -> suppress the no-op invalidation; the shell title
-        // is set explicitly below.
+        // Empty renderer -> suppress the no-op invalidation; the effect below
+        // (setting the shell title) is what actually matters.
         this.setProperty("title", val, true);
         try {
           const shell = AppState.state.oLaunchpad?.ShellUIService;

--- a/app/webapp/cc/MultiInputExt.js
+++ b/app/webapp/cc/MultiInputExt.js
@@ -59,8 +59,7 @@ sap.ui.define(
           this,
           this.getProperty("MultiInputId"),
         );
-        if (!input || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true, true);
+        if (!Lib.claimOnce(this, input)) return;
         try {
           input.attachTokenUpdate(this.onTokenUpdate.bind(this));
           // Custom validator: turn any free-text entry into a Token where

--- a/app/webapp/cc/SmartMultiInputExt.js
+++ b/app/webapp/cc/SmartMultiInputExt.js
@@ -115,8 +115,7 @@ sap.ui.define(
           this,
           this.getProperty("multiInputId"),
         );
-        if (!input || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true, true);
+        if (!Lib.claimOnce(this, input)) return;
         try {
           input.attachTokenUpdate(this.onTokenUpdate.bind(this));
           input.attachInnerControlsCreated(

--- a/app/webapp/cc/Storage.js
+++ b/app/webapp/cc/Storage.js
@@ -1,12 +1,12 @@
+// Invisible control that reads a value from browser storage
+// (session/local, see sap.ui.util.Storage) into its `value` property
+// and fires `finished` when the stored value differs from the current
+// one. The write side is handled by the STORE_DATA frontend action.
 sap.ui.define(
   ["sap/ui/core/Control", "sap/ui/util/Storage", "z2ui5/core/Lib"],
   (Control, Storage, Lib) => {
     "use strict";
 
-    // Invisible control that reads a value from browser storage
-    // (session/local, see sap.ui.util.Storage) into its `value` property
-    // and fires `finished` when the stored value differs from the current
-    // one. The write side is handled by the STORE_DATA frontend action.
     return Control.extend("z2ui5.cc.Storage", {
       metadata: {
         properties: {

--- a/app/webapp/cc/Title.js
+++ b/app/webapp/cc/Title.js
@@ -12,8 +12,8 @@ sap.ui.define(["sap/ui/core/Control", "z2ui5/core/Lib"], (Control, Lib) => {
       },
     },
     setTitle(val) {
-      // Suppress invalidation: the renderer is empty, so a re-render would be
-      // a no-op; the effect happens explicitly below.
+      // Empty renderer -> suppress the no-op invalidation; the effect below
+      // (setting the tab title) is what actually matters.
       this.setProperty("title", val, true);
       document.title = Lib.toText(val);
     },

--- a/app/webapp/cc/UploadSetExt.js
+++ b/app/webapp/cc/UploadSetExt.js
@@ -90,8 +90,7 @@ sap.ui.define(
           this,
           this.getProperty("uploadSetId"),
         );
-        if (!uploadSet || this.getProperty("checkInit")) return;
-        this.setProperty("checkInit", true, true);
+        if (!Lib.claimOnce(this, uploadSet)) return;
         try {
           uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));
           uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));

--- a/app/webapp/controller/App.controller.js
+++ b/app/webapp/controller/App.controller.js
@@ -7,8 +7,9 @@ sap.ui.define(
     "z2ui5/controller/View1.controller",
     "z2ui5/core/Server",
     "z2ui5/core/AppState",
+    "z2ui5/core/ViewSlots",
   ],
-  (BaseController, Controller, Server, AppState) => {
+  (BaseController, Controller, Server, AppState, ViewSlots) => {
     "use strict";
     return BaseController.extend("z2ui5.controller.App", {
       onInit() {
@@ -26,16 +27,17 @@ sap.ui.define(
           AppState.getGlobal("checkLocal") ? window.location.href : uri,
         );
 
-        // Wire up the controller instances and the app container. All other
+        // Wire up the controller instances and the app container. One
+        // controller per view slot, driven by the slot table in
+        // core/ViewSlots - the single place that knows which slots exist, so
+        // adding one there does not need a matching line here. All other
         // shared state (callback arrays, error log, roundtrip flags, ...)
         // starts from the defaults that core/AppState set during
         // Component.init.
-        state.oController = new Controller();
+        for (const slot of ViewSlots.slots) {
+          state[slot.controllerProp] = new Controller();
+        }
         state.oApp = this.getView().byId("app");
-        state.oControllerNest = new Controller();
-        state.oControllerNest2 = new Controller();
-        state.oControllerPopup = new Controller();
-        state.oControllerPopover = new Controller();
 
         // Kick off the initial roundtrip. Historically a stopped router's
         // initial routeMatched event triggered this; the manifest carries no

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -205,22 +205,35 @@ sap.ui.define(
       // Display: popups, popovers, nested views, main view
       // ------------------------------------------------------------------
 
-      async displayFragment(xml, seq) {
+      // Shared load path of the two fragment slots (popup, popover): create
+      // the slot's own JSON model, load the fragment and attach the model.
+      // Returns null when the app was torn down while the fragment loaded or a
+      // newer request superseded this response - we must not open a dialog the
+      // backend no longer knows about.
+      async _loadSlotFragment(slotKey, fragmentId, xml, seq) {
         const oModel = this._createViewModel();
-        applyStoredSizeLimit("POPUP", oModel);
+        applyStoredSizeLimit(slotKey, oModel);
         const oFragment = await Fragment.load({
           definition: xml,
-          controller: ViewSlots.getController("POPUP"),
-          id: "popupId",
+          controller: ViewSlots.getController(slotKey),
+          id: fragmentId,
         });
-        // The app might have been torn down while the fragment loaded, or a
-        // newer request superseded this response - don't open a dialog the
-        // backend no longer knows about.
         if (!Lib.isAlive(AppState.state.oApp) || this._isSuperseded(seq)) {
           oFragment.destroy();
-          return;
+          return null;
         }
         oFragment.setModel(oModel);
+        return oFragment;
+      },
+
+      async displayFragment(xml, seq) {
+        const oFragment = await this._loadSlotFragment(
+          "POPUP",
+          "popupId",
+          xml,
+          seq,
+        );
+        if (!oFragment) return;
         // The shared device + message models are attached inside
         // ViewSlots.setView (the single funnel), so error paths that
         // destroy a view without reaching setView never register it.
@@ -243,18 +256,13 @@ sap.ui.define(
         // handle expected, non-error conditions (app torn down mid-load, or
         // the openBy anchor not being present), matching the parent-not-found
         // guard in displayNestedView.
-        const oModel = this._createViewModel();
-        applyStoredSizeLimit("POPOVER", oModel);
-        const oFragment = await Fragment.load({
-          definition: xml,
-          controller: ViewSlots.getController("POPOVER"),
-          id: "popoverId",
-        });
-        if (!Lib.isAlive(AppState.state.oApp) || this._isSuperseded(seq)) {
-          oFragment.destroy();
-          return;
-        }
-        oFragment.setModel(oModel);
+        const oFragment = await this._loadSlotFragment(
+          "POPOVER",
+          "popoverId",
+          xml,
+          seq,
+        );
+        if (!oFragment) return;
 
         // Find the control to attach the popover to: any open slot first,
         // then the global UI5 control registry as a last resort.
@@ -586,13 +594,17 @@ sap.ui.define(
           preprocessors: { xml: { models: { template: oViewModel } } },
         });
 
-        // Guard against the app being destroyed during the await above.
         // oModel covers oViewModel too when they are the same object (no
         // switchPath); with an OData default model both must go.
-        if (!Lib.isAlive(AppState.state.oApp)) {
+        const discardBuild = () => {
           oView.destroy();
           oModel.destroy();
           if (switchPath) oViewModel.destroy();
+        };
+
+        // Guard against the app being destroyed during the await above.
+        if (!Lib.isAlive(AppState.state.oApp)) {
+          discardBuild();
           return;
         }
 
@@ -609,9 +621,7 @@ sap.ui.define(
           reqSeq !== Server._requestSeq &&
           ViewSlots.getView("MAIN")
         ) {
-          oView.destroy();
-          oModel.destroy();
-          if (switchPath) oViewModel.destroy();
+          discardBuild();
           return;
         }
 

--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -403,31 +403,25 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     const actionsDiv = document.createElement("div");
     actionsDiv.style.cssText = "display: flex; gap: 8px;";
 
+    // The order the buttons are added is also the Tab order and the order the
+    // focus trap below cycles through.
+    const addAction = (label, onClick) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = label;
+      button.style.cssText = btnStyle;
+      button.addEventListener("click", onClick);
+      actionsDiv.appendChild(button);
+    };
+
     if (typeof options.onRetry === "function") {
-      const retryBtn = document.createElement("button");
-      retryBtn.type = "button";
-      retryBtn.textContent = "Retry";
-      retryBtn.style.cssText = btnStyle;
-      retryBtn.addEventListener("click", () => {
+      addAction("Retry", () => {
         errorContainer.remove();
         options.onRetry();
       });
-      actionsDiv.appendChild(retryBtn);
     }
-
-    const refreshBtn = document.createElement("button");
-    refreshBtn.type = "button";
-    refreshBtn.textContent = "Refresh";
-    refreshBtn.style.cssText = btnStyle;
-    refreshBtn.addEventListener("click", () => window.location.reload());
-    actionsDiv.appendChild(refreshBtn);
-
-    const logoutBtn = document.createElement("button");
-    logoutBtn.type = "button";
-    logoutBtn.textContent = "Logout";
-    logoutBtn.style.cssText = btnStyle;
-    logoutBtn.addEventListener("click", () => handleLogout());
-    actionsDiv.appendChild(logoutBtn);
+    addAction("Refresh", () => window.location.reload());
+    addAction("Logout", () => handleLogout());
 
     headerDiv.appendChild(actionsDiv);
     errorContainer.appendChild(headerDiv);
@@ -458,24 +452,25 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     iframe.setAttribute("sandbox", "allow-same-origin");
     errorContainer.appendChild(iframe);
 
-    const preStyle =
-      "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";
+    // textContent does not parse HTML, so the untrusted backend message
+    // cannot execute wherever this <pre> ends up.
+    const createPre = (ownerDocument) => {
+      const pre = ownerDocument.createElement("pre");
+      pre.style.cssText =
+        "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";
+      pre.textContent = errorMessage;
+      return pre;
+    };
+
     const contentDocument = iframe.contentDocument;
     if (contentDocument) {
-      const pre = contentDocument.createElement("pre");
-      pre.style.cssText = preStyle;
-      pre.textContent = errorMessage;
       const target = contentDocument.body || contentDocument.documentElement;
-      target.appendChild(pre);
+      target.appendChild(createPre(contentDocument));
     } else {
       // The sandboxed iframe document was not reachable (sandbox/timing
       // edge). Never leave the fatal overlay empty: fall back to a plain
-      // <pre> in the container. textContent does not parse HTML, so the
-      // untrusted backend message still cannot execute.
-      const pre = document.createElement("pre");
-      pre.style.cssText = preStyle;
-      pre.textContent = errorMessage;
-      errorContainer.appendChild(pre);
+      // <pre> in the container.
+      errorContainer.appendChild(createPre(document));
     }
 
     // Move focus into the dialog so keyboard and screen-reader users land on

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -1361,10 +1361,13 @@ sap.ui.define(
       }
     }
 
+    // The three handlers below resolve their target with ViewSlots.resolveById
+    // (not byId "MAIN"): it searches every open slot first, so controls in a
+    // popup/popover/nested view are found, and falls back to the global
+    // registry, so a fully-qualified id resolves too - ids that come from a
+    // UI5 Message (getControlIds()) or any event carry the view prefix.
+
     function evSetFocus(oController, args) {
-      // resolveById (not byId "MAIN") so a fully-qualified control id also
-      // resolves - ids that come from a UI5 Message (getControlIds()) or any
-      // event carry the view prefix and only match via the global registry.
       const oElement = ViewSlots.resolveById(args[1]);
       if (!oElement) return;
 
@@ -1403,8 +1406,6 @@ sap.ui.define(
       // Native Element.scrollTo is only used as a fallback for controls
       // without a delegate.
       try {
-        // resolveById like SET_FOCUS / SCROLL_INTO_VIEW, so controls in
-        // popups/popovers/nested views and fully-qualified ids work too
         const oElement = ViewSlots.resolveById(args[1]);
         if (!oElement) return;
         const y = Number(args[2]) || 0;
@@ -1451,8 +1452,6 @@ sap.ui.define(
       // Modern declarative scroll: bring a control into the viewport,
       // regardless of where the surrounding scroll container currently is.
       try {
-        // resolveById so a fully-qualified control id (e.g. from a UI5
-        // Message's getControlIds()) also resolves, not just a MAIN-local id.
         const oElement = ViewSlots.resolveById(args[1]);
         if (!oElement) return;
         const dom = oElement.getDomRef();

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -10,14 +10,14 @@
 // state). Renderers must stay cheap and free of visible side effects
 // (rendering API v2); deferring to onAfterRendering also guarantees the
 // control's DOM exists.
+//
+// Nothing hash/route related belongs here: core/Router.js is the one module
+// that knows how a URL hash is split between the FLP shell and the running
+// app, and nothing else may reach for the hash directly.
 sap.ui.define(
   ["z2ui5/core/AppState", "sap/ui/core/Element"],
   (AppState, Element) => {
     "use strict";
-
-    // Everything hash/route related lives in core/Router.js - it is the one
-    // module that knows how a URL hash is split between the FLP shell and the
-    // running app, and nothing else may reach for the hash directly.
 
     // Resolve a control id to its sap.ui.core.Element via the global registry.
     // Element.getElementById arrived in UI5 1.119; older bootstraps fall back

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -93,6 +93,19 @@ sap.ui.define(
       return Boolean(obj?.isDestroyed && obj.isDestroyed());
     }
 
+    // A companion control (MultiInputExt, UploadSetExt, ...) resolves its
+    // target after EVERY render - the onAfterRendering hook it registers in
+    // init() fires once per roundtrip - but may attach its handlers only
+    // once, or every roundtrip would add another listener. Returns true
+    // exactly once: the first render at which `target` actually resolved.
+    // The claim is recorded in the control's own `checkInit` property (set
+    // without invalidating, these controls render nothing).
+    function claimOnce(owner, target) {
+      if (!target || owner.getProperty("checkInit")) return false;
+      owner.setProperty("checkInit", true, true);
+      return true;
+    }
+
     // True when the object exists and is not destroyed. Used to guard
     // async continuations (await, FileReader, getUserMedia, ...) against
     // controls or views that were torn down in the meantime.
@@ -247,6 +260,30 @@ sap.ui.define(
     // string, everything else its string representation.
     function toText(val) {
       return val == null ? "" : String(val);
+    }
+
+    // True for a DOM element that carries a text caret.
+    function isTextInput(el) {
+      return (
+        Boolean(el) && (el.tagName === "INPUT" || el.tagName === "TEXTAREA")
+      );
+    }
+
+    // The caret of a text field as { start, end }, or null when the element
+    // is no text field or carries no selection. Input types without a text
+    // selection (number, date, ...) throw or return null on selectionStart -
+    // reporting that as 0 would later snap the cursor to the far left, so
+    // "no caret" has to stay distinguishable from "caret at 0".
+    function readCaret(el) {
+      if (!isTextInput(el)) return null;
+      try {
+        const start = el.selectionStart;
+        const end = el.selectionEnd;
+        if (start == null || end == null) return null;
+        return { start, end };
+      } catch {
+        return null;
+      }
     }
 
     // Collapse a UI5 Device `system` flag object into a single label. The
@@ -473,6 +510,9 @@ sap.ui.define(
       logError,
       isDestroyed,
       isAlive,
+      claimOnce,
+      isTextInput,
+      readCaret,
       registerCallback,
       unregisterCallback,
       readFileAsDataURL,

--- a/app/webapp/core/Router.js
+++ b/app/webapp/core/Router.js
@@ -267,6 +267,54 @@ sap.ui.define(
       AppState.state.navMode = on ? mode : null;
     }
 
+    // Adopt the rendered app as the current route and write it to the hash.
+    // Only called while routing is on and the response named an app.
+    function updateAppRoute(PARAMS, ID, app) {
+      const state = AppState.state;
+
+      // In FRESH mode the route carries the class only, so every history
+      // entry (Back/Forward/reload/bookmark) starts the app fresh; in KEEP
+      // mode it carries the draft id too, so they restore the exact preserved
+      // state. draftForRoute is what the route (and the echo guard in
+      // onHashChanged) uses - null in FRESH, the app-state ID in KEEP.
+      const draftForRoute = state.navMode === "FRESH" ? null : ID;
+      // Set current app/draft BEFORE touching the hash: the writes below
+      // re-fire hashChanged, and onHashChanged compares the incoming route's
+      // draft id against currentDraftId to ignore our own echo. In FRESH mode
+      // there is no draft, so the guard matches the class.
+      state.currentApp = app;
+      state.currentDraftId = draftForRoute;
+
+      if (state.navFromHash) {
+        // This render is the result of a browser Back/Forward (or a manual
+        // hash edit) routed through onHashChanged. The hash already matches
+        // this history entry and the browser sits at a non-top position -
+        // rewriting it here would drop the forward entries and break the
+        // Forward button. Just adopt the state.
+        state.navFromHash = false;
+        return;
+      }
+      if (PARAMS.SET_PUSH_STATE) return;
+
+      // Reflect the running app in the URL as a bookmarkable route. A forward
+      // navigation done in the backend (client->nav_app_call,
+      // CHECK_NAV_APP_CALL) pushes a NEW history entry so Back returns to the
+      // calling app - the routing equivalent of a UI5 navTo. A plain roundtrip
+      // only replaces the current (top) entry, advancing it to the app's
+      // latest draft so a later Forward restores the newest state.
+      const route = patternFor(app, draftForRoute);
+      if (PARAMS.CHECK_NAV_APP_CALL) {
+        // repoint the caller's entry first - it borrows the echo guard, so
+        // restore it to this app before pushing the route
+        repointCallerEntry(PARAMS, draftForRoute);
+        state.currentApp = app;
+        state.currentDraftId = draftForRoute;
+        navTo(route);
+      } else if (getHash() !== route) {
+        navTo(route, true);
+      }
+    }
+
     // Keep the URL in sync with what was just rendered. Called once per
     // roundtrip from View1's after-render phase.
     function sync(PARAMS, ID) {
@@ -276,48 +324,7 @@ sap.ui.define(
         const state = AppState.state;
         if (state.navRouting) {
           const app = state.oResponse?.APP;
-          if (app) {
-            // In FRESH mode the route carries the class only, so every history
-            // entry (Back/Forward/reload/bookmark) starts the app fresh; in
-            // KEEP mode it carries the draft id too, so they restore the exact
-            // preserved state. draftForRoute is what the route (and the echo
-            // guard in onHashChanged) uses - null in FRESH, the app-state ID
-            // in KEEP.
-            const draftForRoute = state.navMode === "FRESH" ? null : ID;
-            // Set current app/draft BEFORE touching the hash: the writes below
-            // re-fire hashChanged, and onHashChanged compares the incoming
-            // route's draft id against currentDraftId to ignore our own echo.
-            // In FRESH mode there is no draft, so the guard matches the class.
-            state.currentApp = app;
-            state.currentDraftId = draftForRoute;
-            if (state.navFromHash) {
-              // This render is the result of a browser Back/Forward (or a
-              // manual hash edit) routed through onHashChanged. The hash
-              // already matches this history entry and the browser sits at a
-              // non-top position - rewriting it here would drop the forward
-              // entries and break the Forward button. Just adopt the state.
-              state.navFromHash = false;
-            } else if (!PARAMS.SET_PUSH_STATE) {
-              // Reflect the running app in the URL as a bookmarkable route. A
-              // forward navigation done in the backend (client->nav_app_call,
-              // CHECK_NAV_APP_CALL) pushes a NEW history entry so Back returns
-              // to the calling app - the routing equivalent of a UI5 navTo. A
-              // plain roundtrip only replaces the current (top) entry,
-              // advancing it to the app's latest draft so a later Forward
-              // restores the newest state.
-              const route = patternFor(app, draftForRoute);
-              if (PARAMS.CHECK_NAV_APP_CALL) {
-                // repoint the caller's entry first - it borrows the echo
-                // guard, so restore it to this app before pushing the route
-                repointCallerEntry(PARAMS, draftForRoute);
-                state.currentApp = app;
-                state.currentDraftId = draftForRoute;
-                navTo(route);
-              } else if (getHash() !== route) {
-                navTo(route, true);
-              }
-            }
-          }
+          if (app) updateAppRoute(PARAMS, ID, app);
           // Routing owns the app-state hash; skip the legacy handling below.
           if (!PARAMS.SET_PUSH_STATE) return;
         }

--- a/app/webapp/core/Server.js
+++ b/app/webapp/core/Server.js
@@ -278,24 +278,14 @@ sap.ui.define(
           // Read the caret from the actual text field, not from
           // document.activeElement directly. Clicking an inner part of a
           // control (e.g. a SearchField's clear "X" button) can leave the
-          // active element a non-text node whose selectionStart is undefined -
-          // reporting that as 0 would later snap the caret to the far left.
-          // When no text field owns a selection, omit SELECTION_* entirely so
-          // the backend restores focus without forcing a caret position.
+          // active element a non-text node. When no text field owns a
+          // selection, omit SELECTION_* entirely so the backend restores
+          // focus without forcing a caret position.
           const info = { ID: id };
-          const input = this._focusTextInput(active, ui5El);
-          if (input) {
-            try {
-              const start = input.selectionStart;
-              const end = input.selectionEnd;
-              if (start != null && end != null) {
-                info.SELECTION_START = start;
-                info.SELECTION_END = end;
-              }
-            } catch {
-              // Input types without text selection (number, date, ...) throw
-              // or return null here - restore focus only, no caret.
-            }
+          const caret = Lib.readCaret(this._focusTextInput(active, ui5El));
+          if (caret) {
+            info.SELECTION_START = caret.start;
+            info.SELECTION_END = caret.end;
           }
           return info;
         } catch {
@@ -309,14 +299,12 @@ sap.ui.define(
       // Returns null when the control has no text field (e.g. a button), so the
       // caller omits the selection instead of reporting a bogus 0.
       _focusTextInput(active, ui5El) {
-        const isTextInput = (el) =>
-          !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA");
-        if (isTextInput(active)) return active;
+        if (Lib.isTextInput(active)) return active;
         const focusRef = ui5El?.getFocusDomRef?.();
-        if (isTextInput(focusRef)) return focusRef;
+        if (Lib.isTextInput(focusRef)) return focusRef;
         const root = ui5El?.getDomRef?.();
         const inner = root?.querySelector?.("input, textarea");
-        return isTextInput(inner) ? inner : null;
+        return Lib.isTextInput(inner) ? inner : null;
       },
 
       // Records which element the user actually scrolled, per view slot.

--- a/node/tests/focus.spec.js
+++ b/node/tests/focus.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
 const { loadModule } = require("./loadModule");
+const { loadLib } = require("./loadLibModule");
 
 // Tests the real app/webapp/cc/Focus.js caret restore. After a roundtrip the
 // Focus control re-applies the caret position captured before the request.
@@ -28,7 +29,9 @@ function controlStub() {
 // Build a Focus instance wired to a target element and a stubbed document.
 function load({ target, activeElement } = {}) {
   const errors = [];
-  const Lib = { logError: (m) => errors.push(m) };
+  // The real Lib, so the caret capture exercises the shipped readCaret
+  // instead of a copy; only logError is replaced to capture the messages.
+  const Lib = { ...loadLib().Lib, logError: (m) => errors.push(m) };
   const ViewSlots = { byIdOfOwner: () => target };
   const { module: Focus } = loadModule("cc/Focus.js", {
     deps: {

--- a/node/tests/serverFocusInfo.spec.js
+++ b/node/tests/serverFocusInfo.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
 const { loadModule } = require("./loadModule");
+const { loadLib } = require("./loadLibModule");
 
 // Tests Server._focusTextInput / _getFocusInfo: the caret must be read from
 // the control's real <input>/<textarea>, not from document.activeElement
@@ -11,7 +12,13 @@ const { loadModule } = require("./loadModule");
 
 function loadServer({ Element = {}, deps = {}, sandbox = {} } = {}) {
   return loadModule("core/Server.js", {
-    deps: { "sap/ui/core/Element": Element, ...deps },
+    deps: {
+      "sap/ui/core/Element": Element,
+      // the real Lib - the text-field detection and the caret read under
+      // test live there, so a stub would test a copy
+      "z2ui5/core/Lib": loadLib().Lib,
+      ...deps,
+    },
     sandbox,
   });
 }

--- a/node/tests/utilHelpers.spec.js
+++ b/node/tests/utilHelpers.spec.js
@@ -283,3 +283,85 @@ test.describe("getTextPath (ancestor-text breadcrumb of a control)", () => {
     expect(Lib.getTextPath(node).split(" > ").length).toBe(100);
   });
 });
+
+test.describe("isTextInput / readCaret (caret capture)", () => {
+  const { Lib } = loadLib();
+
+  const field = (tagName, start, end) => ({
+    tagName,
+    selectionStart: start,
+    selectionEnd: end,
+  });
+
+  test("recognizes input and textarea only", () => {
+    expect(Lib.isTextInput(field("INPUT"))).toBe(true);
+    expect(Lib.isTextInput(field("TEXTAREA"))).toBe(true);
+    expect(Lib.isTextInput(field("BUTTON"))).toBe(false);
+    expect(Lib.isTextInput(null)).toBe(false);
+    expect(Lib.isTextInput(undefined)).toBe(false);
+  });
+
+  test("reads the caret of a text field", () => {
+    expect(Lib.readCaret(field("INPUT", 2, 5))).toEqual({ start: 2, end: 5 });
+    expect(Lib.readCaret(field("TEXTAREA", 0, 0))).toEqual({ start: 0, end: 0 });
+  });
+
+  test("returns null for a non-text element", () => {
+    expect(Lib.readCaret(field("BUTTON", 1, 1))).toBeNull();
+    expect(Lib.readCaret(null)).toBeNull();
+  });
+
+  // A caret at 0 must stay distinguishable from "no caret" - reporting the
+  // missing one as 0 would snap the cursor to the far left on restore.
+  test("returns null when the field exposes no selection", () => {
+    expect(Lib.readCaret(field("INPUT", null, null))).toBeNull();
+    expect(Lib.readCaret(field("INPUT", undefined, undefined))).toBeNull();
+  });
+
+  test("returns null when reading the selection throws", () => {
+    const hostile = {
+      tagName: "INPUT",
+      get selectionStart() {
+        throw new Error("unsupported input type");
+      },
+    };
+    expect(Lib.readCaret(hostile)).toBeNull();
+  });
+});
+
+test.describe("claimOnce (companion-control wiring guard)", () => {
+  const { Lib } = loadLib();
+
+  const control = () => {
+    const props = { checkInit: false };
+    return {
+      getProperty: (name) => props[name],
+      setProperty: (name, value) => {
+        props[name] = value;
+      },
+      props,
+    };
+  };
+
+  test("claims on the first render that resolved a target", () => {
+    const owner = control();
+    expect(Lib.claimOnce(owner, { id: "target" })).toBe(true);
+    expect(owner.props.checkInit).toBe(true);
+  });
+
+  test("never claims twice - the render hook fires every roundtrip", () => {
+    const owner = control();
+    const target = { id: "target" };
+    expect(Lib.claimOnce(owner, target)).toBe(true);
+    expect(Lib.claimOnce(owner, target)).toBe(false);
+    expect(Lib.claimOnce(owner, target)).toBe(false);
+  });
+
+  test("does not claim while the target is still unresolved", () => {
+    const owner = control();
+    expect(Lib.claimOnce(owner, null)).toBe(false);
+    expect(owner.props.checkInit).toBe(false);
+    // ... and still claims once the target shows up on a later render
+    expect(Lib.claimOnce(owner, { id: "target" })).toBe(true);
+  });
+});

--- a/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
+++ b/src/00/03/z2ui5_cl_a2ui5_context.clas.abap
@@ -975,7 +975,6 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
           ENDIF.
         ELSEIF find( val = lv_value
                      sub = lv_search ) >= 0.
-          " Case-sensitive: use find() because CS is always case-insensitive
           lv_check_found = abap_true.
           EXIT.
         ENDIF.
@@ -1466,30 +1465,31 @@ CLASS z2ui5_cl_a2ui5_context IMPLEMENTATION.
   METHOD ui5_msg_box_format.
 
     DATA(lt_msg) = msg_get_t( val ).
-
     DATA(lv_lines) = lines( lt_msg ).
-    IF lv_lines > 0.
-      DATA(lv_type) = ui5_get_msg_type( lt_msg[ 1 ]-type ).
+
+    IF lv_lines = 0.
+      result-skip = abap_true.
+      RETURN.
     ENDIF.
+
+    " the box takes its type/title from the FIRST message, also when several
+    " are collapsed into one box below
+    DATA(lv_type) = ui5_get_msg_type( lt_msg[ 1 ]-type ).
+    result-title = lv_type.
+    result-type  = to_lower( lv_type ).
 
     IF lv_lines = 1.
-      result-text  = lt_msg[ 1 ]-text.
-      result-type  = to_lower( lv_type ).
-      result-title = lv_type.
-
-    ELSEIF lv_lines > 1.
-      result-text = | { lv_lines } Messages found: |.
-      DATA lt_detail_items TYPE string_table.
-      LOOP AT lt_msg REFERENCE INTO DATA(lr_msg).
-        INSERT |<li>{ lr_msg->text }</li>| INTO TABLE lt_detail_items.
-      ENDLOOP.
-      result-details = `<ul>` && concat_lines_of( lt_detail_items ) && `</ul>`.
-      result-title   = lv_type.
-      result-type    = to_lower( lv_type ).
-
-    ELSE.
-      result-skip = abap_true.
+      result-text = lt_msg[ 1 ]-text.
+      RETURN.
     ENDIF.
+
+    " several messages: a counting headline plus every text as a bullet
+    result-text = | { lv_lines } Messages found: |.
+    DATA lt_detail_items TYPE string_table.
+    LOOP AT lt_msg REFERENCE INTO DATA(lr_msg).
+      INSERT |<li>{ lr_msg->text }</li>| INTO TABLE lt_detail_items.
+    ENDLOOP.
+    result-details = `<ul>` && concat_lines_of( lt_detail_items ) && `</ul>`.
 
   ENDMETHOD.
 

--- a/src/01/01/z2ui5_cl_core_srv_draft.clas.abap
+++ b/src/01/01/z2ui5_cl_core_srv_draft.clas.abap
@@ -55,11 +55,9 @@ CLASS z2ui5_cl_core_srv_draft IMPLEMENTATION.
 
     " z2ui5_cl_exit=>set_config_http_post already guarantees a positive
     " expiry ( <= 0 falls back to its default ), so no second clamp here
-    DATA(lv_exp_time_in_hours) = ls_config-draft_exp_time_in_hours.
-
     DATA(lv_n_hours_ago) = z2ui5_cl_a2ui5_context=>time_subtract_seconds(
                                time    = z2ui5_cl_a2ui5_context=>time_get_timestampl( )
-                               seconds = c_seconds_per_hour * lv_exp_time_in_hours ).
+                               seconds = c_seconds_per_hour * ls_config-draft_exp_time_in_hours ).
 
     DELETE FROM z2ui5_t_01 WHERE timestampl < @lv_n_hours_ago ##SUBRC_OK.
     COMMIT WORK.

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -168,16 +168,17 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
 
     DATA(lo_draft) = NEW z2ui5_cl_core_srv_draft( ).
 
-    " check for new app?
+    " the leave target was never persisted (a fresh app instance) - it takes
+    " over the current app's position in the stack
     IF lo_draft->check_exists( ms_next-o_app_leave->id_draft ) = abap_false.
       result->mo_app->ms_draft-id_prev_app_stack = mo_app->ms_draft-id_prev_app_stack.
       RETURN.
     ENDIF.
 
-    " check for already existing app? Guard the ancestor stack draft with
-    " check_exists too - in a long-lived session the ancestor may have been
-    " purged by cleanup( ) while the leave target still exists, and read_info
-    " would raise NO_DRAFT_ENTRY and break back-navigation
+    " a known app is returned to: pop one level off the stack. Guard the
+    " ancestor stack draft with check_exists too - in a long-lived session the
+    " ancestor may have been purged by cleanup( ) while the leave target still
+    " exists, and read_info would raise NO_DRAFT_ENTRY and break back-navigation
     IF mo_app->ms_draft-id_prev_app_stack IS NOT INITIAL
         AND lo_draft->check_exists( mo_app->ms_draft-id_prev_app_stack ) = abap_true.
       DATA(ls_draft) = lo_draft->read_info( mo_app->ms_draft-id_prev_app_stack ).

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -251,8 +251,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest2_view_destroy.
 
-    " wipe the whole slot (like popup_destroy) so a display( ) queued earlier
-    " in the same roundtrip does not resurrect the view after the destroy
+    " see popover_destroy for why the whole slot is wiped instead of setting a flag
     mo_action->ms_next-s_set-s_view_nest2 = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
@@ -260,8 +259,6 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest2_view_display.
 
-    " like popup_display/popover_display: displaying cancels a destroy
-    " queued earlier in the same roundtrip
     mo_action->ms_next-s_set-s_view_nest2-check_destroy  = abap_false.
     mo_action->ms_next-s_set-s_view_nest2-xml            = val.
     mo_action->ms_next-s_set-s_view_nest2-id             = id.
@@ -284,8 +281,7 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest_view_destroy.
 
-    " wipe the whole slot (like popup_destroy) so a display( ) queued earlier
-    " in the same roundtrip does not resurrect the view after the destroy
+    " see popover_destroy for why the whole slot is wiped instead of setting a flag
     mo_action->ms_next-s_set-s_view_nest = VALUE #( check_destroy = abap_true ).
 
   ENDMETHOD.
@@ -293,8 +289,6 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~nest_view_display.
 
-    " like popup_display/popover_display: displaying cancels a destroy
-    " queued earlier in the same roundtrip
     mo_action->ms_next-s_set-s_view_nest-check_destroy  = abap_false.
     mo_action->ms_next-s_set-s_view_nest-xml            = val.
     mo_action->ms_next-s_set-s_view_nest-id             = id.
@@ -402,27 +396,18 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
 
   METHOD z2ui5_if_client~_bind_edit.
 
-
-    "future: _bind_edit obsolet
-    result = mo_srv_bind->main( val  = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( val )
-                              config = VALUE #(
-                                  path_only            = path
-                                  custom_filter        = custom_filter
-                                  custom_mapper        = custom_mapper
-                                  tab                  = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( tab )
-                                  tab_index            = tab_index
-                                  switch_default_model = switch_default_model ) ).
-
-*    result = mo_srv_bind->main( val    = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( val )
-*                                config = VALUE #(
-*                                    path_only            = path
-*                                    custom_filter        = custom_filter
-*                                    custom_filter_back   = custom_filter_back
-*                                    custom_mapper        = custom_mapper
-*                                    custom_mapper_back   = custom_mapper_back
-*                                    tab                  = z2ui5_cl_a2ui5_context=>conv_get_as_data_ref( tab )
-*                                    tab_index            = tab_index
-*                                    switch_default_model = switch_default_model ) ).
+    " compatibility alias of _bind - delegate instead of repeating the call so
+    " both can never drift apart. custom_mapper_back / custom_filter_back exist
+    " only on this signature and are deliberately no longer evaluated (_bind
+    " has no counterpart for them).
+    result = z2ui5_if_client~_bind( val                  = val
+                                    path                 = path
+                                    view                 = view
+                                    custom_mapper        = custom_mapper
+                                    custom_filter        = custom_filter
+                                    tab                  = tab
+                                    tab_index            = tab_index
+                                    switch_default_model = switch_default_model ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -113,6 +113,15 @@ CLASS z2ui5_cl_core_handler DEFINITION PUBLIC FINAL.
         iv_hash       TYPE string
       RETURNING
         VALUE(result) TYPE string.
+
+    " the part of iv_val before the first iv_sub, or iv_val when it does not
+    " occur - cuts a route token off at the next separator
+    METHODS cut_at
+      IMPORTING
+        iv_val        TYPE string
+        iv_sub        TYPE string
+      RETURNING
+        VALUE(result) TYPE string.
 ENDCLASS.
 
 
@@ -295,17 +304,16 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     " a bookmark fall back to the '?app_start=' query.
     result = iv_hash.
 
-    IF strlen( result ) = 0.
+    IF result IS INITIAL.
       RETURN.
     ENDIF.
 
     IF result(1) = `#`.
       result = substring( val = result
                           off = 1 ).
-    ENDIF.
-
-    IF strlen( result ) = 0.
-      RETURN.
+      IF result IS INITIAL.
+        RETURN.
+      ENDIF.
     ENDIF.
 
     " An app hash starts with '/', a shell hash never does. Checking this
@@ -328,10 +336,8 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
   METHOD request_app_start_draft.
     TRY.
         DATA(lv_hash) = hash_get_app_part( iv_hash ).
-        " the app hash may carry leading slashes ('#/z2ui5-xapp-state=...',
-        " or '#//...' from URLs written through the UI5 HashChanger before
-        " navTo stripped its slash); url_param_get matches parameter names
-        " verbatim, so strip them all
+        " strip the leading slashes (see parse_app_route_rest for why they
+        " stack); url_param_get matches parameter names verbatim
         SHIFT lv_hash LEFT DELETING LEADING `/`.
         result = z2ui5_cl_a2ui5_context=>c_trim_upper(
             z2ui5_cl_a2ui5_context=>url_param_get( val = `z2ui5-xapp-state`
@@ -364,6 +370,16 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
                         off = 4 ).
   ENDMETHOD.
 
+  METHOD cut_at.
+    result = iv_val.
+    DATA(lv_off) = find( val = iv_val
+                         sub = iv_sub ).
+    IF lv_off >= 0.
+      result = substring( val = iv_val
+                          len = lv_off ).
+    ENDIF.
+  ENDMETHOD.
+
   METHOD request_app_start_route.
     " Parse the app class from a hash route '#/app/<CLASS>' (UI5 Router style).
     " Returns empty when the hash carries no app route, so a normal boot or an
@@ -374,9 +390,12 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
           RETURN.
         ENDIF.
         " the class token ends at the next route / query separator
-        SPLIT lv_rest AT `/` INTO lv_rest DATA(lv_dummy).
-        SPLIT lv_rest AT `&` INTO lv_rest lv_dummy.
-        SPLIT lv_rest AT `?` INTO lv_rest lv_dummy.
+        lv_rest = cut_at( iv_val = lv_rest
+                          iv_sub = `/` ).
+        lv_rest = cut_at( iv_val = lv_rest
+                          iv_sub = `&` ).
+        lv_rest = cut_at( iv_val = lv_rest
+                          iv_sub = `?` ).
         result = z2ui5_cl_a2ui5_context=>c_trim_upper( lv_rest ).
       CATCH cx_root ##NO_HANDLER.
     ENDTRY.
@@ -392,14 +411,21 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
         IF lv_rest IS INITIAL.
           RETURN.
         ENDIF.
-        " cut off a trailing query / fragment, then take the 2nd path segment
-        " (the 1st is the class, discarded into lv_dummy)
-        SPLIT lv_rest AT `&` INTO lv_rest DATA(lv_dummy).
-        SPLIT lv_rest AT `?` INTO lv_rest lv_dummy.
-        SPLIT lv_rest AT `/` INTO lv_dummy DATA(lv_draft).
-        " a draft id has no further separators; guard against a stray tail
-        SPLIT lv_draft AT `/` INTO lv_draft lv_dummy.
-        result = z2ui5_cl_a2ui5_context=>c_trim_upper( lv_draft ).
+        " cut off a trailing query / fragment, then take the 2nd path segment -
+        " the 1st is the class, and a draft id carries no further separator
+        lv_rest = cut_at( iv_val = lv_rest
+                          iv_sub = `&` ).
+        lv_rest = cut_at( iv_val = lv_rest
+                          iv_sub = `?` ).
+        DATA(lv_off) = find( val = lv_rest
+                             sub = `/` ).
+        IF lv_off < 0.
+          RETURN.
+        ENDIF.
+        result = z2ui5_cl_a2ui5_context=>c_trim_upper(
+            cut_at( iv_val = substring( val = lv_rest
+                                        off = lv_off + 1 )
+                    iv_sub = `/` ) ).
       CATCH cx_root ##NO_HANDLER.
     ENDTRY.
   ENDMETHOD.

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -135,8 +135,6 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
       " views (resolveById); a concrete view scopes the lookup to that slot.
       DATA(lv_view_slot) = COND string( WHEN view = z2ui5_if_client=>cs_view-main THEN ``
                                         ELSE CONV string( view ) ).
-      " lt_arg already equals t_arg (set at the top); this branch did not
-      " touch it, so inject the view slot directly.
       INSERT lv_view_slot INTO lt_arg INDEX 2.
     ELSEIF lv_val = z2ui5_if_client=>cs_event-bind_element.
       " element-bind a whole view slot to a table row: args = slot, index,
@@ -144,7 +142,7 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
       " binding with braces ({/MT_TAB}), which would be an invalid raw JS
       " argument, so strip the braces here to a plain path ('/MT_TAB') that
       " get_t_arg then quotes. The slot is the follow_up_action view parameter.
-      DATA(lv_bind_path) = CONV string( VALUE #( t_arg[ 2 ] OPTIONAL ) ).
+      DATA(lv_bind_path) = VALUE string( t_arg[ 2 ] OPTIONAL ).
       REPLACE ALL OCCURRENCES OF `{` IN lv_bind_path WITH ``.
       REPLACE ALL OCCURRENCES OF `}` IN lv_bind_path WITH ``.
       lt_arg = VALUE #( ( CONV string( view ) )

--- a/src/01/02/z2ui5_cl_core_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_model.clas.abap
@@ -747,14 +747,12 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
               DATA(lt_attri_dref) = diss_dref( lr_attri ).
               INSERT LINES OF lt_attri_dref INTO TABLE lt_attri_new.
             WHEN OTHERS.
-              " an unexpected ref type_kind is left as a non-dissolvable leaf
-              " (like the unknown-kind WHEN OTHERS below) - an ASSERT here
-              " would raise the uncatchable ASSERTION_FAILED and defeat the
-              " TRY/CATCH around dissolve_run, dumping the whole request
+              " an unexpected ref type_kind is left as a non-dissolvable leaf -
+              " an ASSERT here would raise the uncatchable ASSERTION_FAILED and
+              " defeat the TRY/CATCH around dissolve_run, dumping the whole request
           ENDCASE.
         WHEN OTHERS.
-          " an unknown typedescr kind is left as a non-dissolvable leaf
-          " (this is the unknown-kind WHEN OTHERS the comment above refers to)
+          " same as above: an unknown typedescr kind stays a non-dissolvable leaf
       ENDCASE.
 
     ENDLOOP.
@@ -879,10 +877,8 @@ CLASS z2ui5_cl_core_srv_model IMPLEMENTATION.
             <comp> = io_row_d->get_string( iv_path ).
         ENDCASE.
 
-      CATCH cx_root.
-        " a single malformed cell (e.g. text sent into a numeric target)
-        " must not discard every other edit in this batch - skip just it
-        RETURN.
+      CATCH cx_root ##NO_HANDLER.
+        " skip just this cell - see the method comment
     ENDTRY.
 
   ENDMETHOD.

--- a/src/01/02/z2ui5_if_core_types.intf.abap
+++ b/src/01/02/z2ui5_if_core_types.intf.abap
@@ -131,8 +131,10 @@ INTERFACE z2ui5_if_core_types
       " Hash-based app routing (UI5 Router style): when active, the frontend
       " keeps the URL hash in sync with the running app as a bookmarkable route,
       " and the browser Back/Forward buttons navigate between apps via that hash
-      " (see app/webapp Component.js HashChanger listener). Opt-in per session
-      " via client->set_nav_routing( ). The value carries the routing MODE (see
+      " (see app/webapp/core/Router.js). Opt-in per APP via
+      " client->set_nav_routing( ) - the mode is remembered on the app and
+      " travels in its draft, so it is re-sent with every response of that app
+      " (see z2ui5_cl_core_app=>mv_nav_mode). The value carries the MODE (see
       " z2ui5_if_client=>cs_nav_mode): 'KEEP' syncs the class AND its draft id
       " '#/app/<CLASS>/<DRAFT>' so Back/Forward restore the exact preserved
       " state; 'FRESH' syncs the class only '#/app/<CLASS>' so they start the
@@ -171,10 +173,9 @@ INTERFACE z2ui5_if_core_types
   TYPES:
     BEGIN OF ty_s_response,
       BEGIN OF s_front,
-        params    TYPE ty_s_next_frontend,
-        id        TYPE string,
-        app_start TYPE string,
-        app       TYPE string,
+        params TYPE ty_s_next_frontend,
+        id     TYPE string,
+        app    TYPE string,
       END OF s_front,
       model TYPE string,
     END OF ty_s_response.

--- a/src/01/03/z2ui5_cl_app_app_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_app_js.clas.abap
@@ -34,8 +34,9 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `    "z2ui5/controller/View1.controller",` && |\n| &&
              `    "z2ui5/core/Server",` && |\n| &&
              `    "z2ui5/core/AppState",` && |\n| &&
+             `    "z2ui5/core/ViewSlots",` && |\n| &&
              `  ],` && |\n| &&
-             `  (BaseController, Controller, Server, AppState) => {` && |\n| &&
+             `  (BaseController, Controller, Server, AppState, ViewSlots) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `    return BaseController.extend("z2ui5.controller.App", {` && |\n| &&
              `      onInit() {` && |\n| &&
@@ -53,16 +54,17 @@ CLASS z2ui5_cl_app_app_js IMPLEMENTATION.
              `          AppState.getGlobal("checkLocal") ? window.location.href : uri,` && |\n| &&
              `        );` && |\n| &&
              `` && |\n| &&
-             `        // Wire up the controller instances and the app container. All other` && |\n| &&
+             `        // Wire up the controller instances and the app container. One` && |\n| &&
+             `        // controller per view slot, driven by the slot table in` && |\n| &&
+             `        // core/ViewSlots - the single place that knows which slots exist, so` && |\n| &&
+             `        // adding one there does not need a matching line here. All other` && |\n| &&
              `        // shared state (callback arrays, error log, roundtrip flags, ...)` && |\n| &&
              `        // starts from the defaults that core/AppState set during` && |\n| &&
              `        // Component.init.` && |\n| &&
-             `        state.oController = new Controller();` && |\n| &&
+             `        for (const slot of ViewSlots.slots) {` && |\n| &&
+             `          state[slot.controllerProp] = new Controller();` && |\n| &&
+             `        }` && |\n| &&
              `        state.oApp = this.getView().byId("app");` && |\n| &&
-             `        state.oControllerNest = new Controller();` && |\n| &&
-             `        state.oControllerNest2 = new Controller();` && |\n| &&
-             `        state.oControllerPopup = new Controller();` && |\n| &&
-             `        state.oControllerPopover = new Controller();` && |\n| &&
              `` && |\n| &&
              `        // Kick off the initial roundtrip. Historically a stopped router's` && |\n| &&
              `        // initial routeMatched event triggered this; the manifest carries no` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_dirty_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_dirty_js.clas.abap
@@ -59,8 +59,8 @@ CLASS z2ui5_cl_app_dirty_js IMPLEMENTATION.
              `        },` && |\n| &&
              `      },` && |\n| &&
              `      setIsDirty(val) {` && |\n| &&
-             `        // Empty renderer -> suppress the no-op invalidation; the dirty state` && |\n| &&
-             `        // is applied explicitly below.` && |\n| &&
+             `        // Empty renderer -> suppress the no-op invalidation; the effect below` && |\n| &&
+             `        // (applying the dirty state) is what actually matters.` && |\n| &&
              `        this.setProperty("isDirty", val, true);` && |\n| &&
              `        if (val) {` && |\n| &&
              `          dirtyControls.add(this);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -431,31 +431,25 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    const actionsDiv = document.createElement("div");` && |\n| &&
              `    actionsDiv.style.cssText = "display: flex; gap: 8px;";` && |\n| &&
              `` && |\n| &&
+             `    // The order the buttons are added is also the Tab order and the order the` && |\n| &&
+             `    // focus trap below cycles through.` && |\n| &&
+             `    const addAction = (label, onClick) => {` && |\n| &&
+             `      const button = document.createElement("button");` && |\n| &&
+             `      button.type = "button";` && |\n| &&
+             `      button.textContent = label;` && |\n| &&
+             `      button.style.cssText = btnStyle;` && |\n| &&
+             `      button.addEventListener("click", onClick);` && |\n| &&
+             `      actionsDiv.appendChild(button);` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
              `    if (typeof options.onRetry === "function") {` && |\n| &&
-             `      const retryBtn = document.createElement("button");` && |\n| &&
-             `      retryBtn.type = "button";` && |\n| &&
-             `      retryBtn.textContent = "Retry";` && |\n| &&
-             `      retryBtn.style.cssText = btnStyle;` && |\n| &&
-             `      retryBtn.addEventListener("click", () => {` && |\n| &&
+             `      addAction("Retry", () => {` && |\n| &&
              `        errorContainer.remove();` && |\n| &&
              `        options.onRetry();` && |\n| &&
              `      });` && |\n| &&
-             `      actionsDiv.appendChild(retryBtn);` && |\n| &&
              `    }` && |\n| &&
-             `` && |\n| &&
-             `    const refreshBtn = document.createElement("button");` && |\n| &&
-             `    refreshBtn.type = "button";` && |\n| &&
-             `    refreshBtn.textContent = "Refresh";` && |\n| &&
-             `    refreshBtn.style.cssText = btnStyle;` && |\n| &&
-             `    refreshBtn.addEventListener("click", () => window.location.reload());` && |\n| &&
-             `    actionsDiv.appendChild(refreshBtn);` && |\n| &&
-             `` && |\n| &&
-             `    const logoutBtn = document.createElement("button");` && |\n| &&
-             `    logoutBtn.type = "button";` && |\n| &&
-             `    logoutBtn.textContent = "Logout";` && |\n| &&
-             `    logoutBtn.style.cssText = btnStyle;` && |\n| &&
-             `    logoutBtn.addEventListener("click", () => handleLogout());` && |\n| &&
-             `    actionsDiv.appendChild(logoutBtn);` && |\n| &&
+             `    addAction("Refresh", () => window.location.reload());` && |\n| &&
+             `    addAction("Logout", () => handleLogout());` && |\n| &&
              `` && |\n| &&
              `    headerDiv.appendChild(actionsDiv);` && |\n| &&
              `    errorContainer.appendChild(headerDiv);` && |\n| &&
@@ -486,24 +480,25 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    iframe.setAttribute("sandbox", "allow-same-origin");` && |\n| &&
              `    errorContainer.appendChild(iframe);` && |\n| &&
              `` && |\n| &&
-             `    const preStyle =` && |\n| &&
-             `      "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";` && |\n| &&
+             `    // textContent does not parse HTML, so the untrusted backend message` && |\n| &&
+             `    // cannot execute wherever this <pre> ends up.` && |\n| &&
+             `    const createPre = (ownerDocument) => {` && |\n| &&
+             `      const pre = ownerDocument.createElement("pre");` && |\n| &&
+             `      pre.style.cssText =` && |\n| &&
+             `        "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";` && |\n| &&
+             `      pre.textContent = errorMessage;` && |\n| &&
+             `      return pre;` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
              `    const contentDocument = iframe.contentDocument;` && |\n| &&
              `    if (contentDocument) {` && |\n| &&
-             `      const pre = contentDocument.createElement("pre");` && |\n| &&
-             `      pre.style.cssText = preStyle;` && |\n| &&
-             `      pre.textContent = errorMessage;` && |\n| &&
              `      const target = contentDocument.body || contentDocument.documentElement;` && |\n| &&
-             `      target.appendChild(pre);` && |\n| &&
+             `      target.appendChild(createPre(contentDocument));` && |\n| &&
              `    } else {` && |\n| &&
              `      // The sandboxed iframe document was not reachable (sandbox/timing` && |\n| &&
              `      // edge). Never leave the fatal overlay empty: fall back to a plain` && |\n| &&
-             `      // <pre> in the container. textContent does not parse HTML, so the` && |\n| &&
-             `      // untrusted backend message still cannot execute.` && |\n| &&
-             `      const pre = document.createElement("pre");` && |\n| &&
-             `      pre.style.cssText = preStyle;` && |\n| &&
-             `      pre.textContent = errorMessage;` && |\n| &&
-             `      errorContainer.appendChild(pre);` && |\n| &&
+             `      // <pre> in the container.` && |\n| &&
+             `      errorContainer.appendChild(createPre(document));` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Move focus into the dialog so keyboard and screen-reader users land on` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_focus_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_focus_js.clas.abap
@@ -72,22 +72,7 @@ CLASS z2ui5_cl_app_focus_js IMPLEMENTATION.
              `        // the user had typed past the (stale) captured position. Reading it` && |\n| &&
              `        // here - while the old, still-focused element is in the DOM - keeps the` && |\n| &&
              `        // guard working across a full view rebuild, not only an in-place patch.` && |\n| &&
-             `        this._liveCaret = null;` && |\n| &&
-             `        try {` && |\n| &&
-             `          const active = document.activeElement;` && |\n| &&
-             `          if (` && |\n| &&
-             `            active &&` && |\n| &&
-             `            (active.tagName === "INPUT" || active.tagName === "TEXTAREA")` && |\n| &&
-             `          ) {` && |\n| &&
-             `            const s = active.selectionStart;` && |\n| &&
-             `            const e = active.selectionEnd;` && |\n| &&
-             `            if (s != null && e != null) {` && |\n| &&
-             `              this._liveCaret = { start: s, end: e };` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
-             `        } catch {` && |\n| &&
-             `          this._liveCaret = null;` && |\n| &&
-             `        }` && |\n| &&
+             `        this._liveCaret = Lib.readCaret(document.activeElement);` && |\n| &&
              `      },` && |\n| &&
              `      onAfterRendering() {` && |\n| &&
              `        const liveCaret = this._liveCaret;` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -1391,10 +1391,13 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // The three handlers below resolve their target with ViewSlots.resolveById` && |\n| &&
+             `    // (not byId "MAIN"): it searches every open slot first, so controls in a` && |\n| &&
+             `    // popup/popover/nested view are found, and falls back to the global` && |\n| &&
+             `    // registry, so a fully-qualified id resolves too - ids that come from a` && |\n| &&
+             `    // UI5 Message (getControlIds()) or any event carry the view prefix.` && |\n| &&
+             `` && |\n| &&
              `    function evSetFocus(oController, args) {` && |\n| &&
-             `      // resolveById (not byId "MAIN") so a fully-qualified control id also` && |\n| &&
-             `      // resolves - ids that come from a UI5 Message (getControlIds()) or any` && |\n| &&
-             `      // event carry the view prefix and only match via the global registry.` && |\n| &&
              `      const oElement = ViewSlots.resolveById(args[1]);` && |\n| &&
              `      if (!oElement) return;` && |\n| &&
              `` && |\n| &&
@@ -1433,8 +1436,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // Native Element.scrollTo is only used as a fallback for controls` && |\n| &&
              `      // without a delegate.` && |\n| &&
              `      try {` && |\n| &&
-             `        // resolveById like SET_FOCUS / SCROLL_INTO_VIEW, so controls in` && |\n| &&
-             `        // popups/popovers/nested views and fully-qualified ids work too` && |\n| &&
              `        const oElement = ViewSlots.resolveById(args[1]);` && |\n| &&
              `        if (!oElement) return;` && |\n| &&
              `        const y = Number(args[2]) || 0;` && |\n| &&
@@ -1481,8 +1482,6 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // Modern declarative scroll: bring a control into the viewport,` && |\n| &&
              `      // regardless of where the surrounding scroll container currently is.` && |\n| &&
              `      try {` && |\n| &&
-             `        // resolveById so a fully-qualified control id (e.g. from a UI5` && |\n| &&
-             `        // Message's getControlIds()) also resolves, not just a MAIN-local id.` && |\n| &&
              `        const oElement = ViewSlots.resolveById(args[1]);` && |\n| &&
              `        if (!oElement) return;` && |\n| &&
              `        const dom = oElement.getDomRef();` && |\n| &&
@@ -1627,9 +1626,9 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      SET_TITLE_LAUNCHPAD: evSetTitleLaunchpad,` && |\n| &&
              `      SET_FOCUS: evSetFocus,` && |\n| &&
              `      SCROLL_TO: evScrollTo,` && |\n| &&
-             `      SCROLL_INTO_VIEW: evScrollIntoView,` && |\n|.
+             `      SCROLL_INTO_VIEW: evScrollIntoView,` && |\n| &&
+             `      START_TIMER: evStartTimer,` && |\n|.
     result = result &&
-             `      START_TIMER: evStartTimer,` && |\n| &&
              `      KEYBOARD_SET_MODE: evSetInputMode,` && |\n| &&
              `      KEYBOARD_SHORTCUT: evKeyboardShortcut,` && |\n| &&
              `      Z2UI5: evZ2ui5Custom,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_history_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_history_js.clas.abap
@@ -40,8 +40,8 @@ CLASS z2ui5_cl_app_history_js IMPLEMENTATION.
              `      },` && |\n| &&
              `    },` && |\n| &&
              `    setSearch(val) {` && |\n| &&
-             `      // Empty renderer -> suppress the no-op invalidation; the URL rewrite` && |\n| &&
-             `      // below is the actual effect.` && |\n| &&
+             `      // Empty renderer -> suppress the no-op invalidation; the effect below` && |\n| &&
+             `      // (rewriting the URL) is what actually matters.` && |\n| &&
              `      this.setProperty("search", val, true);` && |\n| &&
              `      try {` && |\n| &&
              `        const search = Lib.toText(val);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -37,14 +37,14 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `// state). Renderers must stay cheap and free of visible side effects` && |\n| &&
              `// (rendering API v2); deferring to onAfterRendering also guarantees the` && |\n| &&
              `// control's DOM exists.` && |\n| &&
+             `//` && |\n| &&
+             `// Nothing hash/route related belongs here: core/Router.js is the one module` && |\n| &&
+             `// that knows how a URL hash is split between the FLP shell and the running` && |\n| &&
+             `// app, and nothing else may reach for the hash directly.` && |\n| &&
              `sap.ui.define(` && |\n| &&
              `  ["z2ui5/core/AppState", "sap/ui/core/Element"],` && |\n| &&
              `  (AppState, Element) => {` && |\n| &&
              `    "use strict";` && |\n| &&
-             `` && |\n| &&
-             `    // Everything hash/route related lives in core/Router.js - it is the one` && |\n| &&
-             `    // module that knows how a URL hash is split between the FLP shell and the` && |\n| &&
-             `    // running app, and nothing else may reach for the hash directly.` && |\n| &&
              `` && |\n| &&
              `    // Resolve a control id to its sap.ui.core.Element via the global registry.` && |\n| &&
              `    // Element.getElementById arrived in UI5 1.119; older bootstraps fall back` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -120,6 +120,19 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      return Boolean(obj?.isDestroyed && obj.isDestroyed());` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // A companion control (MultiInputExt, UploadSetExt, ...) resolves its` && |\n| &&
+             `    // target after EVERY render - the onAfterRendering hook it registers in` && |\n| &&
+             `    // init() fires once per roundtrip - but may attach its handlers only` && |\n| &&
+             `    // once, or every roundtrip would add another listener. Returns true` && |\n| &&
+             `    // exactly once: the first render at which ``target`` actually resolved.` && |\n| &&
+             `    // The claim is recorded in the control's own ``checkInit`` property (set` && |\n| &&
+             `    // without invalidating, these controls render nothing).` && |\n| &&
+             `    function claimOnce(owner, target) {` && |\n| &&
+             `      if (!target || owner.getProperty("checkInit")) return false;` && |\n| &&
+             `      owner.setProperty("checkInit", true, true);` && |\n| &&
+             `      return true;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // True when the object exists and is not destroyed. Used to guard` && |\n| &&
              `    // async continuations (await, FileReader, getUserMedia, ...) against` && |\n| &&
              `    // controls or views that were torn down in the meantime.` && |\n| &&
@@ -276,6 +289,30 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      return val == null ? "" : String(val);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // True for a DOM element that carries a text caret.` && |\n| &&
+             `    function isTextInput(el) {` && |\n| &&
+             `      return (` && |\n| &&
+             `        Boolean(el) && (el.tagName === "INPUT" || el.tagName === "TEXTAREA")` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // The caret of a text field as { start, end }, or null when the element` && |\n| &&
+             `    // is no text field or carries no selection. Input types without a text` && |\n| &&
+             `    // selection (number, date, ...) throw or return null on selectionStart -` && |\n| &&
+             `    // reporting that as 0 would later snap the cursor to the far left, so` && |\n| &&
+             `    // "no caret" has to stay distinguishable from "caret at 0".` && |\n| &&
+             `    function readCaret(el) {` && |\n| &&
+             `      if (!isTextInput(el)) return null;` && |\n| &&
+             `      try {` && |\n| &&
+             `        const start = el.selectionStart;` && |\n| &&
+             `        const end = el.selectionEnd;` && |\n| &&
+             `        if (start == null || end == null) return null;` && |\n| &&
+             `        return { start, end };` && |\n| &&
+             `      } catch {` && |\n| &&
+             `        return null;` && |\n| &&
+             `      }` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // Collapse a UI5 Device ``system`` flag object into a single label. The` && |\n| &&
              `    // order matters - phone/tablet/combi are mutually exclusive with the` && |\n| &&
              `    // desktop fallback. Shared by Server._getDeviceInfo (request payload) and` && |\n| &&
@@ -387,7 +424,8 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `    // edit in a nested/tree table ships only the changed cell instead of` && |\n| &&
              `    // the whole outer table.` && |\n| &&
              `    function buildDeltaFromPaths(paths, modelData) {` && |\n| &&
-             `      const delta = {};` && |\n| &&
+             `      const delta = {};` && |\n|.
+    result = result &&
              `      for (const path of paths) {` && |\n| &&
              `        // path looks like "/<attr>" or "/<attr>/<row>/<field>" with` && |\n| &&
              `        // arbitrarily deep <row>/<subtable> repetitions for nested tables` && |\n| &&
@@ -424,8 +462,7 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `          // already covers this deeper edit.` && |\n| &&
              `          if (field in rowDelta && !rowDelta[field]?.__delta) break;` && |\n| &&
              `          if (!rowDelta[field]?.__delta) rowDelta[field] = { __delta: {} };` && |\n| &&
-             `          node = rowDelta[field];` && |\n|.
-    result = result &&
+             `          node = rowDelta[field];` && |\n| &&
              `        }` && |\n| &&
              `      }` && |\n| &&
              `      return delta;` && |\n| &&
@@ -501,6 +538,9 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      logError,` && |\n| &&
              `      isDestroyed,` && |\n| &&
              `      isAlive,` && |\n| &&
+             `      claimOnce,` && |\n| &&
+             `      isTextInput,` && |\n| &&
+             `      readCaret,` && |\n| &&
              `      registerCallback,` && |\n| &&
              `      unregisterCallback,` && |\n| &&
              `      readFileAsDataURL,` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lptitle_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lptitle_js.clas.abap
@@ -45,8 +45,8 @@ CLASS z2ui5_cl_app_lptitle_js IMPLEMENTATION.
              `        },` && |\n| &&
              `      },` && |\n| &&
              `      setTitle(val) {` && |\n| &&
-             `        // Empty renderer -> suppress the no-op invalidation; the shell title` && |\n| &&
-             `        // is set explicitly below.` && |\n| &&
+             `        // Empty renderer -> suppress the no-op invalidation; the effect below` && |\n| &&
+             `        // (setting the shell title) is what actually matters.` && |\n| &&
              `        this.setProperty("title", val, true);` && |\n| &&
              `        try {` && |\n| &&
              `          const shell = AppState.state.oLaunchpad?.ShellUIService;` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_multiinputext_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_multiinputext_js.clas.abap
@@ -86,8 +86,7 @@ CLASS z2ui5_cl_app_multiinputext_js IMPLEMENTATION.
              `          this,` && |\n| &&
              `          this.getProperty("MultiInputId"),` && |\n| &&
              `        );` && |\n| &&
-             `        if (!input || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true, true);` && |\n| &&
+             `        if (!Lib.claimOnce(this, input)) return;` && |\n| &&
              `        try {` && |\n| &&
              `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
              `          // Custom validator: turn any free-text entry into a Token where` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_router_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_router_js.clas.abap
@@ -294,6 +294,54 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `      AppState.state.navMode = on ? mode : null;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // Adopt the rendered app as the current route and write it to the hash.` && |\n| &&
+             `    // Only called while routing is on and the response named an app.` && |\n| &&
+             `    function updateAppRoute(PARAMS, ID, app) {` && |\n| &&
+             `      const state = AppState.state;` && |\n| &&
+             `` && |\n| &&
+             `      // In FRESH mode the route carries the class only, so every history` && |\n| &&
+             `      // entry (Back/Forward/reload/bookmark) starts the app fresh; in KEEP` && |\n| &&
+             `      // mode it carries the draft id too, so they restore the exact preserved` && |\n| &&
+             `      // state. draftForRoute is what the route (and the echo guard in` && |\n| &&
+             `      // onHashChanged) uses - null in FRESH, the app-state ID in KEEP.` && |\n| &&
+             `      const draftForRoute = state.navMode === "FRESH" ? null : ID;` && |\n| &&
+             `      // Set current app/draft BEFORE touching the hash: the writes below` && |\n| &&
+             `      // re-fire hashChanged, and onHashChanged compares the incoming route's` && |\n| &&
+             `      // draft id against currentDraftId to ignore our own echo. In FRESH mode` && |\n| &&
+             `      // there is no draft, so the guard matches the class.` && |\n| &&
+             `      state.currentApp = app;` && |\n| &&
+             `      state.currentDraftId = draftForRoute;` && |\n| &&
+             `` && |\n| &&
+             `      if (state.navFromHash) {` && |\n| &&
+             `        // This render is the result of a browser Back/Forward (or a manual` && |\n| &&
+             `        // hash edit) routed through onHashChanged. The hash already matches` && |\n| &&
+             `        // this history entry and the browser sits at a non-top position -` && |\n| &&
+             `        // rewriting it here would drop the forward entries and break the` && |\n| &&
+             `        // Forward button. Just adopt the state.` && |\n| &&
+             `        state.navFromHash = false;` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      if (PARAMS.SET_PUSH_STATE) return;` && |\n| &&
+             `` && |\n| &&
+             `      // Reflect the running app in the URL as a bookmarkable route. A forward` && |\n| &&
+             `      // navigation done in the backend (client->nav_app_call,` && |\n| &&
+             `      // CHECK_NAV_APP_CALL) pushes a NEW history entry so Back returns to the` && |\n| &&
+             `      // calling app - the routing equivalent of a UI5 navTo. A plain roundtrip` && |\n| &&
+             `      // only replaces the current (top) entry, advancing it to the app's` && |\n| &&
+             `      // latest draft so a later Forward restores the newest state.` && |\n| &&
+             `      const route = patternFor(app, draftForRoute);` && |\n| &&
+             `      if (PARAMS.CHECK_NAV_APP_CALL) {` && |\n| &&
+             `        // repoint the caller's entry first - it borrows the echo guard, so` && |\n| &&
+             `        // restore it to this app before pushing the route` && |\n| &&
+             `        repointCallerEntry(PARAMS, draftForRoute);` && |\n| &&
+             `        state.currentApp = app;` && |\n| &&
+             `        state.currentDraftId = draftForRoute;` && |\n| &&
+             `        navTo(route);` && |\n| &&
+             `      } else if (getHash() !== route) {` && |\n| &&
+             `        navTo(route, true);` && |\n| &&
+             `      }` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    // Keep the URL in sync with what was just rendered. Called once per` && |\n| &&
              `    // roundtrip from View1's after-render phase.` && |\n| &&
              `    function sync(PARAMS, ID) {` && |\n| &&
@@ -303,48 +351,7 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `        const state = AppState.state;` && |\n| &&
              `        if (state.navRouting) {` && |\n| &&
              `          const app = state.oResponse?.APP;` && |\n| &&
-             `          if (app) {` && |\n| &&
-             `            // In FRESH mode the route carries the class only, so every history` && |\n| &&
-             `            // entry (Back/Forward/reload/bookmark) starts the app fresh; in` && |\n| &&
-             `            // KEEP mode it carries the draft id too, so they restore the exact` && |\n| &&
-             `            // preserved state. draftForRoute is what the route (and the echo` && |\n| &&
-             `            // guard in onHashChanged) uses - null in FRESH, the app-state ID` && |\n| &&
-             `            // in KEEP.` && |\n| &&
-             `            const draftForRoute = state.navMode === "FRESH" ? null : ID;` && |\n| &&
-             `            // Set current app/draft BEFORE touching the hash: the writes below` && |\n| &&
-             `            // re-fire hashChanged, and onHashChanged compares the incoming` && |\n| &&
-             `            // route's draft id against currentDraftId to ignore our own echo.` && |\n| &&
-             `            // In FRESH mode there is no draft, so the guard matches the class.` && |\n| &&
-             `            state.currentApp = app;` && |\n| &&
-             `            state.currentDraftId = draftForRoute;` && |\n| &&
-             `            if (state.navFromHash) {` && |\n| &&
-             `              // This render is the result of a browser Back/Forward (or a` && |\n| &&
-             `              // manual hash edit) routed through onHashChanged. The hash` && |\n| &&
-             `              // already matches this history entry and the browser sits at a` && |\n| &&
-             `              // non-top position - rewriting it here would drop the forward` && |\n| &&
-             `              // entries and break the Forward button. Just adopt the state.` && |\n| &&
-             `              state.navFromHash = false;` && |\n| &&
-             `            } else if (!PARAMS.SET_PUSH_STATE) {` && |\n| &&
-             `              // Reflect the running app in the URL as a bookmarkable route. A` && |\n| &&
-             `              // forward navigation done in the backend (client->nav_app_call,` && |\n| &&
-             `              // CHECK_NAV_APP_CALL) pushes a NEW history entry so Back returns` && |\n| &&
-             `              // to the calling app - the routing equivalent of a UI5 navTo. A` && |\n| &&
-             `              // plain roundtrip only replaces the current (top) entry,` && |\n| &&
-             `              // advancing it to the app's latest draft so a later Forward` && |\n| &&
-             `              // restores the newest state.` && |\n| &&
-             `              const route = patternFor(app, draftForRoute);` && |\n| &&
-             `              if (PARAMS.CHECK_NAV_APP_CALL) {` && |\n| &&
-             `                // repoint the caller's entry first - it borrows the echo` && |\n| &&
-             `                // guard, so restore it to this app before pushing the route` && |\n| &&
-             `                repointCallerEntry(PARAMS, draftForRoute);` && |\n| &&
-             `                state.currentApp = app;` && |\n| &&
-             `                state.currentDraftId = draftForRoute;` && |\n| &&
-             `                navTo(route);` && |\n| &&
-             `              } else if (getHash() !== route) {` && |\n| &&
-             `                navTo(route, true);` && |\n| &&
-             `              }` && |\n| &&
-             `            }` && |\n| &&
-             `          }` && |\n| &&
+             `          if (app) updateAppRoute(PARAMS, ID, app);` && |\n| &&
              `          // Routing owns the app-state hash; skip the legacy handling below.` && |\n| &&
              `          if (!PARAMS.SET_PUSH_STATE) return;` && |\n| &&
              `        }` && |\n| &&
@@ -417,15 +424,15 @@ CLASS z2ui5_cl_app_router_js IMPLEMENTATION.
              `      splitHash,` && |\n| &&
              `      appHashOf,` && |\n| &&
              `      getHash,` && |\n| &&
-             `      getRawHash,` && |\n| &&
+             `      getRawHash,` && |\n|.
+    result = result &&
              `      hrefFor,` && |\n| &&
              `      patternFor,` && |\n| &&
              `      parse,` && |\n| &&
              `      appOf,` && |\n| &&
              `      draftOf,` && |\n| &&
              `      navTo,` && |\n| &&
-             `      navToApp,` && |\n|.
-    result = result &&
+             `      navToApp,` && |\n| &&
              `      onHashChanged,` && |\n| &&
              `      sync,` && |\n| &&
              `    };` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_server_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_server_js.clas.abap
@@ -305,24 +305,14 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          // Read the caret from the actual text field, not from` && |\n| &&
              `          // document.activeElement directly. Clicking an inner part of a` && |\n| &&
              `          // control (e.g. a SearchField's clear "X" button) can leave the` && |\n| &&
-             `          // active element a non-text node whose selectionStart is undefined -` && |\n| &&
-             `          // reporting that as 0 would later snap the caret to the far left.` && |\n| &&
-             `          // When no text field owns a selection, omit SELECTION_* entirely so` && |\n| &&
-             `          // the backend restores focus without forcing a caret position.` && |\n| &&
+             `          // active element a non-text node. When no text field owns a` && |\n| &&
+             `          // selection, omit SELECTION_* entirely so the backend restores` && |\n| &&
+             `          // focus without forcing a caret position.` && |\n| &&
              `          const info = { ID: id };` && |\n| &&
-             `          const input = this._focusTextInput(active, ui5El);` && |\n| &&
-             `          if (input) {` && |\n| &&
-             `            try {` && |\n| &&
-             `              const start = input.selectionStart;` && |\n| &&
-             `              const end = input.selectionEnd;` && |\n| &&
-             `              if (start != null && end != null) {` && |\n| &&
-             `                info.SELECTION_START = start;` && |\n| &&
-             `                info.SELECTION_END = end;` && |\n| &&
-             `              }` && |\n| &&
-             `            } catch {` && |\n| &&
-             `              // Input types without text selection (number, date, ...) throw` && |\n| &&
-             `              // or return null here - restore focus only, no caret.` && |\n| &&
-             `            }` && |\n| &&
+             `          const caret = Lib.readCaret(this._focusTextInput(active, ui5El));` && |\n| &&
+             `          if (caret) {` && |\n| &&
+             `            info.SELECTION_START = caret.start;` && |\n| &&
+             `            info.SELECTION_END = caret.end;` && |\n| &&
              `          }` && |\n| &&
              `          return info;` && |\n| &&
              `        } catch {` && |\n| &&
@@ -336,14 +326,12 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `      // Returns null when the control has no text field (e.g. a button), so the` && |\n| &&
              `      // caller omits the selection instead of reporting a bogus 0.` && |\n| &&
              `      _focusTextInput(active, ui5El) {` && |\n| &&
-             `        const isTextInput = (el) =>` && |\n| &&
-             `          !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA");` && |\n| &&
-             `        if (isTextInput(active)) return active;` && |\n| &&
+             `        if (Lib.isTextInput(active)) return active;` && |\n| &&
              `        const focusRef = ui5El?.getFocusDomRef?.();` && |\n| &&
-             `        if (isTextInput(focusRef)) return focusRef;` && |\n| &&
+             `        if (Lib.isTextInput(focusRef)) return focusRef;` && |\n| &&
              `        const root = ui5El?.getDomRef?.();` && |\n| &&
              `        const inner = root?.querySelector?.("input, textarea");` && |\n| &&
-             `        return isTextInput(inner) ? inner : null;` && |\n| &&
+             `        return Lib.isTextInput(inner) ? inner : null;` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // Records which element the user actually scrolled, per view slot.` && |\n| &&
@@ -424,8 +412,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          // try/catch).` && |\n| &&
              `          if (!entry.dom.isConnected || !Lib.isAlive(entry.control)) {` && |\n| &&
              `            delete store[slot.key];` && |\n| &&
-             `            continue;` && |\n|.
-    result = result &&
+             `            continue;` && |\n| &&
              `          }` && |\n| &&
              `` && |\n| &&
              `          const id = this._stripViewPrefix(` && |\n| &&
@@ -437,7 +424,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `            X: entry.dom.scrollLeft || 0,` && |\n| &&
              `            Y: entry.dom.scrollTop || 0,` && |\n| &&
              `          };` && |\n| &&
-             `        }` && |\n| &&
+             `        }` && |\n|.
+    result = result &&
              `        // Returning undefined lets JSON.stringify omit S_SCROLL entirely.` && |\n| &&
              `        return Object.keys(out).length ? out : undefined;` && |\n| &&
              `      },` && |\n| &&
@@ -825,8 +813,7 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `          }` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          Lib.logError("customJs: execution failed", e);` && |\n| &&
-             `        }` && |\n|.
-    result = result &&
+             `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      // Terminate the roundtrip in an unrecoverable state: clear the busy` && |\n| &&
@@ -838,7 +825,8 @@ CLASS z2ui5_cl_app_server_js IMPLEMENTATION.
              `      responseError(response, title, oOptions) {` && |\n| &&
              `        BusyIndicator.hide();` && |\n| &&
              `        AppState.state.isBusy = false;` && |\n| &&
-             `        ErrorView.show(response, title, oOptions);` && |\n| &&
+             `        ErrorView.show(response, title, oOptions);` && |\n|.
+    result = result &&
              `      },` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_smartmultiinpu_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_smartmultiinpu_js.clas.abap
@@ -142,8 +142,7 @@ CLASS z2ui5_cl_app_smartmultiinpu_js IMPLEMENTATION.
              `          this,` && |\n| &&
              `          this.getProperty("multiInputId"),` && |\n| &&
              `        );` && |\n| &&
-             `        if (!input || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true, true);` && |\n| &&
+             `        if (!Lib.claimOnce(this, input)) return;` && |\n| &&
              `        try {` && |\n| &&
              `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
              `          input.attachInnerControlsCreated(` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_storage_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_storage_js.clas.abap
@@ -25,15 +25,15 @@ CLASS z2ui5_cl_app_storage_js IMPLEMENTATION.
 
   METHOD get.
 
-    result = `sap.ui.define(` && |\n| &&
+    result = `// Invisible control that reads a value from browser storage` && |\n| &&
+             `// (session/local, see sap.ui.util.Storage) into its ``value`` property` && |\n| &&
+             `// and fires ``finished`` when the stored value differs from the current` && |\n| &&
+             `// one. The write side is handled by the STORE_DATA frontend action.` && |\n| &&
+             `sap.ui.define(` && |\n| &&
              `  ["sap/ui/core/Control", "sap/ui/util/Storage", "z2ui5/core/Lib"],` && |\n| &&
              `  (Control, Storage, Lib) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
-             `    // Invisible control that reads a value from browser storage` && |\n| &&
-             `    // (session/local, see sap.ui.util.Storage) into its ``value`` property` && |\n| &&
-             `    // and fires ``finished`` when the stored value differs from the current` && |\n| &&
-             `    // one. The write side is handled by the STORE_DATA frontend action.` && |\n| &&
              `    return Control.extend("z2ui5.cc.Storage", {` && |\n| &&
              `      metadata: {` && |\n| &&
              `        properties: {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_title_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_title_js.clas.abap
@@ -39,8 +39,8 @@ CLASS z2ui5_cl_app_title_js IMPLEMENTATION.
              `      },` && |\n| &&
              `    },` && |\n| &&
              `    setTitle(val) {` && |\n| &&
-             `      // Suppress invalidation: the renderer is empty, so a re-render would be` && |\n| &&
-             `      // a no-op; the effect happens explicitly below.` && |\n| &&
+             `      // Empty renderer -> suppress the no-op invalidation; the effect below` && |\n| &&
+             `      // (setting the tab title) is what actually matters.` && |\n| &&
              `      this.setProperty("title", val, true);` && |\n| &&
              `      document.title = Lib.toText(val);` && |\n| &&
              `    },` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_uploadsetext_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_uploadsetext_js.clas.abap
@@ -117,8 +117,7 @@ CLASS z2ui5_cl_app_uploadsetext_js IMPLEMENTATION.
              `          this,` && |\n| &&
              `          this.getProperty("uploadSetId"),` && |\n| &&
              `        );` && |\n| &&
-             `        if (!uploadSet || this.getProperty("checkInit")) return;` && |\n| &&
-             `        this.setProperty("checkInit", true, true);` && |\n| &&
+             `        if (!Lib.claimOnce(this, uploadSet)) return;` && |\n| &&
              `        try {` && |\n| &&
              `          uploadSet.attachAfterItemAdded(this.onItemAdded.bind(this));` && |\n| &&
              `          uploadSet.attachAfterItemRemoved(this.onItemRemoved.bind(this));` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -232,22 +232,35 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      // Display: popups, popovers, nested views, main view` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&
              `` && |\n| &&
-             `      async displayFragment(xml, seq) {` && |\n| &&
+             `      // Shared load path of the two fragment slots (popup, popover): create` && |\n| &&
+             `      // the slot's own JSON model, load the fragment and attach the model.` && |\n| &&
+             `      // Returns null when the app was torn down while the fragment loaded or a` && |\n| &&
+             `      // newer request superseded this response - we must not open a dialog the` && |\n| &&
+             `      // backend no longer knows about.` && |\n| &&
+             `      async _loadSlotFragment(slotKey, fragmentId, xml, seq) {` && |\n| &&
              `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit("POPUP", oModel);` && |\n| &&
+             `        applyStoredSizeLimit(slotKey, oModel);` && |\n| &&
              `        const oFragment = await Fragment.load({` && |\n| &&
              `          definition: xml,` && |\n| &&
-             `          controller: ViewSlots.getController("POPUP"),` && |\n| &&
-             `          id: "popupId",` && |\n| &&
+             `          controller: ViewSlots.getController(slotKey),` && |\n| &&
+             `          id: fragmentId,` && |\n| &&
              `        });` && |\n| &&
-             `        // The app might have been torn down while the fragment loaded, or a` && |\n| &&
-             `        // newer request superseded this response - don't open a dialog the` && |\n| &&
-             `        // backend no longer knows about.` && |\n| &&
              `        if (!Lib.isAlive(AppState.state.oApp) || this._isSuperseded(seq)) {` && |\n| &&
              `          oFragment.destroy();` && |\n| &&
-             `          return;` && |\n| &&
+             `          return null;` && |\n| &&
              `        }` && |\n| &&
              `        oFragment.setModel(oModel);` && |\n| &&
+             `        return oFragment;` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      async displayFragment(xml, seq) {` && |\n| &&
+             `        const oFragment = await this._loadSlotFragment(` && |\n| &&
+             `          "POPUP",` && |\n| &&
+             `          "popupId",` && |\n| &&
+             `          xml,` && |\n| &&
+             `          seq,` && |\n| &&
+             `        );` && |\n| &&
+             `        if (!oFragment) return;` && |\n| &&
              `        // The shared device + message models are attached inside` && |\n| &&
              `        // ViewSlots.setView (the single funnel), so error paths that` && |\n| &&
              `        // destroy a view without reaching setView never register it.` && |\n| &&
@@ -270,18 +283,13 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        // handle expected, non-error conditions (app torn down mid-load, or` && |\n| &&
              `        // the openBy anchor not being present), matching the parent-not-found` && |\n| &&
              `        // guard in displayNestedView.` && |\n| &&
-             `        const oModel = this._createViewModel();` && |\n| &&
-             `        applyStoredSizeLimit("POPOVER", oModel);` && |\n| &&
-             `        const oFragment = await Fragment.load({` && |\n| &&
-             `          definition: xml,` && |\n| &&
-             `          controller: ViewSlots.getController("POPOVER"),` && |\n| &&
-             `          id: "popoverId",` && |\n| &&
-             `        });` && |\n| &&
-             `        if (!Lib.isAlive(AppState.state.oApp) || this._isSuperseded(seq)) {` && |\n| &&
-             `          oFragment.destroy();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        oFragment.setModel(oModel);` && |\n| &&
+             `        const oFragment = await this._loadSlotFragment(` && |\n| &&
+             `          "POPOVER",` && |\n| &&
+             `          "popoverId",` && |\n| &&
+             `          xml,` && |\n| &&
+             `          seq,` && |\n| &&
+             `        );` && |\n| &&
+             `        if (!oFragment) return;` && |\n| &&
              `` && |\n| &&
              `        // Find the control to attach the popover to: any open slot first,` && |\n| &&
              `        // then the global UI5 control registry as a last resort.` && |\n| &&
@@ -416,7 +424,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        }` && |\n| &&
              `        this.eB(...args);` && |\n| &&
              `      },` && |\n| &&
-             `` && |\n| &&
+             `` && |\n|.
+    result = result &&
              `      // Ancestor-text breadcrumb of a control resolved in an event argument,` && |\n| &&
              `      // e.g. ``$controller.textPath(${$parameters>/item})`` on a menu's` && |\n| &&
              `      // itemSelected -> "Create New Site > Official Store". The parent-chain` && |\n| &&
@@ -424,8 +433,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `      // it; the separator defaults to " > ".` && |\n| &&
              `      textPath(oControl, sSeparator) {` && |\n| &&
              `        return Lib.getTextPath(oControl, sSeparator);` && |\n| &&
-             `      },` && |\n|.
-    result = result &&
+             `      },` && |\n| &&
              `` && |\n| &&
              `      // ------------------------------------------------------------------` && |\n| &&
              `      // eB = "event backend": triggers a backend roundtrip with arguments.` && |\n| &&
@@ -614,13 +622,17 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          preprocessors: { xml: { models: { template: oViewModel } } },` && |\n| &&
              `        });` && |\n| &&
              `` && |\n| &&
-             `        // Guard against the app being destroyed during the await above.` && |\n| &&
              `        // oModel covers oViewModel too when they are the same object (no` && |\n| &&
              `        // switchPath); with an OData default model both must go.` && |\n| &&
-             `        if (!Lib.isAlive(AppState.state.oApp)) {` && |\n| &&
+             `        const discardBuild = () => {` && |\n| &&
              `          oView.destroy();` && |\n| &&
              `          oModel.destroy();` && |\n| &&
              `          if (switchPath) oViewModel.destroy();` && |\n| &&
+             `        };` && |\n| &&
+             `` && |\n| &&
+             `        // Guard against the app being destroyed during the await above.` && |\n| &&
+             `        if (!Lib.isAlive(AppState.state.oApp)) {` && |\n| &&
+             `          discardBuild();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
@@ -637,9 +649,7 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          reqSeq !== Server._requestSeq &&` && |\n| &&
              `          ViewSlots.getView("MAIN")` && |\n| &&
              `        ) {` && |\n| &&
-             `          oView.destroy();` && |\n| &&
-             `          oModel.destroy();` && |\n| &&
-             `          if (switchPath) oViewModel.destroy();` && |\n| &&
+             `          discardBuild();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&

--- a/src/02/z2ui5_cl_ai_xml.clas.abap
+++ b/src/02/z2ui5_cl_ai_xml.clas.abap
@@ -244,40 +244,29 @@ CLASS z2ui5_cl_ai_xml IMPLEMENTATION.
 
   METHOD xml_escape.
 
+    " `&` must be replaced first so the entities added afterwards are not
+    " escaped again. The three whitespace characters become character
+    " references because XML attribute-value normalization would otherwise
+    " turn a literal LF/CR/TAB into a plain space and silently drop the line
+    " breaks of e.g. a two-line noDataText. The char constants come from the
+    " context class - the one place allowed to reference cl_abap_char_utilities
+    " (see "Utilities" in AGENTS.md).
+    DATA(lt_escape) = VALUE ty_t_pair(
+        ( n = `&`                                                v = `&amp;` )
+        ( n = `<`                                                v = `&lt;` )
+        ( n = `>`                                                v = `&gt;` )
+        ( n = `"`                                                v = `&quot;` )
+        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_newline        v = `&#xA;` )
+        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)       v = `&#xD;` )
+        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_horizontal_tab v = `&#x9;` ) ).
+
     result = val.
-    result = replace( val  = result
-                      sub  = `&`
-                      with = `&amp;`
-                      occ  = 0 ).
-    result = replace( val  = result
-                      sub  = `<`
-                      with = `&lt;`
-                      occ  = 0 ).
-    result = replace( val  = result
-                      sub  = `>`
-                      with = `&gt;`
-                      occ  = 0 ).
-    result = replace( val  = result
-                      sub  = `"`
-                      with = `&quot;`
-                      occ  = 0 ).
-    " whitespace as character references - a literal LF/CR/TAB in an attribute
-    " value is turned into a plain space by XML attribute-value normalization,
-    " so line breaks (e.g. a two-line noDataText) would silently disappear.
-    " char constants come from the context class - the one place allowed to
-    " reference cl_abap_char_utilities (see "Utilities" in AGENTS.md)
-    result = replace( val  = result
-                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_newline
-                      with = `&#xA;`
-                      occ  = 0 ).
-    result = replace( val  = result
-                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)
-                      with = `&#xD;`
-                      occ  = 0 ).
-    result = replace( val  = result
-                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_horizontal_tab
-                      with = `&#x9;`
-                      occ  = 0 ).
+    LOOP AT lt_escape INTO DATA(escape).
+      result = replace( val  = result
+                        sub  = escape-n
+                        with = escape-v
+                        occ  = 0 ).
+    ENDLOOP.
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -70,6 +70,31 @@ CLASS z2ui5_cl_app_startup DEFINITION PUBLIC.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+    " Building blocks of the SimpleForm rows above. Private on purpose: this
+    " class lives in the public src/02 package, so everything added to its
+    " public section joins the framework's stable API contract (rule 5).
+
+    " the section headline every render_* method opens with
+    METHODS render_section
+      IMPORTING
+        form  TYPE REF TO z2ui5_cl_ai_xml
+        title TYPE string.
+
+    " a form row of Label + external Link; an empty label renders a blank one,
+    " which is how the SimpleForm keeps the link in the value column
+    METHODS render_link
+      IMPORTING
+        form  TYPE REF TO z2ui5_cl_ai_xml
+        label TYPE string OPTIONAL
+        text  TYPE string
+        href  TYPE string.
+
+    " a form row of Label + read-only Text
+    METHODS render_text
+      IMPORTING
+        form  TYPE REF TO z2ui5_cl_ai_xml
+        label TYPE string
+        text  TYPE string.
 ENDCLASS.
 
 
@@ -243,10 +268,8 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
 
   METHOD render_quickstart.
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `Quickstart`
-      )->shut( ).
+    render_section( form  = form
+                    title = `Quickstart` ).
 
     form->leaf( `Label` )->a( n = `text`
                               v = `Step 1`
@@ -259,17 +282,14 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
       )->leaf( `Label` )->a( n = `text`
                              v = `Step 3`
       )->leaf( `Text` )->a( n = `text`
-                            v = `Define the view, implement behavior`
-      )->leaf( `Label`
-      )->leaf( `Link`
-          )->a( n = `text`
-                v = `(Example)`
-          )->a( n = `target`
-                v = `_blank`
-          )->a( n = `href`
-                v = `https://github.com/abap2UI5/abap2UI5/blob/main/src/02/z2ui5_cl_app_hello_world.clas.abap`
-      )->leaf( `Label` )->a( n = `text`
-                             v = `Step 4` ).
+                            v = `Define the view, implement behavior` ).
+
+    render_link( form = form
+                 text = `(Example)`
+                 href = `https://github.com/abap2UI5/abap2UI5/blob/main/src/02/z2ui5_cl_app_hello_world.clas.abap` ).
+
+    form->leaf( `Label` )->a( n = `text`
+                              v = `Step 4` ).
 
     IF ms_home-class_editable = abap_true.
       form->leaf( `Input`
@@ -303,6 +323,8 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
         )->a( n = `width`
               v = `70%` ).
 
+    " not render_link: this one is bound and additionally disabled until the
+    " class name was checked
     form->leaf( `Label` )->a( n = `text`
                               v = `Step 5`
       )->leaf( `Link`
@@ -319,10 +341,8 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
 
   METHOD render_whats_next.
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `What's next?`
-      )->shut( ).
+    render_section( form  = form
+                    title = `What's next?` ).
 
     DATA(lv_class_samples) = COND string(
       WHEN z2ui5_cl_a2ui5_context=>rtti_check_class_exists( `z2ui5_cl_demo_app_g00` ) THEN `z2ui5_cl_demo_app_g00` ).
@@ -339,63 +359,39 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
           )->a( n = `width`
                 v = `70%` ).
     ELSE.
-      form->leaf( `Label` )->a( n = `text`
-                                v = `Install the sample repository` ).
-      form->leaf( `Link`
-          )->a( n = `text`
-                v = `And explore more than 250 sample apps...`
-          )->a( n = `target`
-                v = `_blank`
-          )->a( n = `href`
-                v = `https://github.com/abap2UI5/samples` ).
+      render_link( form  = form
+                   label = `Install the sample repository`
+                   text  = `And explore more than 250 sample apps...`
+                   href  = `https://github.com/abap2UI5/samples` ).
     ENDIF.
 
   ENDMETHOD.
 
   METHOD render_contribution.
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `Contribution`
-      )->shut( ).
+    render_section( form  = form
+                    title = `Contribution` ).
 
-    form->leaf( `Label` )->a( n = `text`
-                              v = `Open an issue` ).
-    form->leaf( `Link`
-        )->a( n = `text`
-              v = `You have problems, comments or wishes?`
-        )->a( n = `target`
-              v = `_blank`
-        )->a( n = `href`
-              v = `https://github.com/abap2UI5/abap2UI5/issues` ).
+    render_link( form  = form
+                 label = `Open an issue`
+                 text  = `You have problems, comments or wishes?`
+                 href  = `https://github.com/abap2UI5/abap2UI5/issues` ).
 
-    form->leaf( `Label` )->a( n = `text`
-                              v = `Open a Pull Request` ).
-    form->leaf( `Link`
-        )->a( n = `text`
-              v = `You added a new feature or fixed a bug?`
-        )->a( n = `target`
-              v = `_blank`
-        )->a( n = `href`
-              v = `https://github.com/abap2UI5/abap2UI5/pulls` ).
+    render_link( form  = form
+                 label = `Open a Pull Request`
+                 text  = `You added a new feature or fixed a bug?`
+                 href  = `https://github.com/abap2UI5/abap2UI5/pulls` ).
 
   ENDMETHOD.
 
   METHOD render_documentation.
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `Documentation`
-      )->shut( ).
+    render_section( form  = form
+                    title = `Documentation` ).
 
-    form->leaf( `Label` ).
-    form->leaf( `Link`
-        )->a( n = `text`
-              v = `abap2UI5.org`
-        )->a( n = `target`
-              v = `_blank`
-        )->a( n = `href`
-              v = `https://abap2UI5.org` ).
+    render_link( form = form
+                 text = `abap2UI5.org`
+                 href = `https://abap2UI5.org` ).
 
   ENDMETHOD.
 
@@ -420,14 +416,11 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     DATA(form) = create_layout_form( dialog->open( `content` ) ).
     DATA(ls_client) = client->get( ).
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `Frontend`
-      )->shut( ).
-    form->leaf( `Label` )->a( n = `text`
-                              v = `UI5 Version` ).
-    form->leaf( `Text` )->a( n = `text`
-                             v = ls_client-s_ui5-version ).
+    render_section( form  = form
+                    title = `Frontend` ).
+    render_text( form  = form
+                 label = `UI5 Version`
+                 text  = ls_client-s_ui5-version ).
     form->leaf( `Label` )->a( n = `text`
                               v = `Launchpad active` ).
     form->leaf( `CheckBox`
@@ -436,10 +429,8 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
         )->a( n = `enabled`
               v = `false` ).
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `Backend`
-      )->shut( ).
+    render_section( form  = form
+                    title = `Backend` ).
     form->leaf( `Label` )->a( n = `text`
                               v = `ABAP for Cloud` ).
     form->leaf( `CheckBox`
@@ -447,23 +438,18 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
               v = z2ui5_cl_ai_xml=>as_bool( z2ui5_cl_a2ui5_context=>check_abap_cloud( ) )
         )->a( n = `enabled`
               v = `false` ).
-    form->leaf( `Label` )->a( n = `text`
-                              v = `User Exit` ).
-    form->leaf( `Text` )->a( n = `text`
-                             v = z2ui5_cl_exit=>get_user_exit_class( ) ).
+    render_text( form  = form
+                 label = `User Exit`
+                 text  = z2ui5_cl_exit=>get_user_exit_class( ) ).
 
-    form->open( `Toolbar`
-        )->leaf( `Title` )->a( n = `text`
-                               v = `abap2UI5`
-      )->shut( ).
-    form->leaf( `Label` )->a( n = `text`
-                              v = `Version` ).
-    form->leaf( `Text` )->a( n = `text`
-                             v = z2ui5_if_app=>version ).
-    form->leaf( `Label` )->a( n = `text`
-                              v = `Draft Entries (own)` ).
-    form->leaf( `Text` )->a( n = `text`
-                             v = CONV string( NEW z2ui5_cl_core_srv_draft( )->count_entries( ) ) ).
+    render_section( form  = form
+                    title = `abap2UI5` ).
+    render_text( form  = form
+                 label = `Version`
+                 text  = z2ui5_if_app=>version ).
+    render_text( form  = form
+                 label = `Draft Entries (own)`
+                 text  = CONV string( NEW z2ui5_cl_core_srv_draft( )->count_entries( ) ) ).
 
     dialog->open( `endButton`
         )->leaf( `Button`
@@ -475,6 +461,42 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
                   v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD render_section.
+
+    form->open( `Toolbar`
+        )->leaf( `Title` )->a( n = `text`
+                               v = title
+      )->shut( ).
+
+  ENDMETHOD.
+
+  METHOD render_link.
+
+    form->leaf( `Label` ).
+    IF label IS NOT INITIAL.
+      form->a( n = `text`
+               v = label ).
+    ENDIF.
+
+    form->leaf( `Link`
+        )->a( n = `text`
+              v = text
+        )->a( n = `target`
+              v = `_blank`
+        )->a( n = `href`
+              v = href ).
+
+  ENDMETHOD.
+
+  METHOD render_text.
+
+    form->leaf( `Label` )->a( n = `text`
+                              v = label
+      )->leaf( `Text` )->a( n = `text`
+                            v = text ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -226,65 +226,66 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
 
     DATA(ls_config) = config_http_get( ).
 
-    IF ls_config-styles_css IS INITIAL.
-      DATA(lv_style_css) = z2ui5_cl_app_style_css=>get( ).
-    ELSE.
-      lv_style_css = ls_config-styles_css.
-    ENDIF.
+    DATA(lv_style_css) = COND string( WHEN ls_config-styles_css IS INITIAL
+                                      THEN z2ui5_cl_app_style_css=>get( )
+                                      ELSE ls_config-styles_css ).
 
-    result-body = |<!DOCTYPE html>| && |\n| &&
-               |<html lang="en">| && |\n| &&
-               |<head>| && |\n| &&
+    " The entries for all embedded frontend files come from the generated
+    " preload mapping (see .github/app2abap/trans2abap.js), so the list can
+    " never run out of sync with app/webapp.
+    DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = lv_style_css
+                                                  custom_js  = ls_config-custom_js ).
+
+    " Custom controls live in their own BSP, which the frontend finds through
+    " the reserved resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/").
+    " That path is a sibling of the FRONTEND BSP, so it is only correct when
+    " the app is served from it. Here the component base is this ICF node and
+    " the same relative path resolves next to /sap/bc/, where nothing is.
+    "
+    " Hand the absolute BSP path to the frontend instead. It cannot be applied
+    " here: the manifest registers its own value during component creation,
+    " which happens after everything this page can run, so it would win.
+    " Component.js applies the field in init( ), after manifest processing.
+    " AppState~initGlobal keeps fields that are already on the global when
+    " checkLocal is true, so it survives the component start. In BSP and
+    " Launchpad mode the field is absent and the manifest entry stands.
+    DATA(lv_globals) = |window.z2ui5 = \{ checkLocal : true, | &&
+                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" \};|.
+
+    result-body = |<!DOCTYPE html>\n| &&
+                  |<html lang="en">\n| &&
+                  |<head>\n| &&
                   |{ ls_config-content_security_policy }\n| &&
-               |    <meta charset="UTF-8">| && |\n| &&
-               |    <meta name="viewport" content="width=device-width, initial-scale=1.0">| && |\n| &&
-               |    <meta http-equiv="X-UA-Compatible" content="IE=edge">| && |\n| &&
-                |<title>{ ls_config-title }</title>\n| &&
-                | <style>        html, body, body > div, #container, #container-uiarea \{\n| &&
-                |            height: 100%;\n| &&
-                |        \}</style> \n| &&
-                |<script>| && |\n| &&
-             |  function onInitComponent()\{| && |\n| &&
-             |    sap.ui.require.preload(\{| && |\n| &&
-             " The entries for all embedded frontend files come from the
-             " generated preload mapping (see .github/app2abap/trans2abap.js),
-             " so the list can never run out of sync with app/webapp.
-             z2ui5_cl_app_preload=>get( styles_css = lv_style_css
-                                        custom_js  = ls_config-custom_js ) &&
-             |    \});| && |\n| &&
-             |    sap.ui.require(["sap/ui/core/ComponentSupport"], function(ComponentSupport)\{| && |\n| &&
-             " Custom controls live in their own BSP, which the frontend finds
-             " through the reserved resourceRoot in manifest.json
-             " ("z2ui5cc": "../z2ui5cc/"). That path is a sibling of the
-             " FRONTEND BSP, so it is only correct when the app is served from
-             " it. Here the component base is this ICF node and the same
-             " relative path resolves next to /sap/bc/, where nothing is.
-             "
-             " Hand the absolute BSP path to the frontend instead. It cannot be
-             " applied here: the manifest registers its own value during
-             " component creation, which happens after everything this page can
-             " run, so it would win. Component.js applies the field in init( ),
-             " after manifest processing. AppState~initGlobal keeps fields that
-             " are already on the global when checkLocal is true, so it
-             " survives the component start. In BSP and Launchpad mode the
-             " field is absent and the manifest entry stands.
-             |     window.z2ui5 = \{ checkLocal : true, ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" \}; ComponentSupport.run();| && |\n| &&
-             |    \});| && |\n| &&
-             |  \}| && |\n| &&
-             |</script>| && |\n| &&
-                |<script id="sap-ui-bootstrap" data-sap-ui-resourceroots='\{ "z2ui5": "./" \}' data-sap-ui-oninit="onInitComponent" | && |\n| &&
-                 |data-sap-ui-compatVersion="edge" data-sap-ui-async="true" data-sap-ui-frameOptions="trusted" data-sap-ui-bindingSyntax="complex"| && |\n| &&
-                 |data-sap-ui-theme="{ ls_config-theme }" src="{ ls_config-src }"|.
+                  |    <meta charset="UTF-8">\n| &&
+                  |    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n| &&
+                  |    <meta http-equiv="X-UA-Compatible" content="IE=edge">\n| &&
+                  |<title>{ ls_config-title }</title>\n| &&
+                  | <style>        html, body, body > div, #container, #container-uiarea \{\n| &&
+                  |            height: 100%;\n| &&
+                  |        \}</style> \n| &&
+                  |<script>\n| &&
+                  |  function onInitComponent()\{\n| &&
+                  |    sap.ui.require.preload(\{\n| &&
+                  lv_preload &&
+                  |    \});\n| &&
+                  |    sap.ui.require(["sap/ui/core/ComponentSupport"], function(ComponentSupport)\{\n| &&
+                  |     { lv_globals } ComponentSupport.run();\n| &&
+                  |    \});\n| &&
+                  |  \}\n| &&
+                  |</script>\n| &&
+                  |<script id="sap-ui-bootstrap" data-sap-ui-resourceroots='\{ "z2ui5": "./" \}' data-sap-ui-oninit="onInitComponent" \n| &&
+                  |data-sap-ui-compatVersion="edge" data-sap-ui-async="true" data-sap-ui-frameOptions="trusted" data-sap-ui-bindingSyntax="complex"\n| &&
+                  |data-sap-ui-theme="{ ls_config-theme }" src="{ ls_config-src }"|.
 
     LOOP AT ls_config-t_add_config REFERENCE INTO DATA(lr_config).
       result-body = |{ result-body } { lr_config->n }='{ lr_config->v }'|.
     ENDLOOP.
 
-    result-body          = result-body &&
-                 | ></script></head>| && |\n| &&
-                 |<body class="sapUiBody sapUiSizeCompact" id="content">| && |\n| &&
-                 |    <div data-sap-ui-component data-name="z2ui5" data-id="container" data-settings='\{"id" : "z2ui5"\}' data-handle-validation="true"></div>| && |\n| &&
-                 | </body></html>|.
+    result-body = result-body &&
+                  | ></script></head>\n| &&
+                  |<body class="sapUiBody sapUiSizeCompact" id="content">\n| &&
+                  |    <div data-sap-ui-component data-name="z2ui5" data-id="container" data-settings='\{"id" : "z2ui5"\}' data-handle-validation="true"></div>\n| &&
+                  | </body></html>|.
 
     result-status_code   = 200.
     result-status_reason = `success`.

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -298,9 +298,9 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result)        TYPE string.
 
-  "! obsolete - behaves like _bind (both two-way), please use _bind;
-  "! note: _bind has no custom_mapper_back/custom_filter_back parameters -
-  "! keep using _bind_edit while you pass those
+  "! obsolete - delegates to _bind (both two-way), please use _bind.
+  "! custom_mapper_back / custom_filter_back are still accepted for source
+  "! compatibility but are no longer evaluated.
   METHODS _bind_edit
     IMPORTING
       val                  TYPE data


### PR DESCRIPTION
## Description

This PR improves code maintainability and clarity through several focused refactorings:

### ABAP Changes
- **z2ui5_cl_app_startup**: Extract three private helper methods (`render_section`, `render_link`, `render_text`) to reduce duplication in form rendering across multiple methods (`render_quickstart`, `render_whats_next`, `render_contribution`, `render_documentation`, etc.). These building blocks are intentionally private to preserve the stable API contract.
- **z2ui5_cl_http_handler**: Refactor HTML generation to use `COND` expressions instead of nested `IF` statements, improving readability. Consolidate comments explaining custom control resource paths and global state initialization.
- **z2ui5_cl_core_handler**: Add `cut_at` helper method to extract the part of a string before a separator (used for route token parsing). Simplify `hash_get_app_part` logic with `IS INITIAL` checks and improve comments.
- **z2ui5_cl_ai_xml**: Consolidate XML escape character mappings into a single data structure with explanatory comments, replacing repetitive `replace()` calls.
- **z2ui5_cl_a2ui5_context**: Simplify `ui5_msg_box_format` by restructuring early returns and improving comment clarity.
- **z2ui5_cl_core_client**: Consolidate comments in `nest_view_destroy` and `nest2_view_destroy` methods to reference a single explanation.

### JavaScript/TypeScript Changes
- **Router.js / z2ui5_cl_app_router_js**: Extract `updateAppRoute` function to handle app route synchronization logic, reducing duplication in the `sync` method. Improves separation of concerns between route updates and other sync operations.
- **View1.controller.js / z2ui5_cl_app_view1_js**: Extract `_loadSlotFragment` helper to consolidate fragment loading logic for both popup and popover slots, eliminating duplication and improving maintainability.
- **ErrorView.js / z2ui5_cl_app_errorview_js**: Extract `addAction` helper to reduce repetitive button creation code.
- **Lib.js / z2ui5_cl_app_lib_js**: Reorder comments to clarify that hash/route logic belongs exclusively in Router.js. Add `claimOnce` helper method for companion control initialization guards.
- **Server.js / z2ui5_cl_app_server_js**: Simplify caret reading logic by delegating to `Lib.readCaret` and `Lib.isTextInput` helpers.
- **Focus.js / z2ui5_cl_app_focus_js**: Simplify caret capture by delegating to `Lib.readCaret`.
- **Companion controls** (MultiInputExt, SmartMultiInputExt, UploadSetExt): Use `Lib.claimOnce` to replace manual `checkInit` property management.
- **FrontendAction.js / z2ui5_cl_app_frontendaction_js**: Add clarifying comments about ViewSlots.resolveById behavior.
- **App.controller.js / z2ui5_cl_app_app_js**: Import ViewSlots module (required by FrontendAction handlers).
- **Storage.js / z2ui5_cl_app_storage_js**: Move descriptive comment to file header for clarity.

### Test Changes
- **utilHelpers.spec.js**: Add comprehensive test suite for `isTextInput`, `readCaret`, and `claimOnce` helper functions.
- **serverFocusInfo.spec.js** and **focus.spec.js**: Import `loadLib` to enable testing of Lib helper functions.

All changes maintain backward compatibility and improve code clarity without altering public APIs (except for the intentionally private additions in z2ui5_cl_app_startup).

## How to test

- Run `npm run verify:full` to ensure all tests pass and code quality checks succeed
- Existing unit tests validate the extracted helper functions
- Manual verification: startup page renders correctly with all sections (Quickstart, What's next, Contribution, Documentation, Frontend, Backend)

https://claude.ai/code/session_01Siixy6qxsj11XeKeJmvbKy