### PR TITLE
Add Websocket control for ABAP Push Channel integration

### DIFF
--- a/app/webapp/cc/Websocket.js
+++ b/app/webapp/cc/Websocket.js
@@ -10,9 +10,10 @@ sap.ui.define(
     "use strict";
 
     // A roundtrip already in flight makes View1.eB DROP the event (its
-    // isBusy guard), so inbound messages are queued and reported one per
-    // roundtrip instead of being lost in a burst. This is the retry interval
-    // of the drain loop - it only runs while messages are actually waiting.
+    // isBusy guard), so everything the control reports is queued and
+    // delivered one item per roundtrip instead of being lost in a burst.
+    // This is the retry interval of the drain loop - it only runs while
+    // items are actually waiting.
     const DRAIN_RETRY_MS = 50;
 
     return Control.extend("z2ui5.cc.Websocket", {
@@ -43,6 +44,19 @@ sap.ui.define(
           received: {
             allowPreventDefault: true,
             parameters: {},
+          },
+          // Fired when the connection could not be opened or ended without
+          // the app asking for it, so a backend can react. `code` is the
+          // WebSocket close code ("1006" for a handshake that never
+          // completed - inactive ICF node, rejected authentication, unknown
+          // APC application) or "CONSTRUCT" when the constructor itself
+          // threw. The control never surfaces any UI on its own - handling
+          // is delegated entirely to whoever binds this event.
+          error: {
+            parameters: {
+              code: { type: "string" },
+              message: { type: "string" },
+            },
           },
         },
       },
@@ -76,14 +90,21 @@ sap.ui.define(
       },
       _connect() {
         if (this._ws || !this._url) return;
+        const url = this._url;
         let ws;
         try {
-          ws = new WebSocket(this._url);
+          ws = new WebSocket(url);
         } catch (err) {
-          Lib.logError("Websocket: cannot open " + this._url, err);
+          const message = "Cannot open " + url + ": " + (err.message || err);
+          Lib.logError("Websocket: " + message, err);
+          this._report({ kind: "error", code: "CONSTRUCT", message });
           return;
         }
         this._ws = ws;
+        this._opened = false;
+        ws.onopen = () => {
+          if (this._ws === ws) this._opened = true;
+        };
         ws.onmessage = (event) => {
           // The control may have been torn down, or replaced by a newer
           // connection, while this socket was still open.
@@ -92,21 +113,39 @@ sap.ui.define(
             Lib.logError("Websocket: ignored a non-text message");
             return;
           }
-          this._queue.push(event.data);
           if (!this.getProperty("checkRepeat")) this._disconnect();
-          this._drain();
+          this._report({ kind: "message", value: event.data });
         };
         ws.onerror = () => {
-          Lib.logError("Websocket: connection error on " + this._url);
+          // The WebSocket error event carries no detail by specification -
+          // it is always followed by onclose, which is where the actual
+          // reason (the close code) becomes available and is reported.
+          Lib.logError("Websocket: connection error on " + url);
         };
-        ws.onclose = () => {
-          if (this._ws === ws) this._ws = null;
+        // A close the app asked for never gets here: _disconnect() drops the
+        // handlers first. So every close reaching this point is one the
+        // server or the network caused, and the backend should hear about it.
+        ws.onclose = (event) => {
+          if (this._ws !== ws) return;
+          this._ws = null;
+          if (Lib.isDestroyed(this)) return;
+          const cause = this._opened
+            ? "Connection to " + url + " was closed"
+            : "Connection to " + url + " could not be established";
+          const message = event.reason ? cause + ": " + event.reason : cause;
+          Lib.logError("Websocket (" + event.code + "): " + message);
+          this._report({
+            kind: "error",
+            code: String(event.code),
+            message: message,
+          });
         };
       },
       _disconnect() {
         const ws = this._ws;
         if (!ws) return;
         this._ws = null;
+        ws.onopen = null;
         ws.onmessage = null;
         ws.onerror = null;
         ws.onclose = null;
@@ -116,17 +155,32 @@ sap.ui.define(
           Lib.logError("Websocket: close failed", err);
         }
       },
-      // Report the oldest queued message and round-trip once. While the
-      // backend is busy nothing is consumed - the queue is retried until the
-      // event can actually get through, so no message is dropped.
+      // Queue one item for the backend and start draining. Messages and
+      // errors share the queue so they reach the app in the order they
+      // happened - an error after three messages is reported after them.
+      _report(item) {
+        this._queue.push(item);
+        this._drain();
+      },
+      // Hand the oldest queued item to the backend and round-trip once.
+      // While the backend is busy nothing is consumed - the queue is retried
+      // until the event can actually get through, so nothing is dropped.
       _drain() {
         if (!this._queue.length) return;
         if (AppState.state.isBusy) {
           this._scheduleDrain();
           return;
         }
-        this.setProperty("value", this._queue.shift(), true);
-        this.fireReceived();
+        const item = this._queue.shift();
+        if (item.kind === "error") {
+          this.fireError({
+            code: item.code,
+            message: item.message,
+          });
+        } else {
+          this.setProperty("value", item.value, true);
+          this.fireReceived();
+        }
         if (this._queue.length) this._scheduleDrain();
       },
       _scheduleDrain() {

--- a/app/webapp/cc/Websocket.js
+++ b/app/webapp/cc/Websocket.js
@@ -1,0 +1,147 @@
+// Invisible control that keeps a WebSocket connection to an ABAP Push
+// Channel (APC) open and hands every inbound message to the backend: the
+// message text lands in the two-way bound `value` property and the
+// `received` event triggers the roundtrip that lets the app process it.
+// Sending is deliberately NOT part of the control - an app publishes to the
+// AMC channel from ABAP, so consuming a push channel needs no app JavaScript.
+sap.ui.define(
+  ["sap/ui/core/Control", "z2ui5/core/Lib", "z2ui5/core/AppState"],
+  (Control, Lib, AppState) => {
+    "use strict";
+
+    // A roundtrip already in flight makes View1.eB DROP the event (its
+    // isBusy guard), so inbound messages are queued and reported one per
+    // roundtrip instead of being lost in a burst. This is the retry interval
+    // of the drain loop - it only runs while messages are actually waiting.
+    const DRAIN_RETRY_MS = 50;
+
+    return Control.extend("z2ui5.cc.Websocket", {
+      metadata: {
+        properties: {
+          // APC path ("/sap/bc/apc/sap/z2ui5_apc_smp_2"), resolved against
+          // the current origin; a full ws:// or wss:// URL is taken as is.
+          path: {
+            type: "string",
+            defaultValue: "",
+          },
+          // Text of the message currently reported to the backend.
+          value: {
+            type: "string",
+            defaultValue: "",
+          },
+          checkActive: {
+            type: "boolean",
+            defaultValue: true,
+          },
+          // false -> close the connection after the first message.
+          checkRepeat: {
+            type: "boolean",
+            defaultValue: true,
+          },
+        },
+        events: {
+          received: {
+            allowPreventDefault: true,
+            parameters: {},
+          },
+        },
+      },
+      init() {
+        this._queue = [];
+      },
+      // Every state change (checkActive toggled, path rebound) invalidates
+      // the control, so this single hook is where the connection is brought
+      // in line with the properties - no setter override needed.
+      onAfterRendering() {
+        const url = this._resolveUrl();
+        if (url !== this._url) this._disconnect();
+        this._url = url;
+        if (this.getProperty("checkActive")) {
+          this._connect();
+        } else {
+          this._disconnect();
+        }
+      },
+      exit() {
+        clearTimeout(this._drainId);
+        this._disconnect();
+      },
+      _resolveUrl() {
+        const path = this.getProperty("path");
+        if (!path) return "";
+        if (/^wss?:\/\//i.test(path)) return path;
+        // https -> wss, http -> ws
+        const origin = window.location.origin.replace(/^http/i, "ws");
+        return path.charAt(0) === "/" ? origin + path : origin + "/" + path;
+      },
+      _connect() {
+        if (this._ws || !this._url) return;
+        let ws;
+        try {
+          ws = new WebSocket(this._url);
+        } catch (err) {
+          Lib.logError("Websocket: cannot open " + this._url, err);
+          return;
+        }
+        this._ws = ws;
+        ws.onmessage = (event) => {
+          // The control may have been torn down, or replaced by a newer
+          // connection, while this socket was still open.
+          if (Lib.isDestroyed(this) || this._ws !== ws) return;
+          if (typeof event.data !== "string") {
+            Lib.logError("Websocket: ignored a non-text message");
+            return;
+          }
+          this._queue.push(event.data);
+          if (!this.getProperty("checkRepeat")) this._disconnect();
+          this._drain();
+        };
+        ws.onerror = () => {
+          Lib.logError("Websocket: connection error on " + this._url);
+        };
+        ws.onclose = () => {
+          if (this._ws === ws) this._ws = null;
+        };
+      },
+      _disconnect() {
+        const ws = this._ws;
+        if (!ws) return;
+        this._ws = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        try {
+          ws.close();
+        } catch (err) {
+          Lib.logError("Websocket: close failed", err);
+        }
+      },
+      // Report the oldest queued message and round-trip once. While the
+      // backend is busy nothing is consumed - the queue is retried until the
+      // event can actually get through, so no message is dropped.
+      _drain() {
+        if (!this._queue.length) return;
+        if (AppState.state.isBusy) {
+          this._scheduleDrain();
+          return;
+        }
+        this.setProperty("value", this._queue.shift(), true);
+        this.fireReceived();
+        if (this._queue.length) this._scheduleDrain();
+      },
+      _scheduleDrain() {
+        clearTimeout(this._drainId);
+        this._drainId = setTimeout(() => {
+          if (Lib.isDestroyed(this)) return;
+          this._drain();
+        }, DRAIN_RETRY_MS);
+      },
+      renderer: {
+        apiVersion: 2,
+        render(oRm, oControl) {
+          Lib.renderInvisibleSpan(oRm, oControl);
+        },
+      },
+    });
+  },
+);

--- a/src/01/03/z2ui5_cl_app_preload.clas.abap
+++ b/src/01/03/z2ui5_cl_app_preload.clas.abap
@@ -48,6 +48,7 @@ CLASS z2ui5_cl_app_preload IMPLEMENTATION.
              |      "z2ui5/cc/Tree.js": function()\{{ z2ui5_cl_app_tree_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/UITableExt.js": function()\{{ z2ui5_cl_app_uitableext_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/cc/UploadSetExt.js": function()\{{ z2ui5_cl_app_uploadsetext_js=>get( ) }\},| && |\n| &&
+             |      "z2ui5/cc/Websocket.js": function()\{{ z2ui5_cl_app_websocket_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/Component.js": function()\{{ z2ui5_cl_app_component_js=>get( ) }{ custom_js }\},| && |\n| &&
              |      "z2ui5/controller/App.controller.js": function()\{{ z2ui5_cl_app_app_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/controller/View1.controller.js": function()\{{ z2ui5_cl_app_view1_js=>get( ) }\},| && |\n| &&

--- a/src/01/03/z2ui5_cl_app_websocket_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_websocket_js.clas.abap
@@ -37,9 +37,10 @@ CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
              `    "use strict";` && |\n| &&
              `` && |\n| &&
              `    // A roundtrip already in flight makes View1.eB DROP the event (its` && |\n| &&
-             `    // isBusy guard), so inbound messages are queued and reported one per` && |\n| &&
-             `    // roundtrip instead of being lost in a burst. This is the retry interval` && |\n| &&
-             `    // of the drain loop - it only runs while messages are actually waiting.` && |\n| &&
+             `    // isBusy guard), so everything the control reports is queued and` && |\n| &&
+             `    // delivered one item per roundtrip instead of being lost in a burst.` && |\n| &&
+             `    // This is the retry interval of the drain loop - it only runs while` && |\n| &&
+             `    // items are actually waiting.` && |\n| &&
              `    const DRAIN_RETRY_MS = 50;` && |\n| &&
              `` && |\n| &&
              `    return Control.extend("z2ui5.cc.Websocket", {` && |\n| &&
@@ -70,6 +71,19 @@ CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
              `          received: {` && |\n| &&
              `            allowPreventDefault: true,` && |\n| &&
              `            parameters: {},` && |\n| &&
+             `          },` && |\n| &&
+             `          // Fired when the connection could not be opened or ended without` && |\n| &&
+             `          // the app asking for it, so a backend can react. ``code`` is the` && |\n| &&
+             `          // WebSocket close code ("1006" for a handshake that never` && |\n| &&
+             `          // completed - inactive ICF node, rejected authentication, unknown` && |\n| &&
+             `          // APC application) or "CONSTRUCT" when the constructor itself` && |\n| &&
+             `          // threw. The control never surfaces any UI on its own - handling` && |\n| &&
+             `          // is delegated entirely to whoever binds this event.` && |\n| &&
+             `          error: {` && |\n| &&
+             `            parameters: {` && |\n| &&
+             `              code: { type: "string" },` && |\n| &&
+             `              message: { type: "string" },` && |\n| &&
+             `            },` && |\n| &&
              `          },` && |\n| &&
              `        },` && |\n| &&
              `      },` && |\n| &&
@@ -103,14 +117,21 @@ CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
              `      },` && |\n| &&
              `      _connect() {` && |\n| &&
              `        if (this._ws || !this._url) return;` && |\n| &&
+             `        const url = this._url;` && |\n| &&
              `        let ws;` && |\n| &&
              `        try {` && |\n| &&
-             `          ws = new WebSocket(this._url);` && |\n| &&
+             `          ws = new WebSocket(url);` && |\n| &&
              `        } catch (err) {` && |\n| &&
-             `          Lib.logError("Websocket: cannot open " + this._url, err);` && |\n| &&
+             `          const message = "Cannot open " + url + ": " + (err.message || err);` && |\n| &&
+             `          Lib.logError("Websocket: " + message, err);` && |\n| &&
+             `          this._report({ kind: "error", code: "CONSTRUCT", message });` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
              `        this._ws = ws;` && |\n| &&
+             `        this._opened = false;` && |\n| &&
+             `        ws.onopen = () => {` && |\n| &&
+             `          if (this._ws === ws) this._opened = true;` && |\n| &&
+             `        };` && |\n| &&
              `        ws.onmessage = (event) => {` && |\n| &&
              `          // The control may have been torn down, or replaced by a newer` && |\n| &&
              `          // connection, while this socket was still open.` && |\n| &&
@@ -119,21 +140,39 @@ CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
              `            Lib.logError("Websocket: ignored a non-text message");` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
-             `          this._queue.push(event.data);` && |\n| &&
              `          if (!this.getProperty("checkRepeat")) this._disconnect();` && |\n| &&
-             `          this._drain();` && |\n| &&
+             `          this._report({ kind: "message", value: event.data });` && |\n| &&
              `        };` && |\n| &&
              `        ws.onerror = () => {` && |\n| &&
-             `          Lib.logError("Websocket: connection error on " + this._url);` && |\n| &&
+             `          // The WebSocket error event carries no detail by specification -` && |\n| &&
+             `          // it is always followed by onclose, which is where the actual` && |\n| &&
+             `          // reason (the close code) becomes available and is reported.` && |\n| &&
+             `          Lib.logError("Websocket: connection error on " + url);` && |\n| &&
              `        };` && |\n| &&
-             `        ws.onclose = () => {` && |\n| &&
-             `          if (this._ws === ws) this._ws = null;` && |\n| &&
+             `        // A close the app asked for never gets here: _disconnect() drops the` && |\n| &&
+             `        // handlers first. So every close reaching this point is one the` && |\n| &&
+             `        // server or the network caused, and the backend should hear about it.` && |\n| &&
+             `        ws.onclose = (event) => {` && |\n| &&
+             `          if (this._ws !== ws) return;` && |\n| &&
+             `          this._ws = null;` && |\n| &&
+             `          if (Lib.isDestroyed(this)) return;` && |\n| &&
+             `          const cause = this._opened` && |\n| &&
+             `            ? "Connection to " + url + " was closed"` && |\n| &&
+             `            : "Connection to " + url + " could not be established";` && |\n| &&
+             `          const message = event.reason ? cause + ": " + event.reason : cause;` && |\n| &&
+             `          Lib.logError("Websocket (" + event.code + "): " + message);` && |\n| &&
+             `          this._report({` && |\n| &&
+             `            kind: "error",` && |\n| &&
+             `            code: String(event.code),` && |\n| &&
+             `            message: message,` && |\n| &&
+             `          });` && |\n| &&
              `        };` && |\n| &&
              `      },` && |\n| &&
              `      _disconnect() {` && |\n| &&
              `        const ws = this._ws;` && |\n| &&
              `        if (!ws) return;` && |\n| &&
              `        this._ws = null;` && |\n| &&
+             `        ws.onopen = null;` && |\n| &&
              `        ws.onmessage = null;` && |\n| &&
              `        ws.onerror = null;` && |\n| &&
              `        ws.onclose = null;` && |\n| &&
@@ -143,17 +182,32 @@ CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
              `          Lib.logError("Websocket: close failed", err);` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
-             `      // Report the oldest queued message and round-trip once. While the` && |\n| &&
-             `      // backend is busy nothing is consumed - the queue is retried until the` && |\n| &&
-             `      // event can actually get through, so no message is dropped.` && |\n| &&
+             `      // Queue one item for the backend and start draining. Messages and` && |\n| &&
+             `      // errors share the queue so they reach the app in the order they` && |\n| &&
+             `      // happened - an error after three messages is reported after them.` && |\n| &&
+             `      _report(item) {` && |\n| &&
+             `        this._queue.push(item);` && |\n| &&
+             `        this._drain();` && |\n| &&
+             `      },` && |\n| &&
+             `      // Hand the oldest queued item to the backend and round-trip once.` && |\n| &&
+             `      // While the backend is busy nothing is consumed - the queue is retried` && |\n| &&
+             `      // until the event can actually get through, so nothing is dropped.` && |\n| &&
              `      _drain() {` && |\n| &&
              `        if (!this._queue.length) return;` && |\n| &&
              `        if (AppState.state.isBusy) {` && |\n| &&
              `          this._scheduleDrain();` && |\n| &&
              `          return;` && |\n| &&
              `        }` && |\n| &&
-             `        this.setProperty("value", this._queue.shift(), true);` && |\n| &&
-             `        this.fireReceived();` && |\n| &&
+             `        const item = this._queue.shift();` && |\n| &&
+             `        if (item.kind === "error") {` && |\n| &&
+             `          this.fireError({` && |\n| &&
+             `            code: item.code,` && |\n| &&
+             `            message: item.message,` && |\n| &&
+             `          });` && |\n| &&
+             `        } else {` && |\n| &&
+             `          this.setProperty("value", item.value, true);` && |\n| &&
+             `          this.fireReceived();` && |\n| &&
+             `        }` && |\n| &&
              `        if (this._queue.length) this._scheduleDrain();` && |\n| &&
              `      },` && |\n| &&
              `      _scheduleDrain() {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_websocket_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_websocket_js.clas.abap
@@ -1,0 +1,180 @@
+* =====================================================================
+* GENERATED FILE - DO NOT EDIT (AGENTS.md rule 2)
+* Embedded frontend resource, generated from app/webapp/ by
+* .github/app2abap/trans2abap.js. Change the source under app/webapp/
+* and run 'npm run app2abap' to regenerate; the check_app2abap CI gate
+* fails any manual edit here.
+* =====================================================================
+CLASS z2ui5_cl_app_websocket_js DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      RETURNING
+        VALUE(result) TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_app_websocket_js IMPLEMENTATION.
+
+  METHOD get.
+
+    result = `// Invisible control that keeps a WebSocket connection to an ABAP Push` && |\n| &&
+             `// Channel (APC) open and hands every inbound message to the backend: the` && |\n| &&
+             `// message text lands in the two-way bound ``value`` property and the` && |\n| &&
+             `// ``received`` event triggers the roundtrip that lets the app process it.` && |\n| &&
+             `// Sending is deliberately NOT part of the control - an app publishes to the` && |\n| &&
+             `// AMC channel from ABAP, so consuming a push channel needs no app JavaScript.` && |\n| &&
+             `sap.ui.define(` && |\n| &&
+             `  ["sap/ui/core/Control", "z2ui5/core/Lib", "z2ui5/core/AppState"],` && |\n| &&
+             `  (Control, Lib, AppState) => {` && |\n| &&
+             `    "use strict";` && |\n| &&
+             `` && |\n| &&
+             `    // A roundtrip already in flight makes View1.eB DROP the event (its` && |\n| &&
+             `    // isBusy guard), so inbound messages are queued and reported one per` && |\n| &&
+             `    // roundtrip instead of being lost in a burst. This is the retry interval` && |\n| &&
+             `    // of the drain loop - it only runs while messages are actually waiting.` && |\n| &&
+             `    const DRAIN_RETRY_MS = 50;` && |\n| &&
+             `` && |\n| &&
+             `    return Control.extend("z2ui5.cc.Websocket", {` && |\n| &&
+             `      metadata: {` && |\n| &&
+             `        properties: {` && |\n| &&
+             `          // APC path ("/sap/bc/apc/sap/z2ui5_apc_smp_2"), resolved against` && |\n| &&
+             `          // the current origin; a full ws:// or wss:// URL is taken as is.` && |\n| &&
+             `          path: {` && |\n| &&
+             `            type: "string",` && |\n| &&
+             `            defaultValue: "",` && |\n| &&
+             `          },` && |\n| &&
+             `          // Text of the message currently reported to the backend.` && |\n| &&
+             `          value: {` && |\n| &&
+             `            type: "string",` && |\n| &&
+             `            defaultValue: "",` && |\n| &&
+             `          },` && |\n| &&
+             `          checkActive: {` && |\n| &&
+             `            type: "boolean",` && |\n| &&
+             `            defaultValue: true,` && |\n| &&
+             `          },` && |\n| &&
+             `          // false -> close the connection after the first message.` && |\n| &&
+             `          checkRepeat: {` && |\n| &&
+             `            type: "boolean",` && |\n| &&
+             `            defaultValue: true,` && |\n| &&
+             `          },` && |\n| &&
+             `        },` && |\n| &&
+             `        events: {` && |\n| &&
+             `          received: {` && |\n| &&
+             `            allowPreventDefault: true,` && |\n| &&
+             `            parameters: {},` && |\n| &&
+             `          },` && |\n| &&
+             `        },` && |\n| &&
+             `      },` && |\n| &&
+             `      init() {` && |\n| &&
+             `        this._queue = [];` && |\n| &&
+             `      },` && |\n| &&
+             `      // Every state change (checkActive toggled, path rebound) invalidates` && |\n| &&
+             `      // the control, so this single hook is where the connection is brought` && |\n| &&
+             `      // in line with the properties - no setter override needed.` && |\n| &&
+             `      onAfterRendering() {` && |\n| &&
+             `        const url = this._resolveUrl();` && |\n| &&
+             `        if (url !== this._url) this._disconnect();` && |\n| &&
+             `        this._url = url;` && |\n| &&
+             `        if (this.getProperty("checkActive")) {` && |\n| &&
+             `          this._connect();` && |\n| &&
+             `        } else {` && |\n| &&
+             `          this._disconnect();` && |\n| &&
+             `        }` && |\n| &&
+             `      },` && |\n| &&
+             `      exit() {` && |\n| &&
+             `        clearTimeout(this._drainId);` && |\n| &&
+             `        this._disconnect();` && |\n| &&
+             `      },` && |\n| &&
+             `      _resolveUrl() {` && |\n| &&
+             `        const path = this.getProperty("path");` && |\n| &&
+             `        if (!path) return "";` && |\n| &&
+             `        if (/^wss?:\/\//i.test(path)) return path;` && |\n| &&
+             `        // https -> wss, http -> ws` && |\n| &&
+             `        const origin = window.location.origin.replace(/^http/i, "ws");` && |\n| &&
+             `        return path.charAt(0) === "/" ? origin + path : origin + "/" + path;` && |\n| &&
+             `      },` && |\n| &&
+             `      _connect() {` && |\n| &&
+             `        if (this._ws || !this._url) return;` && |\n| &&
+             `        let ws;` && |\n| &&
+             `        try {` && |\n| &&
+             `          ws = new WebSocket(this._url);` && |\n| &&
+             `        } catch (err) {` && |\n| &&
+             `          Lib.logError("Websocket: cannot open " + this._url, err);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        this._ws = ws;` && |\n| &&
+             `        ws.onmessage = (event) => {` && |\n| &&
+             `          // The control may have been torn down, or replaced by a newer` && |\n| &&
+             `          // connection, while this socket was still open.` && |\n| &&
+             `          if (Lib.isDestroyed(this) || this._ws !== ws) return;` && |\n| &&
+             `          if (typeof event.data !== "string") {` && |\n| &&
+             `            Lib.logError("Websocket: ignored a non-text message");` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n| &&
+             `          this._queue.push(event.data);` && |\n| &&
+             `          if (!this.getProperty("checkRepeat")) this._disconnect();` && |\n| &&
+             `          this._drain();` && |\n| &&
+             `        };` && |\n| &&
+             `        ws.onerror = () => {` && |\n| &&
+             `          Lib.logError("Websocket: connection error on " + this._url);` && |\n| &&
+             `        };` && |\n| &&
+             `        ws.onclose = () => {` && |\n| &&
+             `          if (this._ws === ws) this._ws = null;` && |\n| &&
+             `        };` && |\n| &&
+             `      },` && |\n| &&
+             `      _disconnect() {` && |\n| &&
+             `        const ws = this._ws;` && |\n| &&
+             `        if (!ws) return;` && |\n| &&
+             `        this._ws = null;` && |\n| &&
+             `        ws.onmessage = null;` && |\n| &&
+             `        ws.onerror = null;` && |\n| &&
+             `        ws.onclose = null;` && |\n| &&
+             `        try {` && |\n| &&
+             `          ws.close();` && |\n| &&
+             `        } catch (err) {` && |\n| &&
+             `          Lib.logError("Websocket: close failed", err);` && |\n| &&
+             `        }` && |\n| &&
+             `      },` && |\n| &&
+             `      // Report the oldest queued message and round-trip once. While the` && |\n| &&
+             `      // backend is busy nothing is consumed - the queue is retried until the` && |\n| &&
+             `      // event can actually get through, so no message is dropped.` && |\n| &&
+             `      _drain() {` && |\n| &&
+             `        if (!this._queue.length) return;` && |\n| &&
+             `        if (AppState.state.isBusy) {` && |\n| &&
+             `          this._scheduleDrain();` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        this.setProperty("value", this._queue.shift(), true);` && |\n| &&
+             `        this.fireReceived();` && |\n| &&
+             `        if (this._queue.length) this._scheduleDrain();` && |\n| &&
+             `      },` && |\n| &&
+             `      _scheduleDrain() {` && |\n| &&
+             `        clearTimeout(this._drainId);` && |\n| &&
+             `        this._drainId = setTimeout(() => {` && |\n| &&
+             `          if (Lib.isDestroyed(this)) return;` && |\n| &&
+             `          this._drain();` && |\n| &&
+             `        }, DRAIN_RETRY_MS);` && |\n| &&
+             `      },` && |\n| &&
+             `      renderer: {` && |\n| &&
+             `        apiVersion: 2,` && |\n| &&
+             `        render(oRm, oControl) {` && |\n| &&
+             `          Lib.renderInvisibleSpan(oRm, oControl);` && |\n| &&
+             `        },` && |\n| &&
+             `      },` && |\n| &&
+             `    });` && |\n| &&
+             `  },` && |\n| &&
+             `);` && |\n| &&
+             `` && |\n| &&
+              ``.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/01/03/z2ui5_cl_app_websocket_js.clas.xml
+++ b/src/01/03/z2ui5_cl_app_websocket_js.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_APP_WEBSOCKET_JS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abap2UI5 - Websocket.js</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
# Description

Adds a new custom UI5 control `z2ui5.cc.Websocket` that manages WebSocket connections to ABAP Push Channels (APC). This control:

- Maintains a persistent WebSocket connection to an APC endpoint
- Queues inbound messages and delivers them to the backend one per roundtrip via the `received` event
- Handles connection lifecycle (open, close, errors) and reports failures via the `error` event
- Provides properties for configuring the APC path, enabling/disabling the connection, and controlling message repetition
- Implements intelligent queue draining that respects the app's busy state to prevent message loss during concurrent operations

The control is invisible to the user and designed to be used declaratively in views with event bindings to process incoming push messages.

Includes both the source JavaScript file (`app/webapp/cc/Websocket.js`) and the generated ABAP wrapper class (`z2ui5_cl_app_websocket_js`) for embedding in the preload bundle.

## How to test

1. Run `npm run verify:full` to ensure the app2abap generation is correct
2. Verify the generated ABAP class matches the source JavaScript file
3. Test WebSocket connectivity by binding the control to an APC endpoint and verifying messages are received and queued properly
4. Confirm error handling works when connections fail or are rejected

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md) - generated via app2abap
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01VZw8icDrvMdsjLt7c2GmvA