### PR TITLE
Move parameter documentation to method signature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,14 @@ front, a green abaplint does not prove their absence:
   that means *inside* the chain, directly before the element — a `"!` block
   before the chain keyword is "in the wrong position" (bit us on
   `z2ui5_if_client=>cs_nav_mode`).
+- **Never `"!` inside a parameter list.** A single parameter of a `METHODS`
+  statement is not a declaration of its own, so a `"!` block in front of it
+  (anywhere between `IMPORTING` and the final `.`) is "in the wrong position".
+  Document parameters in the method's own doc block, before the `METHODS`
+  keyword, with `"! @parameter <name> | <text>` (see `z2ui5_cl_xml_view` for
+  the house style; bit us on `z2ui5_if_client~_bind( omit_initial )`). A plain
+  `"` comment inside the list stays legal — that is why the `"obsolete …` note
+  on `path` has no `!`.
 - **ABAP Doc is parsed as HTML:** a literal `<`/`>`/`&` must be escaped as
   `&lt;`/`&gt;`/`&amp;` — a placeholder like `#/app/<CLASS>` is otherwise read
   as an unsupported, unclosed HTML tag; write `#/app/&lt;CLASS&gt;`.

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -289,6 +289,24 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE string.
 
+  "! @parameter omit_initial       | keep INITIAL fields out of the serialized
+  "!                                model instead of sending them as `` / 0. An
+  "!                                ABAP field is never absent - it is initial -
+  "!                                so by default every field reaches the client
+  "!                                as an explicit value, which overrides the UI5
+  "!                                property default the original view relies on
+  "!                                (and an enum-typed property rejects the empty
+  "!                                string outright). Set it when a bound
+  "!                                template's rows fill different subsets of the
+  "!                                same properties.
+  "! @parameter omit_initial_paths | the same omission SCOPED to the listed
+  "!                                fields (upper-cased column names, the last
+  "!                                path segment). Use it when the blanket flag
+  "!                                is too coarse: an abap_false that MUST reach
+  "!                                the client is itself initial, so omit_initial
+  "!                                would drop it and the control would fall back
+  "!                                to its own default - list the numeric/enum
+  "!                                columns instead and leave the booleans.
   METHODS _bind
     IMPORTING
       val                  TYPE data
@@ -300,19 +318,8 @@ INTERFACE z2ui5_if_client
       tab                  TYPE data                          OPTIONAL
       tab_index            TYPE i                             OPTIONAL
       switch_default_model TYPE abap_bool                     DEFAULT abap_false
-      "! keep INITIAL fields out of the serialized model instead of sending
-      "! them as `` / 0. An ABAP field is never absent - it is initial - so by
-      "! default every field reaches the client as an explicit value, which
-      "! overrides the UI5 property default the original view relies on (and an
-      "! enum-typed property rejects the empty string outright). Set it when a
-      "! bound template's rows fill different subsets of the same properties.
       omit_initial         TYPE abap_bool                     DEFAULT abap_false
-      "! the same omission SCOPED to the listed fields (upper-cased column
-      "! names, the last path segment). Use it when the blanket flag is too
-      "! coarse: an abap_false that MUST reach the client is itself initial, so
-      "! omit_initial would drop it and the control would fall back to its own
-      "! default - list the numeric/enum columns instead and leave the booleans.
-      omit_initial_paths   TYPE string_table                   OPTIONAL
+      omit_initial_paths   TYPE string_table                  OPTIONAL
     RETURNING
       VALUE(result)        TYPE string.
 


### PR DESCRIPTION
# Description

Refactored the documentation for the `_bind` method's `omit_initial` and `omit_initial_paths` parameters by moving their detailed descriptions from inline comments to proper `@parameter` documentation tags above the method signature. This improves documentation consistency and maintainability by using the standard ABAP documentation format.

The documentation content remains unchanged—only its location and formatting have been updated to follow ABAP documentation conventions.

## How to test

N/A - This is a documentation-only refactor with no functional changes.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_017HrqAXuqw7HZnUZ7KM1yd8