### PR TITLE
Rename custom-controls BSP resource root from z2ui5cc to z2ui5ccc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [docs](https://github.com/abap2UI5/docs) | Project documentation |
 | [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of `src/00/03/` (see "Utilities") |
 | [app-template](https://github.com/abap2UI5/app-template) | Starter repo for app projects — gates, CI and agent setup preconfigured |
-| [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5cc` in `app/webapp/manifest.json` is what makes it findable |
+| [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5ccc` in `app/webapp/manifest.json` is what makes it findable |
 | [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) | Template for a customer's **own** frontend artefacts (reuse library, icon font, CSS) in their own BSP — same mechanism under the reserved resourceRoot `z2ui5ext`. Both roots exist so nobody has to patch `index.html` / `manifest.json`, which are generated here and overwritten downstream |
 
 > **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle — read the in-repo guide **`docs/agents/building-apps.md`** (also wired as the `build-an-app` Claude Code skill; `llms.txt` indexes both audiences). The rendered docs site is <https://abap2ui5.github.io/docs/> — unreachable from many sandboxes, which is why the guide lives in-repo.

--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -40,10 +40,10 @@ sap.ui.define(
         AppState.initGlobal();
 
         // Two sibling BSPs carry frontend artefacts the framework itself does
-        // not ship: z2ui5cc (abap2UI5-addons/custom-controls) and z2ui5ext
+        // not ship: z2ui5ccc (abap2UI5-addons/custom-controls) and z2ui5ext
         // (abap2UI5/customer-frontend-extension, the customer's own library).
         // Both are normally found through their reserved resourceRoot in
-        // manifest.json ("z2ui5cc": "../z2ui5cc/", "z2ui5ext":
+        // manifest.json ("z2ui5ccc": "../z2ui5ccc/", "z2ui5ext":
         // "../z2ui5ext/"), a sibling of THIS BSP. In the standalone HTTP
         // service there is no BSP for them to be a sibling of, so the backend
         // hands the absolute paths over on the global instead
@@ -59,7 +59,7 @@ sap.ui.define(
         // of them installed (or neither) never pays for the other.
         const ccResourceRoot = AppState.getGlobal("ccResourceRoot");
         if (ccResourceRoot) {
-          sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });
+          sap.ui.loader.config({ paths: { z2ui5ccc: ccResourceRoot } });
         }
         const extResourceRoot = AppState.getGlobal("extResourceRoot");
         if (extResourceRoot) {

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -33,7 +33,7 @@
 //                     re-exports - grows via framework PRs only (Component)
 //   ccResourceRoot    absolute path of the custom-control BSP, set by the
 //                     backend GET page when there is no sibling BSP to
-//                     resolve "../z2ui5cc/" against (backend HTML)
+//                     resolve "../z2ui5ccc/" against (backend HTML)
 //   extResourceRoot   same for the customer frontend-extension BSP
 //                     ("../z2ui5ext/") (backend HTML)
 //   requestTimeoutMs  optional override for the roundtrip timeout (apps)

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -75,7 +75,7 @@
       "id": "App"
     },
     "resourceRoots": {
-      "z2ui5cc": "../z2ui5cc/",
+      "z2ui5ccc": "../z2ui5ccc/",
       "z2ui5ext": "../z2ui5ext/"
     }
   },

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -60,7 +60,7 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//                     re-exports - grows via framework PRs only (Component)` && |\n| &&
              `//   ccResourceRoot    absolute path of the custom-control BSP, set by the` && |\n| &&
              `//                     backend GET page when there is no sibling BSP to` && |\n| &&
-             `//                     resolve "../z2ui5cc/" against (backend HTML)` && |\n| &&
+             `//                     resolve "../z2ui5ccc/" against (backend HTML)` && |\n| &&
              `//   extResourceRoot   same for the customer frontend-extension BSP` && |\n| &&
              `//                     ("../z2ui5ext/") (backend HTML)` && |\n| &&
              `//   requestTimeoutMs  optional override for the roundtrip timeout (apps)` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -67,10 +67,10 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        AppState.initGlobal();` && |\n| &&
              `` && |\n| &&
              `        // Two sibling BSPs carry frontend artefacts the framework itself does` && |\n| &&
-             `        // not ship: z2ui5cc (abap2UI5-addons/custom-controls) and z2ui5ext` && |\n| &&
+             `        // not ship: z2ui5ccc (abap2UI5-addons/custom-controls) and z2ui5ext` && |\n| &&
              `        // (abap2UI5/customer-frontend-extension, the customer's own library).` && |\n| &&
              `        // Both are normally found through their reserved resourceRoot in` && |\n| &&
-             `        // manifest.json ("z2ui5cc": "../z2ui5cc/", "z2ui5ext":` && |\n| &&
+             `        // manifest.json ("z2ui5ccc": "../z2ui5ccc/", "z2ui5ext":` && |\n| &&
              `        // "../z2ui5ext/"), a sibling of THIS BSP. In the standalone HTTP` && |\n| &&
              `        // service there is no BSP for them to be a sibling of, so the backend` && |\n| &&
              `        // hands the absolute paths over on the global instead` && |\n| &&
@@ -86,7 +86,7 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        // of them installed (or neither) never pays for the other.` && |\n| &&
              `        const ccResourceRoot = AppState.getGlobal("ccResourceRoot");` && |\n| &&
              `        if (ccResourceRoot) {` && |\n| &&
-             `          sap.ui.loader.config({ paths: { z2ui5cc: ccResourceRoot } });` && |\n| &&
+             `          sap.ui.loader.config({ paths: { z2ui5ccc: ccResourceRoot } });` && |\n| &&
              `        }` && |\n| &&
              `        const extResourceRoot = AppState.getGlobal("extResourceRoot");` && |\n| &&
              `        if (extResourceRoot) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -102,7 +102,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "id": "App"` &&
              `    },` &&
              `    "resourceRoots": {` &&
-             `      "z2ui5cc": "../z2ui5cc/",` &&
+             `      "z2ui5ccc": "../z2ui5ccc/",` &&
              `      "z2ui5ext": "../z2ui5ext/"` &&
              `    }` &&
              `  },` &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -247,11 +247,11 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = lv_style_css
                                                   custom_js  = ls_config-custom_js ).
 
-    " Custom controls (z2ui5cc, abap2UI5-addons/custom-controls) and the
+    " Custom controls (z2ui5ccc, abap2UI5-addons/custom-controls) and the
     " customer's own frontend artefacts (z2ui5ext,
     " abap2UI5/customer-frontend-extension) each live in their own BSP, which
     " the frontend finds through the reserved resourceRoots in manifest.json
-    " ("z2ui5cc": "../z2ui5cc/", "z2ui5ext": "../z2ui5ext/"). Those paths are
+    " ("z2ui5ccc": "../z2ui5ccc/", "z2ui5ext": "../z2ui5ext/"). Those paths are
     " siblings of the FRONTEND BSP, so they are only correct when the app is
     " served from it. Here the component base is this ICF node and the same
     " relative path resolves next to /sap/bc/, where nothing is.
@@ -266,7 +266,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     " stand. Registering a path costs nothing when the BSP is not installed -
     " nothing is requested from it until a view names the namespace.
     DATA(lv_globals) = |window.z2ui5 = \{ checkLocal : true, | &&
-                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cc", | &&
+                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5ccc", | &&
                        |extResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5ext" \};|.
 
     result-body = |<!DOCTYPE html>\n| &&


### PR DESCRIPTION
# Description

This PR renames the reserved resourceRoot identifier for the custom-controls BSP from `z2ui5cc` to `z2ui5ccc` across all framework files. This change affects:

- The manifest.json resourceRoots configuration
- UI5 loader path configuration in Component.js
- Backend resource root registration in the HTTP handler
- Documentation and comments referencing the namespace
- ABAP class implementations that generate these artifacts

The change is consistent across both the frontend JavaScript files and their corresponding ABAP class implementations that generate them.

## How to test

- `npm run verify:full` (app/webapp/ changed)
- Verify that the custom-controls BSP is correctly resolved via the `z2ui5ccc` resourceRoot in manifest.json
- Confirm that the UI5 loader configuration uses the updated namespace

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01UcQ9oaZZpaju6deNgrRz43