### PR TITLE
Support renamed samples app with fallback to old name

### DIFF
--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -344,7 +344,11 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
     render_section( form  = form
                     title = `What's next?` ).
 
+    " the samples repository renamed its overview app from z2ui5_cl_demo_app_g00
+    " to z2ui5_cl_smp_app_000 - check the current name first, keep the old one as
+    " a fallback so an older samples installation still gets the button
     DATA(lv_class_samples) = COND string(
+      WHEN z2ui5_cl_a2ui5_context=>rtti_check_class_exists( `z2ui5_cl_smp_app_000` ) THEN `z2ui5_cl_smp_app_000`
       WHEN z2ui5_cl_a2ui5_context=>rtti_check_class_exists( `z2ui5_cl_demo_app_g00` ) THEN `z2ui5_cl_demo_app_g00` ).
 
     IF lv_class_samples IS NOT INITIAL.


### PR DESCRIPTION
# Description

Updates the startup app to check for the new samples repository app name (`z2ui5_cl_smp_app_000`) first, while maintaining backward compatibility with the old name (`z2ui5_cl_demo_app_g00`). This allows the "What's next?" section to display the samples button regardless of whether users have an older or newer samples installation.

The change uses a conditional expression to check for the new class name first, then falls back to the old one if not found.

## How to test

1. Verify the startup app loads successfully
2. With the new samples installation: confirm the "What's next?" section displays the samples button
3. With an older samples installation: confirm the button still appears using the fallback class name

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01TJG4oDraQ7ecRShjYY6Ea3