### PR TITLE
Fix z2ui5ccc naming to z2ui5_cci for custom-controls BSP

### DIFF
--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -40,10 +40,12 @@ sap.ui.define(
         AppState.initGlobal();
 
         // Two sibling BSPs carry frontend artefacts the framework itself does
-        // not ship: z2ui5ccc (abap2UI5-addons/custom-controls) and z2ui5cci
+        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5cci
         // (abap2UI5/customer-frontend-extension, the customer's own library).
+        // The two roots differ by one underscore and are NOT the same BSP -
+        // z2ui5_cci matches that repository's ABAP prefix z2ui5_cl_cci.
         // Both are normally found through their reserved resourceRoot in
-        // manifest.json ("z2ui5ccc": "../z2ui5ccc/", "z2ui5cci":
+        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci":
         // "../z2ui5cci/"), a sibling of THIS BSP. In the standalone HTTP
         // service there is no BSP for them to be a sibling of, so the backend
         // hands the absolute paths over on the global instead
@@ -59,7 +61,7 @@ sap.ui.define(
         // of them installed (or neither) never pays for the other.
         const ccResourceRoot = AppState.getGlobal("ccResourceRoot");
         if (ccResourceRoot) {
-          sap.ui.loader.config({ paths: { z2ui5ccc: ccResourceRoot } });
+          sap.ui.loader.config({ paths: { z2ui5_cci: ccResourceRoot } });
         }
         const cciResourceRoot = AppState.getGlobal("cciResourceRoot");
         if (cciResourceRoot) {

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -33,7 +33,7 @@
 //                     re-exports - grows via framework PRs only (Component)
 //   ccResourceRoot    absolute path of the custom-control BSP, set by the
 //                     backend GET page when there is no sibling BSP to
-//                     resolve "../z2ui5ccc/" against (backend HTML)
+//                     resolve "../z2ui5_cci/" against (backend HTML)
 //   cciResourceRoot   same for the customer frontend-extension BSP
 //                     ("../z2ui5cci/") (backend HTML)
 //   requestTimeoutMs  optional override for the roundtrip timeout (apps)

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -75,7 +75,7 @@
       "id": "App"
     },
     "resourceRoots": {
-      "z2ui5ccc": "../z2ui5ccc/",
+      "z2ui5_cci": "../z2ui5_cci/",
       "z2ui5cci": "../z2ui5cci/"
     }
   },

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -60,7 +60,7 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//                     re-exports - grows via framework PRs only (Component)` && |\n| &&
              `//   ccResourceRoot    absolute path of the custom-control BSP, set by the` && |\n| &&
              `//                     backend GET page when there is no sibling BSP to` && |\n| &&
-             `//                     resolve "../z2ui5ccc/" against (backend HTML)` && |\n| &&
+             `//                     resolve "../z2ui5_cci/" against (backend HTML)` && |\n| &&
              `//   cciResourceRoot   same for the customer frontend-extension BSP` && |\n| &&
              `//                     ("../z2ui5cci/") (backend HTML)` && |\n| &&
              `//   requestTimeoutMs  optional override for the roundtrip timeout (apps)` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -67,10 +67,12 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        AppState.initGlobal();` && |\n| &&
              `` && |\n| &&
              `        // Two sibling BSPs carry frontend artefacts the framework itself does` && |\n| &&
-             `        // not ship: z2ui5ccc (abap2UI5-addons/custom-controls) and z2ui5cci` && |\n| &&
+             `        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5cci` && |\n| &&
              `        // (abap2UI5/customer-frontend-extension, the customer's own library).` && |\n| &&
+             `        // The two roots differ by one underscore and are NOT the same BSP -` && |\n| &&
+             `        // z2ui5_cci matches that repository's ABAP prefix z2ui5_cl_cci.` && |\n| &&
              `        // Both are normally found through their reserved resourceRoot in` && |\n| &&
-             `        // manifest.json ("z2ui5ccc": "../z2ui5ccc/", "z2ui5cci":` && |\n| &&
+             `        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci":` && |\n| &&
              `        // "../z2ui5cci/"), a sibling of THIS BSP. In the standalone HTTP` && |\n| &&
              `        // service there is no BSP for them to be a sibling of, so the backend` && |\n| &&
              `        // hands the absolute paths over on the global instead` && |\n| &&
@@ -86,7 +88,7 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        // of them installed (or neither) never pays for the other.` && |\n| &&
              `        const ccResourceRoot = AppState.getGlobal("ccResourceRoot");` && |\n| &&
              `        if (ccResourceRoot) {` && |\n| &&
-             `          sap.ui.loader.config({ paths: { z2ui5ccc: ccResourceRoot } });` && |\n| &&
+             `          sap.ui.loader.config({ paths: { z2ui5_cci: ccResourceRoot } });` && |\n| &&
              `        }` && |\n| &&
              `        const cciResourceRoot = AppState.getGlobal("cciResourceRoot");` && |\n| &&
              `        if (cciResourceRoot) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -102,7 +102,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `      "id": "App"` &&
              `    },` &&
              `    "resourceRoots": {` &&
-             `      "z2ui5ccc": "../z2ui5ccc/",` &&
+             `      "z2ui5_cci": "../z2ui5_cci/",` &&
              `      "z2ui5cci": "../z2ui5cci/"` &&
              `    }` &&
              `  },` &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -247,11 +247,11 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = lv_style_css
                                                   custom_js  = ls_config-custom_js ).
 
-    " Custom controls (z2ui5ccc, abap2UI5-addons/custom-controls) and the
+    " Custom controls (z2ui5_cci, abap2UI5-addons/custom-controls) and the
     " customer's own frontend artefacts (z2ui5cci,
     " abap2UI5/customer-frontend-extension) each live in their own BSP, which
     " the frontend finds through the reserved resourceRoots in manifest.json
-    " ("z2ui5ccc": "../z2ui5ccc/", "z2ui5cci": "../z2ui5cci/"). Those paths are
+    " ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci": "../z2ui5cci/"). Those paths are
     " siblings of the FRONTEND BSP, so they are only correct when the app is
     " served from it. Here the component base is this ICF node and the same
     " relative path resolves next to /sap/bc/, where nothing is.
@@ -266,7 +266,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     " stand. Registering a path costs nothing when the BSP is not installed -
     " nothing is requested from it until a view names the namespace.
     DATA(lv_globals) = |window.z2ui5 = \{ checkLocal : true, | &&
-                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5ccc", | &&
+                       |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5_cci", | &&
                        |cciResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cci" \};|.
 
     result-body = |<!DOCTYPE html>\n| &&


### PR DESCRIPTION
# Description

Corrects the naming of the custom-controls BSP from `z2ui5ccc` to `z2ui5_cci` throughout the codebase. The underscore is significant as it matches the ABAP prefix `z2ui5_cl_cci` used in the custom-controls repository.

This fixes a naming inconsistency where the BSP identifier was missing the underscore that distinguishes it from other components. The change updates:
- Resource root configuration in `manifest.json`
- UI5 loader path configuration in Component.js
- Backend resource root registration in HTTP handler
- Documentation comments clarifying the distinction between `z2ui5_cci` and `z2ui5cci`
- All corresponding ABAP class implementations that embed these files

## How to test

- Verify `npm run verify:full` passes (app/webapp/ changed)
- Confirm custom-controls BSP loads correctly when available at the corrected path `/sap/bc/ui5_ui5/sap/z2ui5_cci`
- Verify manifest.json resourceRoots correctly reference `z2ui5_cci` for custom-controls

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01Hm97xHbMy4TyDH53QGTLht