### PR TITLE
Fix naming inconsistency: z2ui5cci → z2ui5_ccc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [docs](https://github.com/abap2UI5/docs) | Project documentation |
 | [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of `src/00/03/` (see "Utilities") |
 | [app-template](https://github.com/abap2UI5/app-template) | Starter repo for app projects — gates, CI and agent setup preconfigured |
-| [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5ccc` in `app/webapp/manifest.json` is what makes it findable |
-| [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) | Template for a customer's **own** frontend artefacts (reuse library, icon font, CSS) in their own BSP — same mechanism under the reserved resourceRoot `z2ui5cci`. Both roots exist so nobody has to patch `index.html` / `manifest.json`, which are generated here and overwritten downstream |
+| [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5_cci` in `app/webapp/manifest.json` is what makes it findable |
+| [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) | Template for a customer's **own** frontend artefacts (reuse library, icon font, CSS) in their own BSP — same mechanism under the reserved resourceRoot `z2ui5_ccc`. Both roots exist so nobody has to patch `index.html` / `manifest.json`, which are generated here and overwritten downstream |
 
 > **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle — read the in-repo guide **`docs/agents/building-apps.md`** (also wired as the `build-an-app` Claude Code skill; `llms.txt` indexes both audiences). The rendered docs site is <https://abap2ui5.github.io/docs/> — unreachable from many sandboxes, which is why the guide lives in-repo.
 

--- a/app/webapp/Component.js
+++ b/app/webapp/Component.js
@@ -40,13 +40,14 @@ sap.ui.define(
         AppState.initGlobal();
 
         // Two sibling BSPs carry frontend artefacts the framework itself does
-        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5cci
+        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5_ccc
         // (abap2UI5/customer-frontend-extension, the customer's own library).
-        // The two roots differ by one underscore and are NOT the same BSP -
-        // z2ui5_cci matches that repository's ABAP prefix z2ui5_cl_cci.
+        // The two roots differ in one letter and are NOT the same BSP - each
+        // matches the ABAP prefix of its repository (z2ui5_cl_cci for the
+        // community controls, z2ui5_cl_ccc for the customer extension).
         // Both are normally found through their reserved resourceRoot in
-        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci":
-        // "../z2ui5cci/"), a sibling of THIS BSP. In the standalone HTTP
+        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5_ccc":
+        // "../z2ui5_ccc/"), a sibling of THIS BSP. In the standalone HTTP
         // service there is no BSP for them to be a sibling of, so the backend
         // hands the absolute paths over on the global instead
         // (z2ui5_cl_http_handler=>_http_get).
@@ -63,9 +64,9 @@ sap.ui.define(
         if (ccResourceRoot) {
           sap.ui.loader.config({ paths: { z2ui5_cci: ccResourceRoot } });
         }
-        const cciResourceRoot = AppState.getGlobal("cciResourceRoot");
-        if (cciResourceRoot) {
-          sap.ui.loader.config({ paths: { z2ui5cci: cciResourceRoot } });
+        const cccResourceRoot = AppState.getGlobal("cccResourceRoot");
+        if (cccResourceRoot) {
+          sap.ui.loader.config({ paths: { z2ui5_ccc: cccResourceRoot } });
         }
 
         UIComponent.prototype.init.call(this);

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -34,8 +34,8 @@
 //   ccResourceRoot    absolute path of the custom-control BSP, set by the
 //                     backend GET page when there is no sibling BSP to
 //                     resolve "../z2ui5_cci/" against (backend HTML)
-//   cciResourceRoot   same for the customer frontend-extension BSP
-//                     ("../z2ui5cci/") (backend HTML)
+//   cccResourceRoot   same for the customer frontend-extension BSP
+//                     ("../z2ui5_ccc/") (backend HTML)
 //   requestTimeoutMs  optional override for the roundtrip timeout (apps)
 //   <custom>          apps can register functions via the js_loader popup
 //                     and call them through the Z2UI5 frontend event

--- a/app/webapp/manifest.json
+++ b/app/webapp/manifest.json
@@ -76,7 +76,7 @@
     },
     "resourceRoots": {
       "z2ui5_cci": "../z2ui5_cci/",
-      "z2ui5cci": "../z2ui5cci/"
+      "z2ui5_ccc": "../z2ui5_ccc/"
     }
   },
   "sap.cloud": {

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -61,8 +61,8 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//   ccResourceRoot    absolute path of the custom-control BSP, set by the` && |\n| &&
              `//                     backend GET page when there is no sibling BSP to` && |\n| &&
              `//                     resolve "../z2ui5_cci/" against (backend HTML)` && |\n| &&
-             `//   cciResourceRoot   same for the customer frontend-extension BSP` && |\n| &&
-             `//                     ("../z2ui5cci/") (backend HTML)` && |\n| &&
+             `//   cccResourceRoot   same for the customer frontend-extension BSP` && |\n| &&
+             `//                     ("../z2ui5_ccc/") (backend HTML)` && |\n| &&
              `//   requestTimeoutMs  optional override for the roundtrip timeout (apps)` && |\n| &&
              `//   <custom>          apps can register functions via the js_loader popup` && |\n| &&
              `//                     and call them through the Z2UI5 frontend event` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_component_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_component_js.clas.abap
@@ -67,13 +67,14 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        AppState.initGlobal();` && |\n| &&
              `` && |\n| &&
              `        // Two sibling BSPs carry frontend artefacts the framework itself does` && |\n| &&
-             `        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5cci` && |\n| &&
+             `        // not ship: z2ui5_cci (abap2UI5-addons/custom-controls) and z2ui5_ccc` && |\n| &&
              `        // (abap2UI5/customer-frontend-extension, the customer's own library).` && |\n| &&
-             `        // The two roots differ by one underscore and are NOT the same BSP -` && |\n| &&
-             `        // z2ui5_cci matches that repository's ABAP prefix z2ui5_cl_cci.` && |\n| &&
+             `        // The two roots differ in one letter and are NOT the same BSP - each` && |\n| &&
+             `        // matches the ABAP prefix of its repository (z2ui5_cl_cci for the` && |\n| &&
+             `        // community controls, z2ui5_cl_ccc for the customer extension).` && |\n| &&
              `        // Both are normally found through their reserved resourceRoot in` && |\n| &&
-             `        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci":` && |\n| &&
-             `        // "../z2ui5cci/"), a sibling of THIS BSP. In the standalone HTTP` && |\n| &&
+             `        // manifest.json ("z2ui5_cci": "../z2ui5_cci/", "z2ui5_ccc":` && |\n| &&
+             `        // "../z2ui5_ccc/"), a sibling of THIS BSP. In the standalone HTTP` && |\n| &&
              `        // service there is no BSP for them to be a sibling of, so the backend` && |\n| &&
              `        // hands the absolute paths over on the global instead` && |\n| &&
              `        // (z2ui5_cl_http_handler=>_http_get).` && |\n| &&
@@ -90,9 +91,9 @@ CLASS z2ui5_cl_app_component_js IMPLEMENTATION.
              `        if (ccResourceRoot) {` && |\n| &&
              `          sap.ui.loader.config({ paths: { z2ui5_cci: ccResourceRoot } });` && |\n| &&
              `        }` && |\n| &&
-             `        const cciResourceRoot = AppState.getGlobal("cciResourceRoot");` && |\n| &&
-             `        if (cciResourceRoot) {` && |\n| &&
-             `          sap.ui.loader.config({ paths: { z2ui5cci: cciResourceRoot } });` && |\n| &&
+             `        const cccResourceRoot = AppState.getGlobal("cccResourceRoot");` && |\n| &&
+             `        if (cccResourceRoot) {` && |\n| &&
+             `          sap.ui.loader.config({ paths: { z2ui5_ccc: cccResourceRoot } });` && |\n| &&
              `        }` && |\n| &&
              `` && |\n| &&
              `        UIComponent.prototype.init.call(this);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
+++ b/src/01/03/z2ui5_cl_app_manifest_json.clas.abap
@@ -103,7 +103,7 @@ CLASS z2ui5_cl_app_manifest_json IMPLEMENTATION.
              `    },` &&
              `    "resourceRoots": {` &&
              `      "z2ui5_cci": "../z2ui5_cci/",` &&
-             `      "z2ui5cci": "../z2ui5cci/"` &&
+             `      "z2ui5_ccc": "../z2ui5_ccc/"` &&
              `    }` &&
              `  },` &&
              `  "sap.cloud": {` &&

--- a/src/02/z2ui5_cl_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.abap
@@ -248,10 +248,10 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
                                                   custom_js  = ls_config-custom_js ).
 
     " Custom controls (z2ui5_cci, abap2UI5-addons/custom-controls) and the
-    " customer's own frontend artefacts (z2ui5cci,
+    " customer's own frontend artefacts (z2ui5_ccc,
     " abap2UI5/customer-frontend-extension) each live in their own BSP, which
     " the frontend finds through the reserved resourceRoots in manifest.json
-    " ("z2ui5_cci": "../z2ui5_cci/", "z2ui5cci": "../z2ui5cci/"). Those paths are
+    " ("z2ui5_cci": "../z2ui5_cci/", "z2ui5_ccc": "../z2ui5_ccc/"). Those paths are
     " siblings of the FRONTEND BSP, so they are only correct when the app is
     " served from it. Here the component base is this ICF node and the same
     " relative path resolves next to /sap/bc/, where nothing is.
@@ -267,7 +267,7 @@ CLASS z2ui5_cl_http_handler IMPLEMENTATION.
     " nothing is requested from it until a view names the namespace.
     DATA(lv_globals) = |window.z2ui5 = \{ checkLocal : true, | &&
                        |ccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5_cci", | &&
-                       |cciResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5cci" \};|.
+                       |cccResourceRoot : "/sap/bc/ui5_ui5/sap/z2ui5_ccc" \};|.
 
     result-body = |<!DOCTYPE html>\n| &&
                   |<html lang="en">\n| &&


### PR DESCRIPTION
# Description

Corrects a naming inconsistency in the customer frontend-extension BSP identifier. The resource root was previously named `z2ui5cci` (missing underscore), but should be `z2ui5_ccc` to:

1. Match the ABAP class prefix `z2ui5_cl_ccc` used in the customer-frontend-extension repository
2. Follow the same naming convention as the community controls BSP (`z2ui5_cci` / `z2ui5_cl_cci`)
3. Clarify that the two roots differ by one letter (c vs ccc), not by underscores

Updates all references across:
- Frontend JavaScript configuration (Component.js, AppState.js, manifest.json)
- Backend ABAP code (HTTP handler, generated class files)
- Documentation (AGENTS.md)

## How to test

- `npm run verify:full` (app/webapp/ changed)
- Verify the manifest.json resourceRoots are correctly configured
- Confirm backend HTTP handler serves correct resource paths for both BSPs

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: no

https://claude.ai/code/session_01BduTfXjDjJ19NAhGtSdDW5