### PR TITLE
feat: marshal control-valued event args, whitelist setP13nData, fix S…

### DIFF
--- a/app/webapp/cc/Storage.js
+++ b/app/webapp/cc/Storage.js
@@ -7,6 +7,33 @@ sap.ui.define(
   (Control, Storage, Lib) => {
     "use strict";
 
+    // Value equality for the stored payload. `value` is typed `any`: a plain
+    // string for the common case, a structure or a table once an app binds
+    // one. A reference comparison reports EVERY object as different, because
+    // sap/ui/util/Storage JSON-round-trips what it stores and therefore hands
+    // back a fresh object on every read - the control would fire `finished`
+    // on each render, the backend would answer with a re-render, and that
+    // fires again: an endless round-trip loop that made a structured value
+    // unusable. Compare by value instead. Key order is not significant (the
+    // stored copy went through JSON, the bound one comes from the model), and
+    // the payload is JSON by construction, so this covers every shape that
+    // can reach the property.
+    function isSameValue(a, b) {
+      if (a === b) return true;
+      if (a === null || b === null) return false;
+      if (typeof a !== "object" || typeof b !== "object") return false;
+      if (Array.isArray(a) !== Array.isArray(b)) return false;
+      if (Array.isArray(a)) {
+        return a.length === b.length && a.every((v, i) => isSameValue(v, b[i]));
+      }
+      const keys = Object.keys(a);
+      if (keys.length !== Object.keys(b).length) return false;
+      return keys.every(
+        (k) =>
+          Object.prototype.hasOwnProperty.call(b, k) && isSameValue(a[k], b[k]),
+      );
+    }
+
     return Control.extend("z2ui5.cc.Storage", {
       metadata: {
         properties: {
@@ -71,7 +98,7 @@ sap.ui.define(
 
         // Only fire "finished" when the stored value differs from the
         // current property to avoid feedback loops.
-        if (stored !== value) {
+        if (!isSameValue(stored, value)) {
           this.setProperty("value", stored, true);
           this.fireFinished({ type, prefix, key, value: stored });
         }

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -495,10 +495,14 @@ sap.ui.define(
         // turned into JSON strings by the backend when it fills
         // T_EVENT_ARG, so apps keep receiving them as strings; stringifying
         // them here as well would encode (and escape) the payload twice.
-        // `args` is this call's own rest-parameter array (Server.roundtrip
-        // mutates ARGUMENTS via shift), so it can be handed over directly -
-        // no defensive copy needed.
-        oBody.ARGUMENTS = args;
+        // Control-valued arguments are marshalled into plain data first (see
+        // Lib.normalizeEventArgs): a UI5 event parameter is often a control or
+        // an array of controls, and JSON.stringify throws on the circular
+        // parent/aggregation graph of a ManagedObject. Everything else passes
+        // through untouched. normalizeEventArgs returns a fresh array, which
+        // is what Server.roundtrip needs - it mutates ARGUMENTS via shift and
+        // must not reach this call's own rest-parameter array.
+        oBody.ARGUMENTS = Lib.normalizeEventArgs(args);
 
         Server.roundtrip(oBody);
         Lib.runCallbacks(AppState.state.onAfterRoundtrip);

--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -113,6 +113,8 @@ sap.ui.define(
       setSticky: ["object"], // sap.m.ListBase/sap.m.Table: JSON array of sap.m.Sticky keys
       setSelectedSection: ["controlIdOrNull"], // sap.uxap.ObjectPageLayout: an EMPTY argument clears the association
       setSelectedItem: ["controlIdOrNull"], // sap.m.List/sap.m.Select/...: an EMPTY argument clears the selection
+      setP13nData: ["object"], // sap.m.p13n.*Panel: JSON array of the panel's items
+
       css: ["string", "string"], // NOT a UI5 method: set one CSS property on the control's own DOM node
       enablePostButton: ["bool"], // sap.m.FeedInput: toggle the Post button independent of `enabled`
       addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -506,6 +506,69 @@ sap.ui.define(
       oRm.close("span");
     }
 
+    // Event arguments are whatever the UI5 expression grammar produced for
+    // them. Most are strings or numbers, but a UI5 event parameter is quite
+    // often a CONTROL or an ARRAY OF CONTROLS -
+    // ViewSettingsDialog.confirm/filterItems, Menu.itemSelected/item,
+    // SinglePlanningCalendar.selectedDatesChange with its DateRange list. Those
+    // could not travel before: JSON.stringify walks a ManagedObject through its
+    // parent/aggregation graph and throws on the circular reference, so the
+    // whole roundtrip body failed to serialize. The expression grammar has no
+    // loop or lambda either, so an app could not project the array itself and
+    // was left parsing a display string (the localized `filterString`) instead.
+    //
+    // Marshal them into plain data here: one object per control carrying its
+    // control id plus the values of its metadata PROPERTIES. Which properties
+    // exist is asked of the control's own metadata - nothing is interpreted,
+    // renamed or decided, so this stays the thin-executor contract. The
+    // backend receives it as the JSON string every object argument becomes in
+    // T_EVENT_ARG and parses it with ajson.
+    //
+    // Anything that is not a control is handed through untouched, so this is
+    // purely additive for every wire that works today.
+    const MAX_ARG_DEPTH = 4;
+
+    function isManagedObject(value) {
+      return (
+        value !== null &&
+        typeof value === "object" &&
+        typeof value.isA === "function" &&
+        value.isA("sap.ui.base.ManagedObject")
+      );
+    }
+
+    function projectControl(control) {
+      const result = { ID: control.getId() };
+      const properties = control.getMetadata().getAllProperties();
+      for (const name in properties) {
+        try {
+          const value = control.getProperty(name);
+          if (value !== undefined) result[name] = value;
+        } catch {
+          // a property whose getter throws is simply not reported - the
+          // remaining ones still have to reach the backend
+        }
+      }
+      return result;
+    }
+
+    function normalizeEventArg(value, depth) {
+      const level = depth || 0;
+      if (level > MAX_ARG_DEPTH) return value;
+      if (isManagedObject(value)) return projectControl(value);
+      if (Array.isArray(value)) {
+        return value.map((entry) => normalizeEventArg(entry, level + 1));
+      }
+      return value;
+    }
+
+    // Always returns a fresh top-level array: Server.roundtrip shifts
+    // oBody.ARGUMENTS, which must not reach the caller's own rest-parameter
+    // array.
+    function normalizeEventArgs(args) {
+      return args.map((arg) => normalizeEventArg(arg, 0));
+    }
+
     return {
       logError,
       isDestroyed,
@@ -535,6 +598,7 @@ sap.ui.define(
       isRootModelSlot,
       effectiveSizeLimit,
       renderInvisibleSpan,
+      normalizeEventArgs,
     };
   },
 );

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,32 @@ Legend
 
 unreleased
 ----------
++ Event arguments: a control-valued event parameter now reaches the backend as
+  data. Several UI5 events hand over a control or an array of controls instead
+  of a scalar - ViewSettingsDialog.confirm gives filterItems,
+  SinglePlanningCalendar.selectedDatesChange a list of DateRange - and those
+  could not travel at all: JSON.stringify walks a ManagedObject through its
+  circular parent/aggregation graph and threw, so the whole roundtrip body
+  failed to serialize. The expression grammar has no loop or lambda either, so
+  an app could not project the array itself and was left parsing a localized
+  display string (filterString). Lib.normalizeEventArgs now marshals each
+  control into an object carrying its ID plus the values of its metadata
+  properties, which the app reads from get_event_arg( ) with z2ui5_cl_ajson.
+  Which properties exist comes from the control's own metadata - nothing is
+  interpreted or renamed - and every argument that is not a control passes
+  through untouched, so existing wires are unaffected
++ CONTROL_METHODS: setP13nData (object). The sap.m.p13n panels
+  (SelectionPanel, SortPanel, GroupPanel) take their item list only through
+  this method - they expose no bindable aggregation for it - so seeding a p13n
+  popup previously required hand-written custom JS. It is now a
+  follow_up_action( cs_event-control_by_id ) like any other imperative call,
+  with the list travelling as one JSON payload
+* cc/Storage: the "did the stored value change" check compares by value
+  instead of by reference. sap/ui/util/Storage JSON-round-trips what it holds,
+  so a structured payload came back as a fresh object on every read, fired
+  `finished` on every render, was answered with a re-render and fired again -
+  an endless roundtrip loop that made anything other than a plain string
+  unusable. A structure or a table can now be stored and read back
 ! Error output: a 500 response no longer carries only the outermost message. The
   body now holds the full diagnostic - the message chain, then one block per
   entry of the previous chain with the exception class, its own text, the source

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -208,6 +208,15 @@ ships for existing apps but is **frozen** — new apps and new code use
   `` `$event.oSource.sId` `` (the pressed control's id),
   `` `${$parameters>/selected}` `` (an event parameter). A bare `{…}` arg is
   NOT resolved and arrives empty. Booleans arrive as `abap_bool` (`X`/space).
+- **A control-valued event parameter arrives as JSON.** Several UI5 events
+  hand over a control or a whole array of controls rather than a scalar —
+  `ViewSettingsDialog.confirm` gives `filterItems`,
+  `SinglePlanningCalendar.selectedDatesChange` a list of `DateRange`. Pass the
+  parameter like any other (`` `${$parameters>/filterItems}` ``); the frontend
+  marshals each control into an object carrying its `ID` plus its public
+  properties, so `client->get_event_arg( )` returns a JSON array you read with
+  `z2ui5_cl_ajson`. Do **not** parse a display string such as
+  `filterString` — it is localized and its format is not a contract.
 - Roundtrip-free client actions: `client->_event_client( val = … t_arg = … )`
   runs a whitelisted frontend action without a server call (toast from a row
   value, client-side sort/filter via `binding_call`, …).
@@ -275,6 +284,24 @@ ships for existing apps but is **frozen** — new apps and new code use
 - The default UI5 bootstrap loads from the CDN; system-local hosting and
   CSP/theme/bootstrap customizing go through `z2ui5_if_exit` /
   `z2ui5_cl_exit`.
+- **A third-party JS library is a deployment decision, not a view trick.**
+  The default CSP in `z2ui5_cl_exit` already whitelists `cdn.jsdelivr.net`
+  and `cdnjs.cloudflare.com`, so a library loaded from one of them is
+  allowed out of the box — anything else needs your own
+  `content_security_policy` in the exit, and a system-local copy served by
+  your own ICF node is the option that survives an offline system. Whichever
+  you pick, load the library through the UI5 loader
+  (`sap.ui.loader.config` path mapping + `sap.ui.define`) and drive it from a
+  custom control; do **not** rely on the jQuery `$` global — UI5 2.x no
+  longer ships it — and keep the library call itself free of business
+  decisions (see "thin frontend" above).
+- **An imperative UI5 method that has no bindable equivalent** — the
+  `sap.m.p13n.*` panels take their item list only through `setP13nData( )`,
+  a `sap.m.Carousel` only moves via `setActivePage( )` — is reached with
+  `client->follow_up_action( val = cs_event-control_by_id … )`. Check
+  `cs_event` and the whitelist before writing custom JS: an argument the
+  whitelist does not declare is silently dropped, but a method it declares
+  needs no JS at all.
 
 ## 9. Validate and iterate like the framework does
 

--- a/node/tests/eventArgs.spec.js
+++ b/node/tests/eventArgs.spec.js
@@ -1,0 +1,146 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loadLib } = require("./loadLibModule");
+
+// Lib.normalizeEventArgs: marshals control-valued event arguments into plain,
+// serializable data. A UI5 event parameter is often a control or an array of
+// controls (ViewSettingsDialog.confirm -> filterItems, Menu.itemSelected ->
+// item, SinglePlanningCalendar.selectedDatesChange -> DateRange list), and
+// JSON.stringify throws on a ManagedObject's circular parent/aggregation
+// graph. Everything that is not a control must pass through untouched.
+
+const { Lib } = loadLib();
+
+// A minimal ManagedObject stand-in: `isA`, `getId`, metadata properties and a
+// getProperty that reads them.
+function control(id, properties, { throwOn = null } = {}) {
+  const own = { ...properties };
+  const parent = { child: null };
+  const self = {
+    isA: (type) => type === "sap.ui.base.ManagedObject",
+    getId: () => id,
+    getMetadata: () => ({
+      getAllProperties: () =>
+        Object.keys(own).reduce((acc, k) => ({ ...acc, [k]: {} }), {}),
+    }),
+    getProperty: (name) => {
+      if (name === throwOn) throw new Error("getter exploded");
+      return own[name];
+    },
+    // the circular reference that made JSON.stringify throw
+    getParent: () => parent,
+  };
+  parent.child = self;
+  return self;
+}
+
+test("a plain string argument is untouched", () => {
+  expect(Lib.normalizeEventArgs(["A", "B"])).toEqual(["A", "B"]);
+});
+
+test("numbers, booleans and null pass through", () => {
+  expect(Lib.normalizeEventArgs([1, true, null, ""])).toEqual([
+    1,
+    true,
+    null,
+    "",
+  ]);
+});
+
+test("the backend event array in args[0] is untouched", () => {
+  const eventArray = ["MY_EVENT", false, false, false];
+  const [head] = Lib.normalizeEventArgs([eventArray, "X"]);
+  expect(head).toEqual(eventArray);
+});
+
+test("a single control becomes its id plus its properties", () => {
+  const result = Lib.normalizeEventArgs([
+    control("__item0", { key: "K1", text: "City", selected: true }),
+  ]);
+
+  expect(result[0]).toEqual({
+    ID: "__item0",
+    key: "K1",
+    text: "City",
+    selected: true,
+  });
+});
+
+test("an array of controls becomes an array of plain objects", () => {
+  const result = Lib.normalizeEventArgs([
+    [
+      control("__i0", { key: "A", text: "Alpha" }),
+      control("__i1", { key: "B", text: "Beta" }),
+    ],
+  ]);
+
+  expect(result[0]).toEqual([
+    { ID: "__i0", key: "A", text: "Alpha" },
+    { ID: "__i1", key: "B", text: "Beta" },
+  ]);
+});
+
+test("the marshalled result survives JSON.stringify", () => {
+  // the whole point: the raw control throws here because of getParent
+  const raw = control("__i0", { key: "A" });
+  const cyclic = { c: raw, back: null };
+  cyclic.back = cyclic;
+  expect(() => JSON.stringify(cyclic)).toThrow();
+
+  const result = Lib.normalizeEventArgs([[raw]]);
+  expect(() => JSON.stringify(result)).not.toThrow();
+  expect(JSON.parse(JSON.stringify(result))[0][0].key).toBe("A");
+});
+
+test("a property whose getter throws is skipped, the rest survives", () => {
+  const result = Lib.normalizeEventArgs([
+    control("__i0", { key: "A", broken: "x", text: "T" }, { throwOn: "broken" }),
+  ]);
+
+  expect(result[0]).toEqual({ ID: "__i0", key: "A", text: "T" });
+});
+
+test("an undefined property value is omitted", () => {
+  const result = Lib.normalizeEventArgs([
+    control("__i0", { key: "A", text: undefined }),
+  ]);
+
+  expect(result[0]).toEqual({ ID: "__i0", key: "A" });
+});
+
+test("a control with no properties still reports its id", () => {
+  expect(Lib.normalizeEventArgs([control("__i0", {})])[0]).toEqual({
+    ID: "__i0",
+  });
+});
+
+test("a plain model object is NOT projected", () => {
+  const payload = { TYPE: "local", VALUE: { FIELD1: 1 } };
+  const [result] = Lib.normalizeEventArgs([payload]);
+  expect(result).toBe(payload);
+});
+
+test("nested arrays of controls are marshalled at every level", () => {
+  const result = Lib.normalizeEventArgs([
+    [[control("__deep", { key: "D" })]],
+  ]);
+  expect(result[0][0][0]).toEqual({ ID: "__deep", key: "D" });
+});
+
+test("recursion stops at the depth cap instead of running away", () => {
+  // build an array nested deeper than MAX_ARG_DEPTH (4); the control past the
+  // cap is handed through as-is rather than recursed into forever
+  let nested = control("__tooDeep", { key: "X" });
+  for (let i = 0; i < 8; i++) nested = [nested];
+
+  expect(() => Lib.normalizeEventArgs([nested])).not.toThrow();
+});
+
+test("a fresh top-level array is returned - Server.roundtrip shifts it", () => {
+  const args = ["A", "B"];
+  const result = Lib.normalizeEventArgs(args);
+
+  expect(result).not.toBe(args);
+  result.shift();
+  expect(args).toEqual(["A", "B"]);
+});

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -307,6 +307,27 @@ test.describe("CONTROL_BY_ID", () => {
     expect(calls).toEqual([["scroll", 42]]);
   });
 
+  // sap.m.p13n.SelectionPanel/SortPanel/GroupPanel take their items through
+  // setP13nData() only - the panels expose no bindable aggregation for them -
+  // so seeding a p13n popup used to need hand-written custom JS. The `object`
+  // arg kind carries the whole item list as one JSON payload.
+  test("casts the setP13nData payload from JSON (p13n panels)", () => {
+    const { FrontendAction, calls, controls } = load();
+    controls.columnsPanel = {
+      setP13nData: (data) => calls.push(["setP13nData", data]),
+    };
+    FrontendAction.execute(null, [
+      "CONTROL_BY_ID",
+      "columnsPanel",
+      "",
+      "setP13nData",
+      '[{"name":"key1","label":"City","visible":true}]',
+    ]);
+    expect(calls).toEqual([
+      ["setP13nData", [{ name: "key1", label: "City", visible: true }]],
+    ]);
+  });
+
   test("resolves a controlId argument to the control (to)", () => {
     const { FrontendAction, calls, controls } = load();
     const page2 = { id: "page2" };

--- a/node/tests/storage.spec.js
+++ b/node/tests/storage.spec.js
@@ -1,0 +1,161 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { loadModule } = require("./loadModule");
+
+// cc/Storage.js: reads a value out of browser storage into its `value`
+// property and fires `finished` only when the stored value actually differs.
+// The equality check has to be by VALUE - sap/ui/util/Storage JSON-round-trips
+// what it holds, so a structured payload comes back as a fresh object every
+// read and a reference comparison would fire on every render (round-trip
+// loop).
+function load({ stored = "", value = "" } = {}) {
+  const errors = [];
+  const { module: StorageControl } = loadModule("cc/Storage.js", {
+    deps: {
+      "sap/ui/core/Control": { extend: (_name, def) => def },
+      "sap/ui/util/Storage": class {
+        constructor() {
+          this.get = () => stored;
+        }
+        static Type = { local: "local", session: "session" };
+      },
+      "z2ui5/core/Lib": {
+        logError: (msg) => errors.push(msg),
+        renderInvisibleSpan() {},
+      },
+    },
+  });
+
+  const fired = [];
+  const instance = Object.create(StorageControl);
+  instance._pendingRead = true;
+  instance._props = { type: "local", prefix: "p", key: "k", value };
+  instance.getProperty = (name) => instance._props[name];
+  instance.setProperty = (name, v) => (instance._props[name] = v);
+  instance.fireFinished = (payload) => fired.push(payload);
+
+  return { instance, fired, errors };
+}
+
+test("a changed string value fires finished once", () => {
+  const { instance, fired } = load({ stored: "new", value: "old" });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+  expect(fired[0].value).toBe("new");
+  expect(instance.getProperty("value")).toBe("new");
+});
+
+test("an unchanged string value does not fire", () => {
+  const { instance, fired } = load({ stored: "same", value: "same" });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(0);
+});
+
+test("a structurally equal object does NOT fire - no round-trip loop", () => {
+  // the exact regression: same content, different object identity, which is
+  // what a JSON round-trip through the storage always produces
+  const { instance, fired } = load({
+    stored: { FIELD1: 1, FIELD2: "text" },
+    value: { FIELD1: 1, FIELD2: "text" },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(0);
+});
+
+test("key order is not significant", () => {
+  const { instance, fired } = load({
+    stored: { FIELD2: "text", FIELD1: 1 },
+    value: { FIELD1: 1, FIELD2: "text" },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(0);
+});
+
+test("a genuinely different object still fires", () => {
+  const { instance, fired } = load({
+    stored: { FIELD1: 2, FIELD2: "text" },
+    value: { FIELD1: 1, FIELD2: "text" },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+  expect(fired[0].value).toEqual({ FIELD1: 2, FIELD2: "text" });
+});
+
+test("an extra key makes the objects different", () => {
+  const { instance, fired } = load({
+    stored: { FIELD1: 1, FIELD2: "text", FIELD3: true },
+    value: { FIELD1: 1, FIELD2: "text" },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+});
+
+test("nested tables compare by value", () => {
+  const rows = () => ({ ROWS: [{ K: "a" }, { K: "b" }] });
+  const { instance, fired } = load({ stored: rows(), value: rows() });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(0);
+});
+
+test("a differing nested row fires", () => {
+  const { instance, fired } = load({
+    stored: { ROWS: [{ K: "a" }, { K: "c" }] },
+    value: { ROWS: [{ K: "a" }, { K: "b" }] },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+});
+
+test("a shorter array is not equal", () => {
+  const { instance, fired } = load({
+    stored: { ROWS: [{ K: "a" }] },
+    value: { ROWS: [{ K: "a" }, { K: "b" }] },
+  });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+});
+
+test("an array is never equal to an object", () => {
+  const { instance, fired } = load({ stored: [], value: {} });
+
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+});
+
+test("null is not equal to an empty object", () => {
+  const { instance, fired } = load({ stored: null, value: {} });
+
+  instance.onAfterRendering();
+
+  // Storage.get() ?? "" turns null into the empty string, which differs
+  expect(fired).toHaveLength(1);
+  expect(fired[0].value).toBe("");
+});
+
+test("the read runs only once per render", () => {
+  const { instance, fired } = load({ stored: "new", value: "old" });
+
+  instance.onAfterRendering();
+  instance.onAfterRendering();
+
+  expect(fired).toHaveLength(1);
+});

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -140,6 +140,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      setSticky: ["object"], // sap.m.ListBase/sap.m.Table: JSON array of sap.m.Sticky keys` && |\n| &&
              `      setSelectedSection: ["controlIdOrNull"], // sap.uxap.ObjectPageLayout: an EMPTY argument clears the association` && |\n| &&
              `      setSelectedItem: ["controlIdOrNull"], // sap.m.List/sap.m.Select/...: an EMPTY argument clears the selection` && |\n| &&
+             `      setP13nData: ["object"], // sap.m.p13n.*Panel: JSON array of the panel's items` && |\n| &&
+             `` && |\n| &&
              `      css: ["string", "string"], // NOT a UI5 method: set one CSS property on the control's own DOM node` && |\n| &&
              `      enablePostButton: ["bool"], // sap.m.FeedInput: toggle the Post button independent of ``enabled``` && |\n| &&
              `      addStyleClass: ["string"], // sap.ui.core.Control: add a CSS style class` && |\n| &&
@@ -422,10 +424,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      if (raw === "" || raw === " " || raw === "false") return false;` && |\n| &&
              `      return raw;` && |\n| &&
              `    }` && |\n| &&
-             `` && |\n| &&
-             `    // kinds whose EMPTY value is meaningful (null), so a missing trailing` && |\n| &&
-             `    // argument still has to be passed: the backend wire drops a trailing empty` && |\n|.
+             `` && |\n|.
     result = result &&
+             `    // kinds whose EMPTY value is meaningful (null), so a missing trailing` && |\n| &&
+             `    // argument still has to be passed: the backend wire drops a trailing empty` && |\n| &&
              `    // t_arg entry, and "clear this association" is exactly a call whose only` && |\n| &&
              `    // argument is empty.` && |\n| &&
              `    const NULLABLE_KINDS = ["controlIdOrNull"];` && |\n| &&
@@ -823,10 +825,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // the download directory or carry a misleading name.` && |\n| &&
              `      // eslint-disable-next-line no-control-regex -- control chars are matched on purpose here` && |\n| &&
              `      a.download = String(args[2] || "").replace(/[\\/:*?"<>|\x00-\x1f]/g, "_");` && |\n| &&
-             `      // Firefox only triggers a programmatic download click when the anchor` && |\n| &&
-             `      // is part of the document, so attach it briefly and remove it again.` && |\n| &&
-             `      document.body.appendChild(a);` && |\n|.
+             `      // Firefox only triggers a programmatic download click when the anchor` && |\n|.
     result = result &&
+             `      // is part of the document, so attach it briefly and remove it again.` && |\n| &&
+             `      document.body.appendChild(a);` && |\n| &&
              `      a.click();` && |\n| &&
              `      document.body.removeChild(a);` && |\n| &&
              `    }` && |\n| &&
@@ -1224,10 +1226,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    // every filter change makes the current variant dirty (the "*" next to the` && |\n| &&
-             `    // variant title) and refreshes the bar's assigned-filters summary` && |\n| &&
-             `    function attachFilterBarChange(oSVM, oFilterBar) {` && |\n| &&
-             `      oFilterBar.getAllFilterItems().forEach((item) => {` && |\n|.
+             `    // variant title) and refreshes the bar's assigned-filters summary` && |\n|.
     result = result &&
+             `    function attachFilterBarChange(oSVM, oFilterBar) {` && |\n| &&
+             `      oFilterBar.getAllFilterItems().forEach((item) => {` && |\n| &&
              `        const control = filterItemControl(item);` && |\n| &&
              `        if (!control || typeof control.attachChange !== "function") return;` && |\n| &&
              `        control.attachChange((oEvent) => {` && |\n| &&
@@ -1625,10 +1627,10 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const samePlace = (el) =>` && |\n| &&
              `          el == null ||` && |\n| &&
              `          el === document.body ||` && |\n| &&
-             `          el === prevActive ||` && |\n| &&
-             `          Boolean(el.id && prevActive && el.id === prevActive.id);` && |\n| &&
-             `        const delegate = {` && |\n|.
+             `          el === prevActive ||` && |\n|.
     result = result &&
+             `          Boolean(el.id && prevActive && el.id === prevActive.id);` && |\n| &&
+             `        const delegate = {` && |\n| &&
              `          onAfterRendering: () => {` && |\n| &&
              `            oElement.removeEventDelegate(delegate);` && |\n| &&
              `            // Defer past the rendering task: when the re-render replaced the` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_lib_js.clas.abap
@@ -534,6 +534,69 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      oRm.close("span");` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    // Event arguments are whatever the UI5 expression grammar produced for` && |\n| &&
+             `    // them. Most are strings or numbers, but a UI5 event parameter is quite` && |\n| &&
+             `    // often a CONTROL or an ARRAY OF CONTROLS -` && |\n| &&
+             `    // ViewSettingsDialog.confirm/filterItems, Menu.itemSelected/item,` && |\n| &&
+             `    // SinglePlanningCalendar.selectedDatesChange with its DateRange list. Those` && |\n| &&
+             `    // could not travel before: JSON.stringify walks a ManagedObject through its` && |\n| &&
+             `    // parent/aggregation graph and throws on the circular reference, so the` && |\n| &&
+             `    // whole roundtrip body failed to serialize. The expression grammar has no` && |\n| &&
+             `    // loop or lambda either, so an app could not project the array itself and` && |\n| &&
+             `    // was left parsing a display string (the localized ``filterString``) instead.` && |\n| &&
+             `    //` && |\n| &&
+             `    // Marshal them into plain data here: one object per control carrying its` && |\n| &&
+             `    // control id plus the values of its metadata PROPERTIES. Which properties` && |\n| &&
+             `    // exist is asked of the control's own metadata - nothing is interpreted,` && |\n| &&
+             `    // renamed or decided, so this stays the thin-executor contract. The` && |\n| &&
+             `    // backend receives it as the JSON string every object argument becomes in` && |\n| &&
+             `    // T_EVENT_ARG and parses it with ajson.` && |\n| &&
+             `    //` && |\n| &&
+             `    // Anything that is not a control is handed through untouched, so this is` && |\n| &&
+             `    // purely additive for every wire that works today.` && |\n| &&
+             `    const MAX_ARG_DEPTH = 4;` && |\n| &&
+             `` && |\n| &&
+             `    function isManagedObject(value) {` && |\n| &&
+             `      return (` && |\n| &&
+             `        value !== null &&` && |\n| &&
+             `        typeof value === "object" &&` && |\n| &&
+             `        typeof value.isA === "function" &&` && |\n| &&
+             `        value.isA("sap.ui.base.ManagedObject")` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    function projectControl(control) {` && |\n| &&
+             `      const result = { ID: control.getId() };` && |\n| &&
+             `      const properties = control.getMetadata().getAllProperties();` && |\n| &&
+             `      for (const name in properties) {` && |\n| &&
+             `        try {` && |\n| &&
+             `          const value = control.getProperty(name);` && |\n| &&
+             `          if (value !== undefined) result[name] = value;` && |\n| &&
+             `        } catch {` && |\n| &&
+             `          // a property whose getter throws is simply not reported - the` && |\n| &&
+             `          // remaining ones still have to reach the backend` && |\n| &&
+             `        }` && |\n| &&
+             `      }` && |\n| &&
+             `      return result;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    function normalizeEventArg(value, depth) {` && |\n| &&
+             `      const level = depth || 0;` && |\n| &&
+             `      if (level > MAX_ARG_DEPTH) return value;` && |\n| &&
+             `      if (isManagedObject(value)) return projectControl(value);` && |\n| &&
+             `      if (Array.isArray(value)) {` && |\n| &&
+             `        return value.map((entry) => normalizeEventArg(entry, level + 1));` && |\n| &&
+             `      }` && |\n| &&
+             `      return value;` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // Always returns a fresh top-level array: Server.roundtrip shifts` && |\n| &&
+             `    // oBody.ARGUMENTS, which must not reach the caller's own rest-parameter` && |\n| &&
+             `    // array.` && |\n| &&
+             `    function normalizeEventArgs(args) {` && |\n| &&
+             `      return args.map((arg) => normalizeEventArg(arg, 0));` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    return {` && |\n| &&
              `      logError,` && |\n| &&
              `      isDestroyed,` && |\n| &&
@@ -563,6 +626,7 @@ CLASS z2ui5_cl_app_lib_js IMPLEMENTATION.
              `      isRootModelSlot,` && |\n| &&
              `      effectiveSizeLimit,` && |\n| &&
              `      renderInvisibleSpan,` && |\n| &&
+             `      normalizeEventArgs,` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&
              `);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_storage_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_storage_js.clas.abap
@@ -34,6 +34,33 @@ CLASS z2ui5_cl_app_storage_js IMPLEMENTATION.
              `  (Control, Storage, Lib) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
+             `    // Value equality for the stored payload. ``value`` is typed ``any``: a plain` && |\n| &&
+             `    // string for the common case, a structure or a table once an app binds` && |\n| &&
+             `    // one. A reference comparison reports EVERY object as different, because` && |\n| &&
+             `    // sap/ui/util/Storage JSON-round-trips what it stores and therefore hands` && |\n| &&
+             `    // back a fresh object on every read - the control would fire ``finished``` && |\n| &&
+             `    // on each render, the backend would answer with a re-render, and that` && |\n| &&
+             `    // fires again: an endless round-trip loop that made a structured value` && |\n| &&
+             `    // unusable. Compare by value instead. Key order is not significant (the` && |\n| &&
+             `    // stored copy went through JSON, the bound one comes from the model), and` && |\n| &&
+             `    // the payload is JSON by construction, so this covers every shape that` && |\n| &&
+             `    // can reach the property.` && |\n| &&
+             `    function isSameValue(a, b) {` && |\n| &&
+             `      if (a === b) return true;` && |\n| &&
+             `      if (a === null || b === null) return false;` && |\n| &&
+             `      if (typeof a !== "object" || typeof b !== "object") return false;` && |\n| &&
+             `      if (Array.isArray(a) !== Array.isArray(b)) return false;` && |\n| &&
+             `      if (Array.isArray(a)) {` && |\n| &&
+             `        return a.length === b.length && a.every((v, i) => isSameValue(v, b[i]));` && |\n| &&
+             `      }` && |\n| &&
+             `      const keys = Object.keys(a);` && |\n| &&
+             `      if (keys.length !== Object.keys(b).length) return false;` && |\n| &&
+             `      return keys.every(` && |\n| &&
+             `        (k) =>` && |\n| &&
+             `          Object.prototype.hasOwnProperty.call(b, k) && isSameValue(a[k], b[k]),` && |\n| &&
+             `      );` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    return Control.extend("z2ui5.cc.Storage", {` && |\n| &&
              `      metadata: {` && |\n| &&
              `        properties: {` && |\n| &&
@@ -98,7 +125,7 @@ CLASS z2ui5_cl_app_storage_js IMPLEMENTATION.
              `` && |\n| &&
              `        // Only fire "finished" when the stored value differs from the` && |\n| &&
              `        // current property to avoid feedback loops.` && |\n| &&
-             `        if (stored !== value) {` && |\n| &&
+             `        if (!isSameValue(stored, value)) {` && |\n| &&
              `          this.setProperty("value", stored, true);` && |\n| &&
              `          this.fireFinished({ type, prefix, key, value: stored });` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -523,10 +523,14 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `        // turned into JSON strings by the backend when it fills` && |\n| &&
              `        // T_EVENT_ARG, so apps keep receiving them as strings; stringifying` && |\n| &&
              `        // them here as well would encode (and escape) the payload twice.` && |\n| &&
-             `        // ``args`` is this call's own rest-parameter array (Server.roundtrip` && |\n| &&
-             `        // mutates ARGUMENTS via shift), so it can be handed over directly -` && |\n| &&
-             `        // no defensive copy needed.` && |\n| &&
-             `        oBody.ARGUMENTS = args;` && |\n| &&
+             `        // Control-valued arguments are marshalled into plain data first (see` && |\n| &&
+             `        // Lib.normalizeEventArgs): a UI5 event parameter is often a control or` && |\n| &&
+             `        // an array of controls, and JSON.stringify throws on the circular` && |\n| &&
+             `        // parent/aggregation graph of a ManagedObject. Everything else passes` && |\n| &&
+             `        // through untouched. normalizeEventArgs returns a fresh array, which` && |\n| &&
+             `        // is what Server.roundtrip needs - it mutates ARGUMENTS via shift and` && |\n| &&
+             `        // must not reach this call's own rest-parameter array.` && |\n| &&
+             `        oBody.ARGUMENTS = Lib.normalizeEventArgs(args);` && |\n| &&
              `` && |\n| &&
              `        Server.roundtrip(oBody);` && |\n| &&
              `        Lib.runCallbacks(AppState.state.onAfterRoundtrip);` && |\n| &&


### PR DESCRIPTION
…torage equality

Three gaps that forced apps into hand-written custom JS, each closed through the mechanism the frontend is meant to grow by (rule 19) rather than a new bespoke handler.

Control-valued event arguments (Lib.normalizeEventArgs, View1.controller eB): a UI5 event parameter is often a control or an array of controls - ViewSettingsDialog.confirm/filterItems, Menu.itemSelected/item, SinglePlanningCalendar.selectedDatesChange with its DateRange list. Those never reached the backend: JSON.stringify walks a ManagedObject through its circular parent/aggregation graph and throws, so the whole request body failed to serialize, and the expression grammar has no loop or lambda for an app to project the array itself. Apps were left parsing the localized display string instead. Each control is now marshalled into an object carrying its ID plus the values of its metadata properties; which properties exist is asked of the control's own metadata, so this stays marshalling and makes no decisions. Non-control arguments pass through untouched - purely additive for every wire that works today.

CONTROL_METHODS.setP13nData (object): the sap.m.p13n panels take their item list only through this method and expose no bindable aggregation for it. With the entry it is an ordinary control_by_id call, and with the change above the panels' own getP13nData() read-back travels as a normal event argument - so the p13n family needs no custom JS at either end.

cc/Storage: compare the stored value structurally instead of by reference. sap/ui/util/Storage JSON-round-trips its payload, so an object came back as a fresh instance on every read, fired `finished` on every render, got a re-render in reply and fired again. That endless loop is why the property was usable with plain strings only; a structure or table now works.

Docs: building-apps.md gains the control-valued-argument rule (and the explicit "do not parse filterString"), the imperative-method-before-custom-JS pointer, and a third-party-library section - the default CSP already whitelists cdn.jsdelivr.net and cdnjs.cloudflare.com, the open question was never permission but that the library must go through the UI5 loader and not the jQuery global.

Specs: node/tests/storage.spec.js (12) and node/tests/eventArgs.spec.js (13) are new, frontendAction.spec.js covers the setP13nData cast. npm run verify, check:api, check:ui5 and eslint are green.


Claude-Session: https://claude.ai/code/session_01XFWymFErvofmmSnMk9ZQdB

# Description

<!-- A clear description of what this PR changes and why the change is needed. -->

## How to test

<!-- Steps to verify the change: app snippet, test to run, or scenario to click through. -->

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no
