### PR TITLE
Show only the messages in the error popup, the full dump behind Details

### DIFF
--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -65,22 +65,53 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
       .join(" - ");
   }
 
-  // Turn the raw error text into a one-glance preview for the friendly dialog.
-  // Backend errors often arrive as a whole HTML page (an ABAP dump rendered as
-  // a 500 error page): prefer the structured error message, else fall back to
-  // stripping script/style/title and the remaining tags. Rendered as plain
-  // MessageBox text, so the stripped markup cannot execute.
+  // A framework 500 body is a sectioned plain-text dump built by
+  // z2ui5_cx_a2ui5_error=>get_text_full: a version header line, then
+  // `--- error ---` with the message chain (one message per line), then
+  // `--- exception chain ---` (a block per cause with class, source position,
+  // kernel id, attributes) and `--- context ---`. The popup shows only the
+  // messages; the rest is one click away behind Details and in Copy, which
+  // both work on the untruncated text. Returns "" when the text is not such
+  // a dump - a network error, a client-side failure or an ABAP dump rendered
+  // as an HTML error page all keep the single-line preview below.
+  const ERROR_SECTION_HEADER = "--- error ---";
+
+  function extractFrameworkMessages(text) {
+    const lines = text.split("\n");
+    const start = lines.findIndex(
+      (line) => line.trim() === ERROR_SECTION_HEADER,
+    );
+    if (start < 0) return "";
+    const messages = [];
+    for (const line of lines.slice(start + 1)) {
+      // the next section header ends the block
+      if (line.trim().startsWith("---")) break;
+      const cleaned = cleanText(line);
+      if (cleaned) messages.push(cleaned);
+    }
+    return messages.join("\n");
+  }
+
+  // Turn the raw error text into a preview for the friendly dialog: the
+  // framework's own messages when the body carries them, otherwise a
+  // one-glance line. Backend errors may also arrive as a whole HTML page (an
+  // ABAP dump rendered as a 500 error page): prefer the structured error
+  // message, else fall back to stripping script/style/title and the remaining
+  // tags. Rendered as plain text, so the stripped markup cannot execute.
   function buildErrorPreview(text) {
     if (!text) return "";
-    let preview = text;
-    if (/<[a-z][\s\S]*>/i.test(preview)) {
-      preview =
-        extractServerError(preview) ||
-        cleanText(
-          preview.replace(/<(script|style|title)[\s\S]*?<\/\1>/gi, " "),
-        );
+    let preview = extractFrameworkMessages(text);
+    if (!preview) {
+      preview = text;
+      if (/<[a-z][\s\S]*>/i.test(preview)) {
+        preview =
+          extractServerError(preview) ||
+          cleanText(
+            preview.replace(/<(script|style|title)[\s\S]*?<\/\1>/gi, " "),
+          );
+      }
+      preview = preview.replace(/\s+/g, " ").trim();
     }
-    preview = preview.replace(/\s+/g, " ").trim();
     return preview.length > PREVIEW_MAX_LENGTH
       ? `${preview.slice(0, PREVIEW_MAX_LENGTH)}...`
       : preview;
@@ -200,6 +231,15 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
       // Show only the extracted error text; a short neutral fallback covers
       // the rare case where nothing could be extracted.
       const message = buildErrorPreview(details) || "An error occurred.";
+      // A framework preview is one message per line, so the line breaks have
+      // to survive - sap.m.Text normalizes whitespace unless told otherwise.
+      // Set through the mutator and guarded: the property arrived in UI5 1.60
+      // and a control without it must not take the whole dialog down (the
+      // catch below would drop the user to the raw overlay).
+      const messageText = new Text({ text: message });
+      if (typeof messageText.setRenderWhitespace === "function") {
+        messageText.setRenderWhitespace(true);
+      }
       // Restart is the primary action, so it also gets the initial focus.
       const restartButton = new Button({
         text: "Restart",
@@ -260,7 +300,7 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
         // promise keeps it open, so the only ways out are the explicit
         // actions built above.
         escapeHandler: (oPromise) => oPromise.reject(),
-        content: [new Text({ text: message })],
+        content: [messageText],
         buttons,
         initialFocus: restartButton,
         afterClose: () => {

--- a/changelog.txt
+++ b/changelog.txt
@@ -39,14 +39,19 @@ unreleased
   an endless roundtrip loop that made anything other than a plain string
   unusable. A structure or a table can now be stored and read back
 ! Error output: a 500 response no longer carries only the outermost message. The
-  body now holds the full diagnostic - the message chain, then one block per
-  entry of the previous chain with the exception class, its own text, the source
-  position it was raised at (program / class include / line - what identifies
-  the failing method for a CX_SY_MOVE_CAST_ERROR, whose text names only the two
-  types), the kernel error id and every public exception attribute that carries a
-  value - followed by the app / event / draft / url of the failing roundtrip and
-  the system context (system, client, host, release, user, time). Rendered by the
+  body now holds the full diagnostic in sections - `--- error ---` with the
+  message chain, `--- exception chain ---` with one block per entry of the
+  previous chain (exception class, own text, the source position it was raised
+  at - program / class include / line, what identifies the failing method for a
+  CX_SY_MOVE_CAST_ERROR whose text names only the two types - the kernel error
+  id and every public exception attribute that carries a value), and
+  `--- context ---` with the app / event / draft / url of the failing roundtrip
+  and the system (system, client, host, release, user, time). Rendered by the
   new z2ui5_cx_a2ui5_error=>get_text_full( ), which works for any exception
+! The error popup shows only the messages of that dump, one per line; the detail
+  sections stay one click away behind Details (developer tools Error tab) and in
+  Copy, which both carry the untruncated text. Non-framework errors (network,
+  client-side, SAP HTML error page) keep the single-line preview
 * z2ui5_cx_a2ui5_error chains the exception passed as val as its previous. The
   framework's dominant raise pattern (EXPORTING val = x, no previous) used to
   drop everything below x, so the cause of a wrapped error - and its source

--- a/node/tests/errorView.spec.js
+++ b/node/tests/errorView.spec.js
@@ -73,6 +73,9 @@ function load({ ui5 = true } = {}) {
       // The Copy button flips its label via setText; mirror it into settings so
       // tests can observe the "Copied" feedback.
       inst.setText = (t) => (inst.settings.text = t);
+      // The message Text keeps its line breaks via setRenderWhitespace; mirror
+      // it the same way so the dialog test can assert it was set.
+      inst.setRenderWhitespace = (v) => (inst.settings.renderWhitespace = v);
       if (kind === "Dialog") created.dialogs.push(inst);
       return inst;
     };
@@ -201,6 +204,50 @@ test.describe("ErrorView friendly dialog", () => {
     expect(message).not.toContain("color: red");
     expect(message).not.toContain("20260719");
     expect(message).not.toContain("<");
+  });
+
+  test("shows only the messages of a framework dump, one per line", () => {
+    const { ErrorView, state, created } = load();
+    // The 500 body built by z2ui5_cx_a2ui5_error=>get_text_full: version
+    // header, the `--- error ---` message chain, then the detail sections.
+    const dump = [
+      "abap2UI5 1.142.0 - unhandled exception in a POST request",
+      "",
+      "--- error ---",
+      "Request failed in app ZCL_MY_APP, event ONPRESS",
+      "Json parsing error: Not JSON @Line 1, Offset 1",
+      "",
+      "--- exception chain ---",
+      "[1] Z2UI5_CX_A2UI5_ERROR",
+      "    position : CLASS=ZCL_MY_APP=====CP / line 42",
+      "",
+      "--- context ---",
+      "    user     : SMITH",
+    ].join("\n");
+    ErrorView.show(dump);
+    const messageControl = created.dialogs[0].settings.content[0];
+    // Only the two messages, kept on separate lines.
+    expect(messageControl.settings.text).toBe(
+      "Request failed in app ZCL_MY_APP, event ONPRESS\n" +
+        "Json parsing error: Not JSON @Line 1, Offset 1",
+    );
+    // sap.m.Text would collapse those line breaks without this.
+    expect(messageControl.settings.renderWhitespace).toBe(true);
+    // Everything else stays behind Details / Copy - and the Error tab keeps
+    // the untruncated dump.
+    expect(messageControl.settings.text).not.toContain("abap2UI5");
+    expect(messageControl.settings.text).not.toContain("position");
+    expect(messageControl.settings.text).not.toContain("SMITH");
+    expect(state.lastError.text).toBe(dump);
+  });
+
+  test("keeps the single-line preview for a non-framework error", () => {
+    const { ErrorView, created } = load();
+    // No `--- error ---` section: a network failure is one line as before.
+    ErrorView.show("Network error: failed to fetch");
+    expect(created.dialogs[0].settings.content[0].settings.text).toBe(
+      "Network error: failed to fetch",
+    );
   });
 
   test("truncates a long preview but keeps the full text for the Error tab", () => {

--- a/src/00/03/z2ui5_cx_a2ui5_error.clas.abap
+++ b/src/00/03/z2ui5_cx_a2ui5_error.clas.abap
@@ -173,14 +173,17 @@ CLASS z2ui5_cx_a2ui5_error IMPLEMENTATION.
 
     DATA(lv_nl) = z2ui5_cl_a2ui5_context=>cv_char_util_newline.
 
-    " headline first: the plain message chain, unchanged - the detail blocks
-    " below only add to it, so nothing that used to be readable at a glance
-    " moved somewhere else. get_text( ) on a z2ui5 error already renders the
-    " whole concise chain, every other exception class has only its own text
-    result = val->get_text( ).
-    result = COND #( WHEN result IS INITIAL THEN `UNKNOWN_ERROR` ELSE result ).
+    " The messages first, one per line: this section is what the frontend
+    " lifts out for the error popup (app/webapp/core/ErrorView.js reads it by
+    " its `--- error ---` header, everything after the next `--- ` header
+    " stays behind Details) - keep the header spelling in sync with it.
+    " get_text( ) on a z2ui5 error already renders the whole concise chain,
+    " every other exception class has only its own text.
+    DATA(lv_message) = val->get_text( ).
+    lv_message = COND #( WHEN lv_message IS INITIAL THEN `UNKNOWN_ERROR` ELSE lv_message ).
 
-    result = result && lv_nl && lv_nl && `--- exception chain ---`.
+    result = `--- error ---` && lv_nl && lv_message &&
+             lv_nl && lv_nl && `--- exception chain ---`.
 
     DATA(lo_x) = val.
     WHILE lo_x IS BOUND AND lv_count < cv_chain_max.

--- a/src/00/03/z2ui5_cx_a2ui5_error.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cx_a2ui5_error.clas.testclasses.abap
@@ -152,8 +152,11 @@ CLASS ltcl_unit_test IMPLEMENTATION.
 
     DATA(lv_text) = z2ui5_cx_a2ui5_error=>get_text_full( lx_outer ).
 
-    " headline (both messages), one detail block per chain entry, the class
-    " name of every entry and the system context
+    " the message section (both messages), one detail block per chain entry,
+    " the class name of every entry and the system context. The `--- error ---`
+    " header is a contract with the frontend: app/webapp/core/ErrorView.js
+    " lifts exactly that section into the error popup
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_text CS `--- error ---` ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_text CS `outer problem` ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_text CS `root cause` ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_text CS `exception chain` ) ).

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -92,22 +92,53 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `      .join(" - ");` && |\n| &&
              `  }` && |\n| &&
              `` && |\n| &&
-             `  // Turn the raw error text into a one-glance preview for the friendly dialog.` && |\n| &&
-             `  // Backend errors often arrive as a whole HTML page (an ABAP dump rendered as` && |\n| &&
-             `  // a 500 error page): prefer the structured error message, else fall back to` && |\n| &&
-             `  // stripping script/style/title and the remaining tags. Rendered as plain` && |\n| &&
-             `  // MessageBox text, so the stripped markup cannot execute.` && |\n| &&
+             `  // A framework 500 body is a sectioned plain-text dump built by` && |\n| &&
+             `  // z2ui5_cx_a2ui5_error=>get_text_full: a version header line, then` && |\n| &&
+             `  // ``--- error ---`` with the message chain (one message per line), then` && |\n| &&
+             `  // ``--- exception chain ---`` (a block per cause with class, source position,` && |\n| &&
+             `  // kernel id, attributes) and ``--- context ---``. The popup shows only the` && |\n| &&
+             `  // messages; the rest is one click away behind Details and in Copy, which` && |\n| &&
+             `  // both work on the untruncated text. Returns "" when the text is not such` && |\n| &&
+             `  // a dump - a network error, a client-side failure or an ABAP dump rendered` && |\n| &&
+             `  // as an HTML error page all keep the single-line preview below.` && |\n| &&
+             `  const ERROR_SECTION_HEADER = "--- error ---";` && |\n| &&
+             `` && |\n| &&
+             `  function extractFrameworkMessages(text) {` && |\n| &&
+             `    const lines = text.split("\n");` && |\n| &&
+             `    const start = lines.findIndex(` && |\n| &&
+             `      (line) => line.trim() === ERROR_SECTION_HEADER,` && |\n| &&
+             `    );` && |\n| &&
+             `    if (start < 0) return "";` && |\n| &&
+             `    const messages = [];` && |\n| &&
+             `    for (const line of lines.slice(start + 1)) {` && |\n| &&
+             `      // the next section header ends the block` && |\n| &&
+             `      if (line.trim().startsWith("---")) break;` && |\n| &&
+             `      const cleaned = cleanText(line);` && |\n| &&
+             `      if (cleaned) messages.push(cleaned);` && |\n| &&
+             `    }` && |\n| &&
+             `    return messages.join("\n");` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
+             `  // Turn the raw error text into a preview for the friendly dialog: the` && |\n| &&
+             `  // framework's own messages when the body carries them, otherwise a` && |\n| &&
+             `  // one-glance line. Backend errors may also arrive as a whole HTML page (an` && |\n| &&
+             `  // ABAP dump rendered as a 500 error page): prefer the structured error` && |\n| &&
+             `  // message, else fall back to stripping script/style/title and the remaining` && |\n| &&
+             `  // tags. Rendered as plain text, so the stripped markup cannot execute.` && |\n| &&
              `  function buildErrorPreview(text) {` && |\n| &&
              `    if (!text) return "";` && |\n| &&
-             `    let preview = text;` && |\n| &&
-             `    if (/<[a-z][\s\S]*>/i.test(preview)) {` && |\n| &&
-             `      preview =` && |\n| &&
-             `        extractServerError(preview) ||` && |\n| &&
-             `        cleanText(` && |\n| &&
-             `          preview.replace(/<(script|style|title)[\s\S]*?<\/\1>/gi, " "),` && |\n| &&
-             `        );` && |\n| &&
+             `    let preview = extractFrameworkMessages(text);` && |\n| &&
+             `    if (!preview) {` && |\n| &&
+             `      preview = text;` && |\n| &&
+             `      if (/<[a-z][\s\S]*>/i.test(preview)) {` && |\n| &&
+             `        preview =` && |\n| &&
+             `          extractServerError(preview) ||` && |\n| &&
+             `          cleanText(` && |\n| &&
+             `            preview.replace(/<(script|style|title)[\s\S]*?<\/\1>/gi, " "),` && |\n| &&
+             `          );` && |\n| &&
+             `      }` && |\n| &&
+             `      preview = preview.replace(/\s+/g, " ").trim();` && |\n| &&
              `    }` && |\n| &&
-             `    preview = preview.replace(/\s+/g, " ").trim();` && |\n| &&
              `    return preview.length > PREVIEW_MAX_LENGTH` && |\n| &&
              `      ? ``${preview.slice(0, PREVIEW_MAX_LENGTH)}...``` && |\n| &&
              `      : preview;` && |\n| &&
@@ -227,6 +258,15 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `      // Show only the extracted error text; a short neutral fallback covers` && |\n| &&
              `      // the rare case where nothing could be extracted.` && |\n| &&
              `      const message = buildErrorPreview(details) || "An error occurred.";` && |\n| &&
+             `      // A framework preview is one message per line, so the line breaks have` && |\n| &&
+             `      // to survive - sap.m.Text normalizes whitespace unless told otherwise.` && |\n| &&
+             `      // Set through the mutator and guarded: the property arrived in UI5 1.60` && |\n| &&
+             `      // and a control without it must not take the whole dialog down (the` && |\n| &&
+             `      // catch below would drop the user to the raw overlay).` && |\n| &&
+             `      const messageText = new Text({ text: message });` && |\n| &&
+             `      if (typeof messageText.setRenderWhitespace === "function") {` && |\n| &&
+             `        messageText.setRenderWhitespace(true);` && |\n| &&
+             `      }` && |\n| &&
              `      // Restart is the primary action, so it also gets the initial focus.` && |\n| &&
              `      const restartButton = new Button({` && |\n| &&
              `        text: "Restart",` && |\n| &&
@@ -287,7 +327,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `        // promise keeps it open, so the only ways out are the explicit` && |\n| &&
              `        // actions built above.` && |\n| &&
              `        escapeHandler: (oPromise) => oPromise.reject(),` && |\n| &&
-             `        content: [new Text({ text: message })],` && |\n| &&
+             `        content: [messageText],` && |\n| &&
              `        buttons,` && |\n| &&
              `        initialFocus: restartButton,` && |\n| &&
              `        afterClose: () => {` && |\n| &&
@@ -384,7 +424,8 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    // Record the fatal error so the Developer Tools Error tab can re-show it` && |\n| &&
              `    // (title, text and the same Retry action) after the overlay is gone.` && |\n| &&
              `    AppState.state.lastError = {` && |\n| &&
-             `      title: title || "Application Error - Please Restart The App",` && |\n| &&
+             `      title: title || "Application Error - Please Restart The App",` && |\n|.
+    result = result &&
              `      text: errorMessage,` && |\n| &&
              `      onRetry: typeof options.onRetry === "function" ? options.onRetry : null,` && |\n| &&
              `    };` && |\n| &&
@@ -424,8 +465,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    h3.style.cssText = "margin: 0";` && |\n| &&
              `    headerDiv.appendChild(h3);` && |\n| &&
              `` && |\n| &&
-             `    const btnStyle =` && |\n|.
-    result = result &&
+             `    const btnStyle =` && |\n| &&
              `      "padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;";` && |\n| &&
              `` && |\n| &&
              `    const actionsDiv = document.createElement("div");` && |\n| &&


### PR DESCRIPTION
# Description

Follow-up to #2528. The full exception dump that PR added went into the error popup **whole**, and the preview collapses all whitespace into a single line — so the version header, the message chain, every chain entry and the system context arrived as one 500-character run-on line. The information belongs in the popup's reach, just not in its first line.

The 500 body is now **sectioned**, and the popup shows only the first section:

```
abap2UI5 1.142.0 - unhandled exception in a POST request

--- error ---
Request failed, no event (initial rendering)
Json parsing error: Not JSON @Line 1, Offset 1

--- exception chain ---
[1] Z2UI5_CX_A2UI5_ERROR
    text     : Request failed, no event (initial rendering)
...
--- context ---
    system   : ABC / client 123 / host localhost / release OPEN
```

Popup content, taken from that body:

```
Request failed, no event (initial rendering)
Json parsing error: Not JSON @Line 1, Offset 1
```

**Details** (developer tools Error tab) and **Copy** are unchanged and still carry the untruncated dump.

### Changes

- `z2ui5_cx_a2ui5_error=>get_text_full( )` emits the message chain under an `--- error ---` header, so the section is addressable instead of positional.
- `app/webapp/core/ErrorView.js` lifts that section out by its header and renders the messages one per line. `sap.m.Text` normalizes whitespace, so the message control gets `renderWhitespace` — set through the mutator and guarded with a `typeof` check, since the property arrived in UI5 1.60 and a control without it must not drop the user to the raw overlay.
- A body **without** an `--- error ---` section — a network failure, a client-side error, an ABAP dump rendered as an HTML error page — keeps the single-line preview it had, HTML extraction included.
- The header spelling is a contract between the two sides; both carry a comment pointing at the other, and a test on each side pins it.
- `src/01/03/z2ui5_cl_app_errorview_js.clas.abap` regenerated from `app/webapp` via `npm run app2abap`.

## How to test

1. Start the dev server (`npm run express`) and POST a broken body, e.g. `curl -X POST localhost:3000 -d 'no json at all'` — the response is the sectioned 500 body above.
2. In the browser, trigger a fatal error (e.g. an app that raises in `main( )`): the popup lists only the messages, one per line.
3. Click **Details** — the developer tools Error tab shows the whole dump, chain and context included. **Copy** puts the same full text on the clipboard.
4. Provoke a non-framework error (stop the server mid-request): the popup still shows the one-line `Network error: ...` preview.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — abaplint in all three targets, 482 transpiled unit tests, 422 JS specs, ui5lint and eslint, plus the app2abap drift gate
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — two new specs in `node/tests/errorView.spec.js` (framework preview, non-framework preview) and the `--- error ---` header assertion in `z2ui5_cx_a2ui5_error.clas.testclasses.abap`
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` — `src/01/03` is generated, not hand-edited
- [x] Public API in `src/02/` only changed additively — unchanged in this PR
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9qpfgQf8Hb293cxEjD7tD

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9qpfgQf8Hb293cxEjD7tD)_