### PR TITLE
Redesign error dialog with square frame and message blocks

### DIFF
--- a/app/webapp/core/ErrorView.js
+++ b/app/webapp/core/ErrorView.js
@@ -15,6 +15,15 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
   // full text stays on the Developer Tools Error tab); longer previews are cut.
   const PREVIEW_MAX_LENGTH = 500;
 
+  // The stylesheet that squares off the fatal-error dialog and lays out its
+  // messages. Injected once, on demand - the overlay is the one place that
+  // needs it and a fatal error must not depend on a stylesheet the app may
+  // never load.
+  const STYLE_ID = "z2ui5ErrorViewStyle";
+  const DIALOG_CLASS = "z2ui5ErrorDialog";
+  const MESSAGE_CLASS = "z2ui5ErrorMessage";
+  const HINT_CLASS = "z2ui5ErrorHint";
+
   // Remember the last dialog's inputs so the DeveloperTools can re-show the popup
   // after the user closes the developer tools they opened via its Details action.
   let lastDialogTitle = "";
@@ -147,6 +156,65 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     }
   }
 
+  // The dialog is deliberately square: a fatal error is not a regular popup,
+  // and the sharp frame plus the red rule in front of every message sets it
+  // apart from the app behind it. Colors come from the UI5 theme parameters
+  // (with a literal fallback), so the overlay follows the app theme instead of
+  // hard-coding one. Injected once and best-effort - a browser that refuses
+  // the stylesheet still gets the fully functional, just unstyled, dialog.
+  const DIALOG_STYLES = `
+.${DIALOG_CLASS}.sapMDialog,
+.${DIALOG_CLASS} .sapMDialogTitleGroup,
+.${DIALOG_CLASS} .sapMIBar,
+.${DIALOG_CLASS} .sapMDialogFooter,
+.${DIALOG_CLASS} .sapMDialogScrollCont,
+.${DIALOG_CLASS} .sapMBtnInner {
+  border-radius: 0 !important;
+}
+.${MESSAGE_CLASS} {
+  display: block;
+  margin: 0 0 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+  border-left: 0.1875rem solid var(--sapNegativeColor, #bb0000);
+  background: var(--sapErrorBackground, #ffebeb);
+  color: var(--sapTextColor, #32363a);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.${MESSAGE_CLASS}:last-of-type {
+  margin-bottom: 0;
+}
+.${HINT_CLASS} {
+  display: block;
+  margin-top: 0.75rem;
+  color: var(--sapContent_LabelColor, #6a6d70);
+  font-size: 0.8125rem;
+}
+`;
+
+  function ensureDialogStyles() {
+    try {
+      if (document.getElementById(STYLE_ID)) return;
+      const head = document.head || document.documentElement;
+      if (!head) return;
+      const style = document.createElement("style");
+      style.id = STYLE_ID;
+      style.textContent = DIALOG_STYLES;
+      head.appendChild(style);
+    } catch {
+      // Styling is cosmetic - never let it take the error dialog down.
+    }
+  }
+
+  // addStyleClass comes from sap.ui.core.Control, but the fatal-error path
+  // must survive a half-broken core, so it is called defensively.
+  function withClass(control, className) {
+    if (control && typeof control.addStyleClass === "function") {
+      control.addStyleClass(className);
+    }
+    return control;
+  }
+
   function createContainer() {
     // Always start from a fresh element: reusing a previous overlay would
     // keep its keydown focus-trap listener alive and stack a duplicate on
@@ -155,6 +223,8 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
 
     const container = document.createElement("div");
     container.id = "serverErrorContainer";
+    // Square frame, same as the friendly dialog above - the two are the same
+    // overlay to the user, one just renders without UI5.
     container.style.cssText = `
       position: fixed;
       top: 50%;
@@ -163,12 +233,13 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
       width: 90%;
       height: 90%;
       background: white;
-      border: 2px solid #d32f2f;
-      border-radius: 4px;
-      box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+      border: 1px solid #bb0000;
+      border-radius: 0;
+      box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.25);
       z-index: 9999;
       display: flex;
       flex-direction: column;
+      font-family: "72", "72full", Arial, Helvetica, sans-serif;
     `;
     document.body.appendChild(container);
     return container;
@@ -228,17 +299,39 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
         friendlyDialog.destroy();
         friendlyDialog = null;
       }
+      ensureDialogStyles();
       // Show only the extracted error text; a short neutral fallback covers
       // the rare case where nothing could be extracted.
       const message = buildErrorPreview(details) || "An error occurred.";
-      // A framework preview is one message per line, so the line breaks have
-      // to survive - sap.m.Text normalizes whitespace unless told otherwise.
-      // Set through the mutator and guarded: the property arrived in UI5 1.60
-      // and a control without it must not take the whole dialog down (the
-      // catch below would drop the user to the raw overlay).
-      const messageText = new Text({ text: message });
-      if (typeof messageText.setRenderWhitespace === "function") {
-        messageText.setRenderWhitespace(true);
+      // A framework preview is one message per line: give each message its own
+      // Text so the dialog reads as a list of messages instead of a paragraph.
+      // Dialog.content stacks its controls vertically, so this needs no layout
+      // control - sap.m.Text is the only content type the dialog depends on,
+      // which is what keeps it renderable on a half-broken core.
+      const content = message.split("\n").map((line) => {
+        const text = new Text({ text: line });
+        // A single message can still carry its own indentation (a chain entry
+        // that slipped through), so keep whitespace. Set through the mutator
+        // and guarded: the property arrived in UI5 1.60 and a control without
+        // it must not take the whole dialog down (the catch below would drop
+        // the user to the raw overlay).
+        if (typeof text.setRenderWhitespace === "function") {
+          text.setRenderWhitespace(true);
+        }
+        return withClass(text, MESSAGE_CLASS);
+      });
+      // Everything the popup left out - the exception chain, the source
+      // positions, the system context - is behind Details and in Copy. Say so,
+      // otherwise the shortened popup looks like all there is.
+      if (String(details || "").trim() !== message) {
+        content.push(
+          withClass(
+            new Text({
+              text: "Choose Details for the full technical information.",
+            }),
+            HINT_CLASS,
+          ),
+        );
       }
       // Restart is the primary action, so it also gets the initial focus.
       const restartButton = new Button({
@@ -296,11 +389,16 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
         type: "Message",
         state: "Error",
         icon: "sap-icon://message-error",
+        // Without a width the message dialog sizes itself to the longest
+        // unbreakable run of the error text - a URL or a class name stretches
+        // it across the screen. A fixed content width keeps the box the same
+        // shape whatever the backend sent.
+        contentWidth: "36rem",
         // Escape must not dismiss the fatal-error popup: rejecting the escape
         // promise keeps it open, so the only ways out are the explicit
         // actions built above.
         escapeHandler: (oPromise) => oPromise.reject(),
-        content: [messageText],
+        content,
         buttons,
         initialFocus: restartButton,
         afterClose: () => {
@@ -308,6 +406,7 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
           dialog.destroy();
         },
       });
+      withClass(dialog, DIALOG_CLASS);
       friendlyDialog = dialog;
       dialog.open();
       return true;
@@ -429,16 +528,16 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     // Header bar with title and action buttons.
     const headerDiv = document.createElement("div");
     headerDiv.style.cssText =
-      "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";
+      "padding: 0.75rem 1rem; background: #bb0000; color: white; display: flex; justify-content: space-between; align-items: center; gap: 1rem;";
 
     const h3 = document.createElement("h3");
     h3.id = "serverErrorTitle";
     h3.textContent = title || "Application Error - Please Restart The App";
-    h3.style.cssText = "margin: 0";
+    h3.style.cssText = "margin: 0; font-size: 1rem; font-weight: bold;";
     headerDiv.appendChild(h3);
 
     const btnStyle =
-      "padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;";
+      "padding: 0.375rem 0.875rem; background: white; color: #bb0000; border: 1px solid white; border-radius: 0; cursor: pointer; font: inherit; font-weight: bold; white-space: nowrap;";
 
     const actionsDiv = document.createElement("div");
     actionsDiv.style.cssText = "display: flex; gap: 8px;";
@@ -497,7 +596,7 @@ sap.ui.define(["z2ui5/core/AppState"], (AppState) => {
     const createPre = (ownerDocument) => {
       const pre = ownerDocument.createElement("pre");
       pre.style.cssText =
-        "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";
+        "margin:0;padding:1rem;font-family:monospace;font-size:0.75rem;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;";
       pre.textContent = errorMessage;
       return pre;
     };

--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,14 @@ unreleased
   sections stay one click away behind Details (developer tools Error tab) and in
   Copy, which both carry the untruncated text. Non-framework errors (network,
   client-side, SAP HTML error page) keep the single-line preview
+! Error popup design: a square frame instead of rounded corners, and every
+  message is its own block with a red rule in front of it rather than one run-on
+  paragraph. A fixed content width keeps a long url or class name from stretching
+  the box across the screen, and a hint line below the messages names Details as
+  the way to the exception chain and the system context - the shortened popup no
+  longer looks like all there is. Colors come from the UI5 theme parameters, so
+  the popup follows the app theme; the raw-DOM fallback overlay (shown when the
+  UI5 core itself cannot render) got the same square frame
 * z2ui5_cx_a2ui5_error chains the exception passed as val as its previous. The
   framework's dominant raise pattern (EXPORTING val = x, no previous) used to
   drop everything below x, so the cause of a wrapped error - and its source

--- a/node/tests/errorView.spec.js
+++ b/node/tests/errorView.spec.js
@@ -70,6 +70,13 @@ function load({ ui5 = true } = {}) {
       };
       inst.destroy = () => (inst.destroyed = true);
       inst.focus = () => {};
+      // The dialog and its message/hint texts are styled through style
+      // classes; record them so the tests can assert what got which.
+      inst.classes = [];
+      inst.addStyleClass = (c) => {
+        inst.classes.push(c);
+        return inst;
+      };
       // The Copy button flips its label via setText; mirror it into settings so
       // tests can observe the "Copied" feedback.
       inst.setText = (t) => (inst.settings.text = t);
@@ -141,8 +148,14 @@ test.describe("ErrorView friendly dialog", () => {
     ErrorView.show("some backend dump");
     expect(created.dialogs).toHaveLength(1);
     const dlg = created.dialogs[0].settings;
-    // No "An unexpected error occurred" prefix - just the error text.
+    // No "An unexpected error occurred" prefix - just the error text, and
+    // nothing else: the whole error is shown, so there is no Details hint.
+    expect(dlg.content).toHaveLength(1);
     expect(dlg.content[0].settings.text).toBe("some backend dump");
+    // The squared-off styling is applied to the dialog and to the message.
+    expect(created.dialogs[0].classes).toEqual(["z2ui5ErrorDialog"]);
+    expect(dlg.content[0].classes).toEqual(["z2ui5ErrorMessage"]);
+    expect(dlg.contentWidth).toBe("36rem");
     // The footer uses the `buttons` aggregation: Details / Copy / Restart.
     const [detailsButton, copyButton, restartButton] = dlg.buttons;
     expect(detailsButton.settings.text).toBe("Details");
@@ -225,19 +238,29 @@ test.describe("ErrorView friendly dialog", () => {
       "    user     : SMITH",
     ].join("\n");
     ErrorView.show(dump);
-    const messageControl = created.dialogs[0].settings.content[0];
-    // Only the two messages, kept on separate lines.
-    expect(messageControl.settings.text).toBe(
-      "Request failed in app ZCL_MY_APP, event ONPRESS\n" +
-        "Json parsing error: Not JSON @Line 1, Offset 1",
+    const content = created.dialogs[0].settings.content;
+    // Only the two messages, each one its own Text control.
+    const messages = content.filter((c) =>
+      c.classes.includes("z2ui5ErrorMessage"),
     );
-    // sap.m.Text would collapse those line breaks without this.
-    expect(messageControl.settings.renderWhitespace).toBe(true);
+    expect(messages.map((c) => c.settings.text)).toEqual([
+      "Request failed in app ZCL_MY_APP, event ONPRESS",
+      "Json parsing error: Not JSON @Line 1, Offset 1",
+    ]);
+    // sap.m.Text would collapse the whitespace of a message without this.
+    expect(messages[0].settings.renderWhitespace).toBe(true);
+    // The rest of the dump is not lost, just one click away - the popup says so.
+    const hint = content[content.length - 1];
+    expect(hint.classes).toEqual(["z2ui5ErrorHint"]);
+    expect(hint.settings.text).toBe(
+      "Choose Details for the full technical information.",
+    );
     // Everything else stays behind Details / Copy - and the Error tab keeps
     // the untruncated dump.
-    expect(messageControl.settings.text).not.toContain("abap2UI5");
-    expect(messageControl.settings.text).not.toContain("position");
-    expect(messageControl.settings.text).not.toContain("SMITH");
+    const shown = messages.map((c) => c.settings.text).join("\n");
+    expect(shown).not.toContain("abap2UI5");
+    expect(shown).not.toContain("position");
+    expect(shown).not.toContain("SMITH");
     expect(state.lastError.text).toBe(dump);
   });
 

--- a/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_errorview_js.clas.abap
@@ -42,6 +42,15 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `  // full text stays on the Developer Tools Error tab); longer previews are cut.` && |\n| &&
              `  const PREVIEW_MAX_LENGTH = 500;` && |\n| &&
              `` && |\n| &&
+             `  // The stylesheet that squares off the fatal-error dialog and lays out its` && |\n| &&
+             `  // messages. Injected once, on demand - the overlay is the one place that` && |\n| &&
+             `  // needs it and a fatal error must not depend on a stylesheet the app may` && |\n| &&
+             `  // never load.` && |\n| &&
+             `  const STYLE_ID = "z2ui5ErrorViewStyle";` && |\n| &&
+             `  const DIALOG_CLASS = "z2ui5ErrorDialog";` && |\n| &&
+             `  const MESSAGE_CLASS = "z2ui5ErrorMessage";` && |\n| &&
+             `  const HINT_CLASS = "z2ui5ErrorHint";` && |\n| &&
+             `` && |\n| &&
              `  // Remember the last dialog's inputs so the DeveloperTools can re-show the popup` && |\n| &&
              `  // after the user closes the developer tools they opened via its Details action.` && |\n| &&
              `  let lastDialogTitle = "";` && |\n| &&
@@ -174,6 +183,65 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    }` && |\n| &&
              `  }` && |\n| &&
              `` && |\n| &&
+             `  // The dialog is deliberately square: a fatal error is not a regular popup,` && |\n| &&
+             `  // and the sharp frame plus the red rule in front of every message sets it` && |\n| &&
+             `  // apart from the app behind it. Colors come from the UI5 theme parameters` && |\n| &&
+             `  // (with a literal fallback), so the overlay follows the app theme instead of` && |\n| &&
+             `  // hard-coding one. Injected once and best-effort - a browser that refuses` && |\n| &&
+             `  // the stylesheet still gets the fully functional, just unstyled, dialog.` && |\n| &&
+             `  const DIALOG_STYLES = ``` && |\n| &&
+             `.${DIALOG_CLASS}.sapMDialog,` && |\n| &&
+             `.${DIALOG_CLASS} .sapMDialogTitleGroup,` && |\n| &&
+             `.${DIALOG_CLASS} .sapMIBar,` && |\n| &&
+             `.${DIALOG_CLASS} .sapMDialogFooter,` && |\n| &&
+             `.${DIALOG_CLASS} .sapMDialogScrollCont,` && |\n| &&
+             `.${DIALOG_CLASS} .sapMBtnInner {` && |\n| &&
+             `  border-radius: 0 !important;` && |\n| &&
+             `}` && |\n| &&
+             `.${MESSAGE_CLASS} {` && |\n| &&
+             `  display: block;` && |\n| &&
+             `  margin: 0 0 0.5rem 0;` && |\n| &&
+             `  padding: 0.5rem 0.75rem;` && |\n| &&
+             `  border-left: 0.1875rem solid var(--sapNegativeColor, #bb0000);` && |\n| &&
+             `  background: var(--sapErrorBackground, #ffebeb);` && |\n| &&
+             `  color: var(--sapTextColor, #32363a);` && |\n| &&
+             `  line-height: 1.4;` && |\n| &&
+             `  overflow-wrap: anywhere;` && |\n| &&
+             `}` && |\n| &&
+             `.${MESSAGE_CLASS}:last-of-type {` && |\n| &&
+             `  margin-bottom: 0;` && |\n| &&
+             `}` && |\n| &&
+             `.${HINT_CLASS} {` && |\n| &&
+             `  display: block;` && |\n| &&
+             `  margin-top: 0.75rem;` && |\n| &&
+             `  color: var(--sapContent_LabelColor, #6a6d70);` && |\n| &&
+             `  font-size: 0.8125rem;` && |\n| &&
+             `}` && |\n| &&
+             ```;` && |\n| &&
+             `` && |\n| &&
+             `  function ensureDialogStyles() {` && |\n| &&
+             `    try {` && |\n| &&
+             `      if (document.getElementById(STYLE_ID)) return;` && |\n| &&
+             `      const head = document.head || document.documentElement;` && |\n| &&
+             `      if (!head) return;` && |\n| &&
+             `      const style = document.createElement("style");` && |\n| &&
+             `      style.id = STYLE_ID;` && |\n| &&
+             `      style.textContent = DIALOG_STYLES;` && |\n| &&
+             `      head.appendChild(style);` && |\n| &&
+             `    } catch {` && |\n| &&
+             `      // Styling is cosmetic - never let it take the error dialog down.` && |\n| &&
+             `    }` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
+             `  // addStyleClass comes from sap.ui.core.Control, but the fatal-error path` && |\n| &&
+             `  // must survive a half-broken core, so it is called defensively.` && |\n| &&
+             `  function withClass(control, className) {` && |\n| &&
+             `    if (control && typeof control.addStyleClass === "function") {` && |\n| &&
+             `      control.addStyleClass(className);` && |\n| &&
+             `    }` && |\n| &&
+             `    return control;` && |\n| &&
+             `  }` && |\n| &&
+             `` && |\n| &&
              `  function createContainer() {` && |\n| &&
              `    // Always start from a fresh element: reusing a previous overlay would` && |\n| &&
              `    // keep its keydown focus-trap listener alive and stack a duplicate on` && |\n| &&
@@ -182,6 +250,8 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `` && |\n| &&
              `    const container = document.createElement("div");` && |\n| &&
              `    container.id = "serverErrorContainer";` && |\n| &&
+             `    // Square frame, same as the friendly dialog above - the two are the same` && |\n| &&
+             `    // overlay to the user, one just renders without UI5.` && |\n| &&
              `    container.style.cssText = ``` && |\n| &&
              `      position: fixed;` && |\n| &&
              `      top: 50%;` && |\n| &&
@@ -190,12 +260,13 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `      width: 90%;` && |\n| &&
              `      height: 90%;` && |\n| &&
              `      background: white;` && |\n| &&
-             `      border: 2px solid #d32f2f;` && |\n| &&
-             `      border-radius: 4px;` && |\n| &&
-             `      box-shadow: 0 4px 6px rgba(0,0,0,0.3);` && |\n| &&
+             `      border: 1px solid #bb0000;` && |\n| &&
+             `      border-radius: 0;` && |\n| &&
+             `      box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.25);` && |\n| &&
              `      z-index: 9999;` && |\n| &&
              `      display: flex;` && |\n| &&
              `      flex-direction: column;` && |\n| &&
+             `      font-family: "72", "72full", Arial, Helvetica, sans-serif;` && |\n| &&
              `    ``;` && |\n| &&
              `    document.body.appendChild(container);` && |\n| &&
              `    return container;` && |\n| &&
@@ -255,17 +326,39 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `        friendlyDialog.destroy();` && |\n| &&
              `        friendlyDialog = null;` && |\n| &&
              `      }` && |\n| &&
+             `      ensureDialogStyles();` && |\n| &&
              `      // Show only the extracted error text; a short neutral fallback covers` && |\n| &&
              `      // the rare case where nothing could be extracted.` && |\n| &&
              `      const message = buildErrorPreview(details) || "An error occurred.";` && |\n| &&
-             `      // A framework preview is one message per line, so the line breaks have` && |\n| &&
-             `      // to survive - sap.m.Text normalizes whitespace unless told otherwise.` && |\n| &&
-             `      // Set through the mutator and guarded: the property arrived in UI5 1.60` && |\n| &&
-             `      // and a control without it must not take the whole dialog down (the` && |\n| &&
-             `      // catch below would drop the user to the raw overlay).` && |\n| &&
-             `      const messageText = new Text({ text: message });` && |\n| &&
-             `      if (typeof messageText.setRenderWhitespace === "function") {` && |\n| &&
-             `        messageText.setRenderWhitespace(true);` && |\n| &&
+             `      // A framework preview is one message per line: give each message its own` && |\n| &&
+             `      // Text so the dialog reads as a list of messages instead of a paragraph.` && |\n| &&
+             `      // Dialog.content stacks its controls vertically, so this needs no layout` && |\n| &&
+             `      // control - sap.m.Text is the only content type the dialog depends on,` && |\n| &&
+             `      // which is what keeps it renderable on a half-broken core.` && |\n| &&
+             `      const content = message.split("\n").map((line) => {` && |\n| &&
+             `        const text = new Text({ text: line });` && |\n| &&
+             `        // A single message can still carry its own indentation (a chain entry` && |\n| &&
+             `        // that slipped through), so keep whitespace. Set through the mutator` && |\n| &&
+             `        // and guarded: the property arrived in UI5 1.60 and a control without` && |\n| &&
+             `        // it must not take the whole dialog down (the catch below would drop` && |\n| &&
+             `        // the user to the raw overlay).` && |\n| &&
+             `        if (typeof text.setRenderWhitespace === "function") {` && |\n| &&
+             `          text.setRenderWhitespace(true);` && |\n| &&
+             `        }` && |\n| &&
+             `        return withClass(text, MESSAGE_CLASS);` && |\n| &&
+             `      });` && |\n| &&
+             `      // Everything the popup left out - the exception chain, the source` && |\n| &&
+             `      // positions, the system context - is behind Details and in Copy. Say so,` && |\n| &&
+             `      // otherwise the shortened popup looks like all there is.` && |\n| &&
+             `      if (String(details || "").trim() !== message) {` && |\n| &&
+             `        content.push(` && |\n| &&
+             `          withClass(` && |\n| &&
+             `            new Text({` && |\n| &&
+             `              text: "Choose Details for the full technical information.",` && |\n| &&
+             `            }),` && |\n| &&
+             `            HINT_CLASS,` && |\n| &&
+             `          ),` && |\n| &&
+             `        );` && |\n| &&
              `      }` && |\n| &&
              `      // Restart is the primary action, so it also gets the initial focus.` && |\n| &&
              `      const restartButton = new Button({` && |\n| &&
@@ -323,11 +416,17 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `        type: "Message",` && |\n| &&
              `        state: "Error",` && |\n| &&
              `        icon: "sap-icon://message-error",` && |\n| &&
+             `        // Without a width the message dialog sizes itself to the longest` && |\n| &&
+             `        // unbreakable run of the error text - a URL or a class name stretches` && |\n| &&
+             `        // it across the screen. A fixed content width keeps the box the same` && |\n| &&
+             `        // shape whatever the backend sent.` && |\n| &&
+             `        contentWidth: "36rem",` && |\n| &&
              `        // Escape must not dismiss the fatal-error popup: rejecting the escape` && |\n| &&
              `        // promise keeps it open, so the only ways out are the explicit` && |\n| &&
              `        // actions built above.` && |\n| &&
-             `        escapeHandler: (oPromise) => oPromise.reject(),` && |\n| &&
-             `        content: [messageText],` && |\n| &&
+             `        escapeHandler: (oPromise) => oPromise.reject(),` && |\n|.
+    result = result &&
+             `        content,` && |\n| &&
              `        buttons,` && |\n| &&
              `        initialFocus: restartButton,` && |\n| &&
              `        afterClose: () => {` && |\n| &&
@@ -335,6 +434,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `          dialog.destroy();` && |\n| &&
              `        },` && |\n| &&
              `      });` && |\n| &&
+             `      withClass(dialog, DIALOG_CLASS);` && |\n| &&
              `      friendlyDialog = dialog;` && |\n| &&
              `      dialog.open();` && |\n| &&
              `      return true;` && |\n| &&
@@ -424,8 +524,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    // Record the fatal error so the Developer Tools Error tab can re-show it` && |\n| &&
              `    // (title, text and the same Retry action) after the overlay is gone.` && |\n| &&
              `    AppState.state.lastError = {` && |\n| &&
-             `      title: title || "Application Error - Please Restart The App",` && |\n|.
-    result = result &&
+             `      title: title || "Application Error - Please Restart The App",` && |\n| &&
              `      text: errorMessage,` && |\n| &&
              `      onRetry: typeof options.onRetry === "function" ? options.onRetry : null,` && |\n| &&
              `    };` && |\n| &&
@@ -457,16 +556,16 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    // Header bar with title and action buttons.` && |\n| &&
              `    const headerDiv = document.createElement("div");` && |\n| &&
              `    headerDiv.style.cssText =` && |\n| &&
-             `      "padding: 15px; background: #d32f2f; color: white; display: flex; justify-content: space-between; align-items: center;";` && |\n| &&
+             `      "padding: 0.75rem 1rem; background: #bb0000; color: white; display: flex; justify-content: space-between; align-items: center; gap: 1rem;";` && |\n| &&
              `` && |\n| &&
              `    const h3 = document.createElement("h3");` && |\n| &&
              `    h3.id = "serverErrorTitle";` && |\n| &&
              `    h3.textContent = title || "Application Error - Please Restart The App";` && |\n| &&
-             `    h3.style.cssText = "margin: 0";` && |\n| &&
+             `    h3.style.cssText = "margin: 0; font-size: 1rem; font-weight: bold;";` && |\n| &&
              `    headerDiv.appendChild(h3);` && |\n| &&
              `` && |\n| &&
              `    const btnStyle =` && |\n| &&
-             `      "padding: 6px 14px; background: white; color: #d32f2f; border: none; border-radius: 3px; cursor: pointer; font-weight: bold;";` && |\n| &&
+             `      "padding: 0.375rem 0.875rem; background: white; color: #bb0000; border: 1px solid white; border-radius: 0; cursor: pointer; font: inherit; font-weight: bold; white-space: nowrap;";` && |\n| &&
              `` && |\n| &&
              `    const actionsDiv = document.createElement("div");` && |\n| &&
              `    actionsDiv.style.cssText = "display: flex; gap: 8px;";` && |\n| &&
@@ -525,7 +624,7 @@ CLASS z2ui5_cl_app_errorview_js IMPLEMENTATION.
              `    const createPre = (ownerDocument) => {` && |\n| &&
              `      const pre = ownerDocument.createElement("pre");` && |\n| &&
              `      pre.style.cssText =` && |\n| &&
-             `        "margin:0;padding:8px;font-family:monospace;font-size:12px;white-space:pre-wrap;word-break:break-all;";` && |\n| &&
+             `        "margin:0;padding:1rem;font-family:monospace;font-size:0.75rem;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;";` && |\n| &&
              `      pre.textContent = errorMessage;` && |\n| &&
              `      return pre;` && |\n| &&
              `    };` && |\n| &&


### PR DESCRIPTION
# Description

Redesigns the fatal error dialog UI to improve clarity and visual hierarchy:

- **Square frame instead of rounded corners** for both the UI5-rendered friendly dialog and the raw-DOM fallback overlay, making the error state visually distinct from regular app dialogs
- **Individual message blocks** instead of a single paragraph: each error message gets its own `Text` control with a red left border, better readability for multi-line errors
- **Fixed content width** (`36rem`) to prevent long URLs or class names from stretching the dialog across the screen
- **Hint text** below messages ("Choose Details for the full technical information") when the preview is truncated, clarifying that the full error is available via Details/Copy
- **Theme-aware colors** using UI5 CSS variables (`--sapNegativeColor`, `--sapErrorBackground`, `--sapTextColor`) with fallbacks, so the popup follows the app theme
- **Consistent styling** across both dialogs: injected stylesheet for the friendly dialog, matching inline styles for the raw-DOM fallback
- **Improved typography**: uses the UI5 "72" font family, adjusted padding/spacing to rem units, better line-height for readability

The changes maintain full backward compatibility and graceful degradation—styling is cosmetic and never blocks the error dialog from rendering.

## How to test

1. Run `npm run verify:full` (app/webapp/ changed)
2. Run the error view unit tests: `npm run test -- errorView.spec.js`
3. Manually trigger a fatal error in the app and verify:
   - Dialog has a square frame (no rounded corners)
   - Each error message appears as a separate block with a red left border
   - If error is truncated, a hint line appears below the messages
   - Dialog width is fixed and doesn't stretch with long text
   - Colors match the app theme (or fallback colors if theme unavailable)

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: no

https://claude.ai/code/session_016x1Km3Z8dyTN8BVZYNMW1F