### PR TITLE
Add support for customer frontend-extension BSP (z2ui5ext)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [docs](https://github.com/abap2UI5/docs) | Project documentation |
 | [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of `src/00/03/` (see "Utilities") |
 | [app-template](https://github.com/abap2UI5/app-template) | Starter repo for app projects — gates, CI and agent setup preconfigured |
+| [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5cc` in `app/webapp/manifest.json` is what makes it findable |
+| [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) | Template for a customer's **own** frontend artefacts (reuse library, icon font, CSS) in their own BSP — same mechanism under the reserved resourceRoot `z2ui5ext`. Both roots exist so nobody has to patch `index.html` / `manifest.json`, which are generated here and overwritten downstream |
 
 > **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle — read the in-repo guide **`docs/agents/building-apps.md`** (also wired as the `build-an-app` Claude Code skill; `llms.txt` indexes both audiences). The rendered docs site is <https://abap2ui5.github.io/docs/> — unreachable from many sandboxes, which is why the guide lives in-repo.
 

--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -39,20 +39,31 @@ sap.ui.define(
         // a fully initialized global from here on.
         AppState.initGlobal();
 
-        // A custom-control BSP is normally found through the reserved
-        // resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/"), a sibling
-        // of THIS BSP. In the standalone HTTP service there is no BSP for it
-        // to be a sibling of, so the backend hands the absolute path over on
-        // the global instead (z2ui5_cl_http_handler=>_http_get).
+        // Two sibling BSPs carry frontend artefacts the framework itself does
+        // not ship: z2ui5cc (abap2UI5-addons/custom-controls) and z2ui5ext
+        // (abap2UI5/customer-frontend-extension, the customer's own library).
+        // Both are normally found through their reserved resourceRoot in
+        // manifest.json ("z2ui5cc": "../z2ui5cc/", "z2ui5ext":
+        // "../z2ui5ext/"), a sibling of THIS BSP. In the standalone HTTP
+        // service there is no BSP for them to be a sibling of, so the backend
+        // hands the absolute paths over on the global instead
+        // (z2ui5_cl_http_handler=>_http_get).
         //
-        // It has to be applied HERE and not in the page: the manifest
+        // They have to be applied HERE and not in the page: the manifest
         // registers its own value while the component is being created, which
         // is after everything the shell can run, so a registration made there
         // is overwritten again. init() runs after manifest processing.
-        // Absent in BSP and Launchpad mode, where the manifest entry is right.
+        // Absent in BSP and Launchpad mode, where the manifest entries are
+        // right. Neither BSP is loaded from here - nothing is requested until
+        // a view actually names the namespace - so a system that has only one
+        // of them installed (or neither) never pays for the other.
         const ccResourceRoot = AppState.getGlobal("ccResourceRoot");
         if (ccResourceRoot) {
           sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });
+        }
+        const extResourceRoot = AppState.getGlobal("extResourceRoot");
+        if (extResourceRoot) {
+          sap.ui.loader.config({ paths: { z2ui5ext: extResourceRoot } });
         }
 
         UIComponent.prototype.init.call(this);

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -31,6 +31,11 @@
 //                     core:require; the global covers releases without
 //                     core:require); owns the date helpers Util
 //                     re-exports - grows via framework PRs only (Component)
+//   ccResourceRoot    absolute path of the custom-control BSP, set by the
+//                     backend GET page when there is no sibling BSP to
+//                     resolve "../z2ui5cc/" against (backend HTML)
+//   extResourceRoot   same for the customer frontend-extension BSP
+//                     ("../z2ui5ext/") (backend HTML)
 //   requestTimeoutMs  optional override for the roundtrip timeout (apps)
 //   <custom>          apps can register functions via the js_loader popup
 //                     and call them through the Z2UI5 frontend event

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -75,7 +75,8 @@
       "id": "App"
     },
     "resourceRoots": {
-      "z2ui5cc": "../z2ui5cc/"
+      "z2ui5cc": "../z2ui5cc/",
+      "z2ui5ext": "../z2ui5ext/"
     }
   },
   "sap.cloud": {

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -58,6 +58,11 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//                     core:require; the global covers releases without` && |\n| &&
              `//                     core:require); owns the date helpers Util` && |\n| &&
              `//                     re-exports - grows via framework PRs only (Component)` && |\n| &&
+             `//   ccResourceRoot    absolute path of the custom-control BSP, set by the` && |\n| &&
+             `//                     backend GET page when there is no sibling BSP to` && |\n| &&
+             `//                     resolve "../z2ui5cc/" against (backend HTML)` && |\n| &&
+             `//   extResourceRoot   same for the customer frontend-extension BSP` && |\n| &&
+             `//                     ("../z2ui5ext/") (backend HTML)` && |\n| &&
              `//   requestTimeoutMs  optional override for the roundtrip timeout (apps)` && |\n| &&
              `//   <custom>          apps can register functions via the js_loader popup` && |\n| &&
              `//                     and call them through the Z2UI5 frontend event` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -66,20 +66,31 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        // a fully initialized global from here on.` && |\n| &&
              `        AppState.initGlobal();` && |\n| &&
              `` && |\n| &&
-             `        // A custom-control BSP is normally found through the reserved` && |\n| &&
-             `        // resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/"), a sibling` && |\n| &&
-             `        // of THIS BSP. In the standalone HTTP service there is no BSP for it` && |\n| &&
-             `        // to be a sibling of, so the backend hands the absolute path over on` && |\n| &&
-             `        // the global instead (z2ui5_cl_http_handler=>_http_get).` && |\n| &&
+             `        // Two sibling BSPs carry frontend artefacts the framework itself does` && |\n| &&
+             `        // not ship: z2ui5cc (abap2UI5-addons/custom-controls) and z2ui5ext` && |\n| &&
+             `        // (abap2UI5/customer-frontend-extension, the customer's own library).` && |\n| &&
+             `        // Both are normally found through their reserved resourceRoot in` && |\n| &&
+             `        // manifest.json ("z2ui5cc": "../z2ui5cc/", "z2ui5ext":` && |\n| &&
+             `        // "../z2ui5ext/"), a sibling of THIS BSP. In the standalone HTTP` && |\n| &&
+             `        // service there is no BSP for them to be a sibling of, so the backend` && |\n| &&
+             `        // hands the absolute paths over on the global instead` && |\n| &&
+             `        // (z2ui5_cl_http_handler=>_http_get).` && |\n| &&
              `        //` && |\n| &&
-             `        // It has to be applied HERE and not in the page: the manifest` && |\n| &&
+             `        // They have to be applied HERE and not in the page: the manifest` && |\n| &&
              `        // registers its own value while the component is being created, which` && |\n| &&
              `        // is after everything the shell can run, so a registration made there` && |\n| &&
              `        // is overwritten again. init() runs after manifest processing.` && |\n| &&
-             `        // Absent in BSP and Launchpad mode, where the manifest entry is right.` && |\n| &&
+             `        // Absent in BSP and Launchpad mode, where the manifest entries are` && |\n| &&
+             `        // right. Neither BSP is loaded from here - nothing is requested until` && |\n| &&
+             `        // a view actually names the namespace - so a system that has only one` && |\n| &&
+             `        // of them installed (or neither) never pays for the other.` && |\n| &&
              `        const ccResourceRoot = AppState.getGlobal("ccResourceRoot");` && |\n| &&
              `        if (ccResourceRoot) {` && |\n| &&
              `          sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });` && |\n| &&
+             `        }` && |\n| &&
+             `        const extResourceRoot = AppState.getGlobal("extResourceRoot");` && |\n| &&
+             `        if (extResourceRoot) {` && |\n| &&
+             `          sap.ui.loader.config({ paths: { z2ui5ext: extResourceRoot } });` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
              `        UIComponent.prototype.init.call(this);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -102,7 +102,8 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "id": "App"` &&
              `    },` &&
              `    "resourceRoots": {` &&
-             `      "z2ui5cc": "../z2ui5cc/"` &&
+             `      "z2ui5cc": "../z2ui5cc/",` &&
+             `      "z2ui5ext": "../z2ui5ext/"` &&
              `    }` &&
              `  },` &&
              `  "sap.cloud": {` &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -247,21 +247,27 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = lv_style_css
                                                   custom_js  = ls_config-custom_js ).
 
-    " Custom controls live in their own BSP, which the frontend finds through
-    " the reserved resourceRoot in manifest.json ("z2ui5cc": "../z2ui5cc/").
-    " That path is a sibling of the FRONTEND BSP, so it is only correct when
-    " the app is served from it. Here the component base is this ICF node and
-    " the same relative path resolves next to /sap/bc/, where nothing is.
+    " Custom controls (z2ui5cc, abap2UI5-addons/custom-controls) and the
+    " customer's own frontend artefacts (z2ui5ext,
+    " abap2UI5/customer-frontend-extension) each live in their own BSP, which
+    " the frontend finds through the reserved resourceRoots in manifest.json
+    " ("z2ui5cc": "../z2ui5cc/", "z2ui5ext": "../z2ui5ext/"). Those paths are
+    " siblings of the FRONTEND BSP, so they are only correct when the app is
+    " served from it. Here the component base is this ICF node and the same
+    " relative path resolves next to /sap/bc/, where nothing is.
     "
-    " Hand the absolute BSP path to the frontend instead. It cannot be applied
-    " here: the manifest registers its own value during component creation,
-    " which happens after everything this page can run, so it would win.
-    " Component.js applies the field in init( ), after manifest processing.
-    " AppState~initGlobal keeps fields that are already on the global when
-    " checkLocal is true, so it survives the component start. In BSP and
-    " Launchpad mode the field is absent and the manifest entry stands.
+    " Hand the absolute BSP paths to the frontend instead. They cannot be
+    " applied here: the manifest registers its own value during component
+    " creation, which happens after everything this page can run, so it would
+    " win. Component.js applies the fields in init( ), after manifest
+    " processing. AppState~initGlobal keeps fields that are already on the
+    " global when checkLocal is true, so they survive the component start. In
+    " BSP and Launchpad mode the fields are absent and the manifest entries
+    " stand. Registering a path costs nothing when the BSP is not installed -
+    " nothing is requested from it until a view names the namespace.
     DATA(lv_globals) = |window.z2ui5 = \{ checkLocal : true, | &&
-                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc" \};|.
+                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc", | &&
+                       |extResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5ext" \};|.
 
     result-body = |<!DOCTYPE html>\n| &&
                   |<html lang="en">\n| &&


### PR DESCRIPTION
# Description

This PR extends the framework to support a second optional sibling BSP for customer-specific frontend artefacts (reuse library, icon fonts, CSS, etc.) alongside the existing custom-controls BSP.

**Changes:**
- Add `extResourceRoot` configuration to the HTTP handler, pointing to `/sap/bc/ui5_ui5/sap/z2ui5ext`
- Update Component.js to register the `z2ui5ext` resource root in the UI5 loader when available
- Add `z2ui5ext` to the manifest.json resourceRoots alongside the existing `z2ui5cc`
- Update AppState.js documentation to describe both resource root globals
- Update AGENTS.md to document the new [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) repository
- Expand comments throughout to clarify that both BSPs are optional and only loaded when actually referenced by a view

The mechanism mirrors the existing custom-controls support: the backend provides absolute paths when running in standalone HTTP mode (where there's no sibling BSP to resolve relative paths against), while BSP and Launchpad deployments use the manifest entries directly. Neither BSP is loaded unless a view explicitly names its namespace, so systems with only one installed (or neither) incur no cost for the other.

## How to test

- Verify the generated Component.js and manifest.json contain the new `z2ui5ext` entries
- Confirm `npm run verify:full` passes (app/webapp/ was modified)
- No manual testing needed; this is a configuration extension that only activates when a view uses the `z2ui5ext` namespace

## Checklist

- [x] `npm run verify:full` passes (app/webapp/ changed)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (changes are in agent classes that generate code)
- [x] Public API in `src/02/` only changed additively (HTTP handler now provides additional global)
- [x] Changes made via abapGit: yes

https://claude.ai/code/session_01WtycUZ47d9XzTcQBkLtrnE