### PR TITLE
Refactor control method denylist to separate exact matches from prefixes

### DIFF
--- a/app/webapp/core/FrontendAction.js
+++ b/app/webapp/core/FrontendAction.js
@@ -182,49 +182,66 @@ sap.ui.define(
     // still checked to be a function before the call, so a typo just no-ops.)
     // Named setters/mutators (setVisible, addItem, removeItem, ...) stay
     // allowed - they are the API the backend legitimately drives. Denied are
-    // the framework-hostile methods: teardown/reparenting (destroy*, exit,
+    // the framework-hostile methods: teardown/reparenting (destroy, exit,
     // setParent, addDependent, placeAt), model/binding swaps (setModel,
     // setBinding*, bind*/unbind*), event-handler tampering (attach*/detach*,
     // fireEvent), the render lifecycle (rerender, invalidate) and the GENERIC
-    // reflection aggregation mutators (setAggregation/add/insert/remove* and
-    // removeAll*) which reparent tracked controls behind the framework's back
-    // (the named per-aggregation methods above remain allowed).
-    // Built from a list (not one long literal) so no single source line is too
+    // reflection mutators (setAggregation/addAggregation/insertAggregation/
+    // removeAggregation/removeAllAggregation and their Association twins),
+    // which take the member NAME as an argument and reparent tracked controls
+    // behind the framework's back.
+    // Two lists, because the two halves need different matching. A generic
+    // reflection mutator has ONE spelling, so it is denied by EXACT name -
+    // matching it by prefix would swallow the named per-aggregation methods
+    // that share those first characters (removeAllSelectedDates,
+    // removeAllItems, destroySpecialDates, ...), which are exactly the API
+    // this allowlist is meant to offer: they detach or destroy children the
+    // control itself owns - the same footprint the already-allowed removeItem
+    // has - and carry no invariant beyond it. The other half is hostile in
+    // every spelling (bindProperty as much as bind), so it stays a PREFIX.
+    // Built from lists (not one long literal) so no single source line is too
     // long once embedded into the ABAP string constant (trans2abap.js caps
-    // generated lines at 255 chars). Each entry is a method-name PREFIX.
+    // generated lines at 255 chars).
+    const CONTROL_METHOD_DENY_EXACT = [
+      "destroy",
+      "exit",
+      "fireEvent",
+      "clone",
+      "applySettings",
+      "setAggregation",
+      "addAggregation",
+      "insertAggregation",
+      "removeAggregation",
+      "removeAllAggregation",
+      "destroyAggregation",
+      "setAssociation",
+      "addAssociation",
+      "removeAssociation",
+      "removeAllAssociation",
+    ];
     const CONTROL_METHOD_DENY_PREFIXES = [
       "_",
-      "destroy",
       "bind",
       "unbind",
       "attach",
       "detach",
-      "fireEvent",
-      "exit",
-      "removeAll",
-      "removeAggregation",
-      "addAggregation",
-      "insertAggregation",
-      "setAggregation",
       "addDependent",
       "placeAt",
       "rerender",
       "invalidate",
-      "applySettings",
-      "clone",
       "setModel",
-      "setBindingContext",
+      "setBinding", // covers setBindingContext
       "setParent",
-      "setBinding",
-      "setAssociation",
     ];
     const CONTROL_METHOD_DENY = new RegExp(
       "^(" + CONTROL_METHOD_DENY_PREFIXES.join("|") + ")",
     );
+    const CONTROL_METHOD_DENY_SET = new Set(CONTROL_METHOD_DENY_EXACT);
     function isSafeControlMethod(method) {
       return (
         typeof method === "string" &&
         method.length > 0 &&
+        !CONTROL_METHOD_DENY_SET.has(method) &&
         !CONTROL_METHOD_DENY.test(method)
       );
     }

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -432,6 +432,43 @@ test.describe("CONTROL_BY_ID", () => {
     expect(errors).toHaveLength(4);
   });
 
+  test("rejects the GENERIC reflection mutators by exact name", () => {
+    const { FrontendAction, calls, errors, controls } = load();
+    const generic = [
+      "setAggregation", "addAggregation", "insertAggregation",
+      "removeAggregation", "removeAllAggregation", "destroyAggregation",
+      "setAssociation", "addAssociation", "removeAssociation",
+      "removeAllAssociation",
+    ];
+    controls.x = {};
+    for (const m of generic) controls.x[m] = () => calls.push([m]);
+    for (const m of generic) {
+      FrontendAction.execute(null, ["CONTROL_BY_ID", "x", "", m, "items"]);
+    }
+    expect(calls).toHaveLength(0);
+    expect(errors).toHaveLength(generic.length);
+  });
+
+  test("but the NAMED per-aggregation mutators that share their prefix are allowed", () => {
+    const { FrontendAction, calls, errors, controls } = load();
+    // the deny entries are "removeAllAggregation"/"destroy"/... by exact name,
+    // so these keep working: they detach or destroy children the control owns,
+    // the same footprint the long-allowed removeItem has (app 307's
+    // Calendar.removeAllSelectedDates has no bindable alternative - the
+    // control writes the user's selection into that aggregation itself).
+    const named = [
+      "removeAllSelectedDates", "removeAllItems", "removeAllContent",
+      "destroySpecialDates", "destroyItems", "removeItem",
+    ];
+    controls.cal = {};
+    for (const m of named) controls.cal[m] = () => calls.push([m]);
+    for (const m of named) {
+      FrontendAction.execute(null, ["CONTROL_BY_ID", "cal", "", m]);
+    }
+    expect(calls).toEqual(named.map((m) => [m]));
+    expect(errors).toHaveLength(0);
+  });
+
   test("calls an unlisted but safe public method (generalized allowlist)", () => {
     const { FrontendAction, calls, controls } = load();
     // enablePostButton is NOT in CONTROL_METHODS, but it is a public, non-denied

--- a/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_frontendaction_js.clas.abap
@@ -209,49 +209,66 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    // still checked to be a function before the call, so a typo just no-ops.)` && |\n| &&
              `    // Named setters/mutators (setVisible, addItem, removeItem, ...) stay` && |\n| &&
              `    // allowed - they are the API the backend legitimately drives. Denied are` && |\n| &&
-             `    // the framework-hostile methods: teardown/reparenting (destroy*, exit,` && |\n| &&
+             `    // the framework-hostile methods: teardown/reparenting (destroy, exit,` && |\n| &&
              `    // setParent, addDependent, placeAt), model/binding swaps (setModel,` && |\n| &&
              `    // setBinding*, bind*/unbind*), event-handler tampering (attach*/detach*,` && |\n| &&
              `    // fireEvent), the render lifecycle (rerender, invalidate) and the GENERIC` && |\n| &&
-             `    // reflection aggregation mutators (setAggregation/add/insert/remove* and` && |\n| &&
-             `    // removeAll*) which reparent tracked controls behind the framework's back` && |\n| &&
-             `    // (the named per-aggregation methods above remain allowed).` && |\n| &&
-             `    // Built from a list (not one long literal) so no single source line is too` && |\n| &&
+             `    // reflection mutators (setAggregation/addAggregation/insertAggregation/` && |\n| &&
+             `    // removeAggregation/removeAllAggregation and their Association twins),` && |\n| &&
+             `    // which take the member NAME as an argument and reparent tracked controls` && |\n| &&
+             `    // behind the framework's back.` && |\n| &&
+             `    // Two lists, because the two halves need different matching. A generic` && |\n| &&
+             `    // reflection mutator has ONE spelling, so it is denied by EXACT name -` && |\n| &&
+             `    // matching it by prefix would swallow the named per-aggregation methods` && |\n| &&
+             `    // that share those first characters (removeAllSelectedDates,` && |\n| &&
+             `    // removeAllItems, destroySpecialDates, ...), which are exactly the API` && |\n| &&
+             `    // this allowlist is meant to offer: they detach or destroy children the` && |\n| &&
+             `    // control itself owns - the same footprint the already-allowed removeItem` && |\n| &&
+             `    // has - and carry no invariant beyond it. The other half is hostile in` && |\n| &&
+             `    // every spelling (bindProperty as much as bind), so it stays a PREFIX.` && |\n| &&
+             `    // Built from lists (not one long literal) so no single source line is too` && |\n| &&
              `    // long once embedded into the ABAP string constant (trans2abap.js caps` && |\n| &&
-             `    // generated lines at 255 chars). Each entry is a method-name PREFIX.` && |\n| &&
+             `    // generated lines at 255 chars).` && |\n| &&
+             `    const CONTROL_METHOD_DENY_EXACT = [` && |\n| &&
+             `      "destroy",` && |\n| &&
+             `      "exit",` && |\n| &&
+             `      "fireEvent",` && |\n| &&
+             `      "clone",` && |\n| &&
+             `      "applySettings",` && |\n| &&
+             `      "setAggregation",` && |\n| &&
+             `      "addAggregation",` && |\n| &&
+             `      "insertAggregation",` && |\n| &&
+             `      "removeAggregation",` && |\n| &&
+             `      "removeAllAggregation",` && |\n| &&
+             `      "destroyAggregation",` && |\n| &&
+             `      "setAssociation",` && |\n| &&
+             `      "addAssociation",` && |\n| &&
+             `      "removeAssociation",` && |\n| &&
+             `      "removeAllAssociation",` && |\n| &&
+             `    ];` && |\n| &&
              `    const CONTROL_METHOD_DENY_PREFIXES = [` && |\n| &&
              `      "_",` && |\n| &&
-             `      "destroy",` && |\n| &&
              `      "bind",` && |\n| &&
              `      "unbind",` && |\n| &&
              `      "attach",` && |\n| &&
              `      "detach",` && |\n| &&
-             `      "fireEvent",` && |\n| &&
-             `      "exit",` && |\n| &&
-             `      "removeAll",` && |\n| &&
-             `      "removeAggregation",` && |\n| &&
-             `      "addAggregation",` && |\n| &&
-             `      "insertAggregation",` && |\n| &&
-             `      "setAggregation",` && |\n| &&
              `      "addDependent",` && |\n| &&
              `      "placeAt",` && |\n| &&
              `      "rerender",` && |\n| &&
              `      "invalidate",` && |\n| &&
-             `      "applySettings",` && |\n| &&
-             `      "clone",` && |\n| &&
              `      "setModel",` && |\n| &&
-             `      "setBindingContext",` && |\n| &&
+             `      "setBinding", // covers setBindingContext` && |\n| &&
              `      "setParent",` && |\n| &&
-             `      "setBinding",` && |\n| &&
-             `      "setAssociation",` && |\n| &&
              `    ];` && |\n| &&
              `    const CONTROL_METHOD_DENY = new RegExp(` && |\n| &&
              `      "^(" + CONTROL_METHOD_DENY_PREFIXES.join("|") + ")",` && |\n| &&
              `    );` && |\n| &&
+             `    const CONTROL_METHOD_DENY_SET = new Set(CONTROL_METHOD_DENY_EXACT);` && |\n| &&
              `    function isSafeControlMethod(method) {` && |\n| &&
              `      return (` && |\n| &&
              `        typeof method === "string" &&` && |\n| &&
              `        method.length > 0 &&` && |\n| &&
+             `        !CONTROL_METHOD_DENY_SET.has(method) &&` && |\n| &&
              `        !CONTROL_METHOD_DENY.test(method)` && |\n| &&
              `      );` && |\n| &&
              `    }` && |\n| &&
@@ -407,7 +424,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `            return JSON.parse(raw);` && |\n| &&
              `          } catch {` && |\n| &&
              `            return {};` && |\n| &&
-             `          }` && |\n| &&
+             `          }` && |\n|.
+    result = result &&
              `        default:` && |\n| &&
              `          return raw;` && |\n| &&
              `      }` && |\n| &&
@@ -424,8 +442,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      if (raw === "" || raw === " " || raw === "false") return false;` && |\n| &&
              `      return raw;` && |\n| &&
              `    }` && |\n| &&
-             `` && |\n|.
-    result = result &&
+             `` && |\n| &&
              `    // kinds whose EMPTY value is meaningful (null), so a missing trailing` && |\n| &&
              `    // argument still has to be passed: the backend wire drops a trailing empty` && |\n| &&
              `    // t_arg entry, and "clear this association" is exactly a call whose only` && |\n| &&
@@ -808,7 +825,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      }` && |\n| &&
              `      // A data: URL carrying active HTML combined with an attacker-chosen` && |\n| &&
              `      // .html/.hta filename is a known drive-by vector; block executable data:` && |\n| &&
-             `      // MIME types outright (real downloads are octet-stream, images, pdf, ...).` && |\n| &&
+             `      // MIME types outright (real downloads are octet-stream, images, pdf, ...).` && |\n|.
+    result = result &&
              `      if (` && |\n| &&
              `        /^data:(text\/html|application\/xhtml|text\/xml|image\/svg)/i.test(` && |\n| &&
              `          args[1],` && |\n| &&
@@ -825,8 +843,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // the download directory or carry a misleading name.` && |\n| &&
              `      // eslint-disable-next-line no-control-regex -- control chars are matched on purpose here` && |\n| &&
              `      a.download = String(args[2] || "").replace(/[\\/:*?"<>|\x00-\x1f]/g, "_");` && |\n| &&
-             `      // Firefox only triggers a programmatic download click when the anchor` && |\n|.
-    result = result &&
+             `      // Firefox only triggers a programmatic download click when the anchor` && |\n| &&
              `      // is part of the document, so attach it briefly and remove it again.` && |\n| &&
              `      document.body.appendChild(a);` && |\n| &&
              `      a.click();` && |\n| &&
@@ -1209,7 +1226,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `          const control = oFilterBar.determineControlByName(` && |\n| &&
              `            entry.fieldName,` && |\n| &&
              `            entry.groupName,` && |\n| &&
-             `          );` && |\n| &&
+             `          );` && |\n|.
+    result = result &&
              `          // setValue, not a model write: the two-way binding abap2UI5 put on` && |\n| &&
              `          // the property carries the restored value back to the backend on the` && |\n| &&
              `          // next roundtrip, so selecting a variant needs none of its own` && |\n| &&
@@ -1226,8 +1244,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `    }` && |\n| &&
              `` && |\n| &&
              `    // every filter change makes the current variant dirty (the "*" next to the` && |\n| &&
-             `    // variant title) and refreshes the bar's assigned-filters summary` && |\n|.
-    result = result &&
+             `    // variant title) and refreshes the bar's assigned-filters summary` && |\n| &&
              `    function attachFilterBarChange(oSVM, oFilterBar) {` && |\n| &&
              `      oFilterBar.getAllFilterItems().forEach((item) => {` && |\n| &&
              `        const control = filterItemControl(item);` && |\n| &&
@@ -1610,7 +1627,8 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `      // otherwise once it is.` && |\n| &&
              `      Lib.whenRendered(oElement, oController, () => {` && |\n| &&
              `        applyFocus();` && |\n| &&
-             `        const dom = oElement.getDomRef();` && |\n| &&
+             `        const dom = oElement.getDomRef();` && |\n|.
+    result = result &&
              `        if (dom && dom.contains(document.activeElement)) return;` && |\n| &&
              `        // The focus did not stick. A view_model_update in the same response` && |\n| &&
              `        // may have changed the control - e.g. re-enabled a locked input via` && |\n| &&
@@ -1627,8 +1645,7 @@ CLASS z2ui5_cl_app_frontendaction_js IMPLEMENTATION.
              `        const samePlace = (el) =>` && |\n| &&
              `          el == null ||` && |\n| &&
              `          el === document.body ||` && |\n| &&
-             `          el === prevActive ||` && |\n|.
-    result = result &&
+             `          el === prevActive ||` && |\n| &&
              `          Boolean(el.id && prevActive && el.id === prevActive.id);` && |\n| &&
              `        const delegate = {` && |\n| &&
              `          onAfterRendering: () => {` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -351,6 +351,10 @@ INTERFACE z2ui5_if_client
   "! cs_event-control_by_id - call a method on a control resolved by id:
   "! t_arg = id, method, params. Any public control method works unless it is
   "! on the frontend denylist (methods that would break framework invariants).
+  "! The named per-aggregation mutators are on the allowed side of that line -
+  "! addItem, removeItem, removeAllItems, destroyContent - and only the GENERIC
+  "! reflection variants that take the member name as an argument are denied
+  "! (addAggregation, removeAllAggregation, setAssociation, ...).
   "! The view is passed as the separate
   "! view parameter (default cs_view-main resolves the id across all open
   "! views; pass cs_view-popup/popover/... to scope the lookup to that view).


### PR DESCRIPTION
## Description

This PR refactors the security denylist for control method invocation to distinguish between two categories of forbidden methods:

1. **Exact matches** (`CONTROL_METHOD_DENY_EXACT`): Generic reflection mutators that take the member name as an argument (e.g., `setAggregation`, `removeAllAggregation`, `setAssociation`). These are denied by exact name matching to avoid blocking named per-aggregation methods that share the same prefix (e.g., `removeAllItems`, `destroySpecialDates`).

2. **Prefix matches** (`CONTROL_METHOD_DENY_PREFIXES`): Methods that are hostile in every spelling (e.g., `bind*`, `attach*`, `detach*`). These continue to be denied by prefix matching.

The key insight is that named per-aggregation mutators like `removeItem` and `removeAllItems` are safe—they detach or destroy children the control owns—and should remain allowed. Only the generic reflection variants that take the member name as an argument are dangerous because they can reparent tracked controls behind the framework's back.

The implementation adds:
- A new `CONTROL_METHOD_DENY_EXACT` array with exact method names
- A `CONTROL_METHOD_DENY_SET` for O(1) lookup
- Updated `isSafeControlMethod()` to check the exact set before the prefix regex
- Comprehensive documentation explaining the distinction

## How to test

Run the new unit tests that verify:
1. Generic reflection mutators are rejected by exact name
2. Named per-aggregation mutators that share prefixes are allowed

```bash
npm run verify:full
```

The test suite includes:
- `rejects the GENERIC reflection mutators by exact name` - verifies all generic methods are blocked
- `but the NAMED per-aggregation mutators that share their prefix are allowed` - verifies safe named methods work

## Checklist

- [x] `npm run verify:full` passes
- [x] Unit tests added (`node/tests/frontendAction.spec.js`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` updated additively (documentation only)
- [x] Changes made via abapGit: no (manual edits to source files and tests)

https://claude.ai/code/session_018pccCDrPahqBvn8vwPw2jR