### PR TITLE
Add link to live browser-based demo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ ENDCLASS.
 
 That's it – your first UI5 app is ready and abap2UI5 handles the rest! 🎉
 
+No system at hand? [**Try abap2UI5 live in your browser**](https://abap2ui5.github.io/web-abap2UI5-build/) – the whole framework runs client-side (transpiled ABAP + sql.js), rebuilt daily from this repo by [web-abap2UI5](https://github.com/abap2UI5/web-abap2UI5).
+
 #### How It Works
 
 abap2UI5 is a **single-page app**. The browser loads a UI5 shell once, then talks to ABAP via JSON roundtrips:


### PR DESCRIPTION
# Description

This PR adds a note to the README directing users to the live web-based demo of abap2UI5. The demo runs entirely client-side using transpiled ABAP and sql.js, making it accessible to users without an SAP system.

The addition includes a link to the [web-abap2UI5](https://github.com/abap2UI5/web-abap2UI5) project, which rebuilds the demo daily from the main repository.

## How to test

- Verify the link in the README is correct and functional
- Confirm the link appears in the appropriate location (after the "first UI5 app is ready" section)

## Checklist

- [x] No code changes (documentation only)
- [x] No automated tests needed
- [x] No changes to generated or protected source directories
- [x] No public API changes
- [x] Changes made via direct file edit (README.md)

https://claude.ai/code/session_01PzMi9GSFJ1YeYSgFR152HG