### PR TITLE
Optimize README with a rewritten How It Works section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/abap2UI5/abap2UI5/stargazers"><img src="https://img.shields.io/github/stars/abap2UI5/abap2UI5?style=flat&color=blue" alt="GitHub stars"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/abap2UI5/abap2UI5?color=blue" alt="License: MIT"></a>
+  <img src="https://img.shields.io/badge/ABAP-NW%207.02%20%E2%86%92%20Cloud-blue" alt="ABAP NW 7.02 to ABAP Cloud">
+</p>
+
+<p align="center">
   <a href="https://abap2UI5.org">📚 Documentation</a> •
   <a href="#learn-abap2ui5">🎯 Samples (580+ apps)</a> •
   <a href="https://github.com/abap2UI5/abap2UI5/issues">💬 Issues</a> •
@@ -46,46 +52,68 @@ That's it – your first UI5 app is ready and abap2UI5 handles the rest! 🎉
 
 No system at hand? [**Try abap2UI5 live in your browser**](https://abap2ui5.github.io/web-abap2UI5-build/) – the whole framework runs client-side (transpiled ABAP + sql.js), rebuilt daily from this repo by [web-abap2UI5](https://github.com/abap2UI5/web-abap2UI5).
 
+#### How It Works
+
+Your entire app is **one ABAP class** implementing `z2ui5_if_app`. The framework calls its `main` method on every roundtrip – once at startup and once per user interaction – and your app decides what happens:
+
+```abap
+METHOD z2ui5_if_app~main.
+  IF client->check_on_init( ).
+    view_display( ).   " app start – build a UI5 XML view, bind ABAP variables into it
+  ELSEIF client->check_on_event( ).
+    on_event( ).       " user interaction – bound data already contains the user's input
+  ENDIF.
+ENDMETHOD.
+```
+
+Under the hood, abap2UI5 is a **single-page app**: the browser loads a generic UI5 shell once, then every user interaction becomes one HTTP/JSON roundtrip to ABAP:
+
+```mermaid
+sequenceDiagram
+    participant Browser as Browser (UI5)
+    participant ABAP as Backend (ABAP)
+    Browser->>ABAP: HTTP GET
+    ABAP-->>Browser: HTML + UI5 shell (loaded once)
+    loop every user interaction
+        Browser->>ABAP: POST { event, model changes }
+        Note over ABAP: restore app state<br/>apply two-way bindings<br/>call your app's main( )<br/>persist new state
+        ABAP-->>Browser: { view XML, view model, actions }
+        Note over Browser: UI5 renders the view, binds the model,<br/>waits for the next event
+    end
+```
+
+Between roundtrips the framework does all the plumbing you would otherwise write yourself:
+
+* **State** – your app object is serialized to a draft table and restored on the next request, so attributes simply keep their values between interactions
+* **Two-Way Binding** – `client->_bind( var )` connects an ABAP variable to a UI5 control; user input is written back into the variable before `main` runs, and tables travel as deltas
+* **Events** – `client->_event( 'SAVE' )` wires any UI5 event to a name you check in ABAP with `client->get( )-event`
+* **Rendering** – views are plain UI5 XML built in ABAP with the view builder `z2ui5_cl_ai_xml`; every UI5 control, property, and aggregation is available 1:1
+
+The same protocol also carries popups, navigation, messages, and frontend actions – you never touch JSON, HTTP, or JavaScript yourself.
+
 #### Learn abap2UI5
 
 Three sample repositories, one learning path – from your first app to your full stack:
 
-|      | Repository | What you learn | Where to start |
-|------|------------|----------------|----------------|
+|      | Repository | What you learn |
+|------|------------|----------------|
 | 1️⃣ | [**samples**](https://github.com/abap2UI5/samples) | **the abap2UI5 basics** – bindings, events, popups, navigation, complete apps |
 | 2️⃣ | [**samples-controls**](https://github.com/abap2UI5/samples-controls) | **how to use every UI5 control** – the UI5 Demo Kit rebuilt with abap2UI5 |
 | 3️⃣ | [**samples-stack**](https://github.com/abap2UI5/samples-stack) | **how abap2UI5 plays with your stack** – OData, RAP, WebSockets, the Fiori Launchpad and more |
 
 Every repository ships ready-to-run apps – install with abapGit, click through, read the source.
 
-#### How It Works
-
-abap2UI5 is a **single-page app**. The browser loads a UI5 shell once, then talks to ABAP via JSON roundtrips:
-
-```
- Browser (UI5)                        Backend (ABAP)
-       │                                    │
-       │── GET ────────────────────────────▶│  Returns HTML + UI5 shell
-       │◀── HTML ────────────────────────── │
-       │                                    │
-       │── POST { event, model deltas } ──▶ │  1. Load session draft
-       │                                    │  2. Apply two-way bindings
-       │                                    │  3. Call your app->main( )
-       │                                    │  4. Persist new draft
-       │◀─ { actions (incl. view XML), model } │
-       │                                    │
-       │  (UI5 renders, binds, awaits next event)
-```
-
-You never touch JSON, HTTP, or JavaScript yourself. You implement `z2ui5_if_app~main`, build views with an ABAP XML view builder, and bind ABAP variables to UI5 controls — the framework handles serialization, sessions, and rendering.
-
 #### References
 * Fiori-type Apps built 100% with ABAP [(Logali Group - 23.04.2026)](https://logaligroup.com/magia-en-el-servidor-local-apps-tipo-fiori-creadas-100-con-codigo-abap/)
 * Webinar on Launchpad Integration [(YouTube - 30.07.2025)](https://www.youtube.com/watch?v=t5g3F3PHsbw&list=PLLpkZ_86h4quGSfsjohDHt9CrpjXdeA1P)
 * Featured on SAP Developer News [(YouTube - 21.03.2025)](https://www.youtube.com/watch?v=vKrpkDe2mkU&list=PL6RpkC85SLQAVBSQXN9522_1jNvPavBgg&t=90s)
 * Webinar on Creating UI5 UIs from ABAP with abap2UI5 [(YouTube - 12.12.2024)](https://www.youtube.com/watch?v=N2OAdxf7Lng)
-* Highlighted in the Boring Enterprise Nerdletter [(YouTube)](https://www.youtube.com/watch?v=I81z6W_BTIA&t=1010s) [(Newsletter - 11.12.2024)](https://boringenterprisenerds.substack.com/p/72-abap2ui5-aancos-crystal-ball-sapta)
 * Webinar on Developing UI5 Apps with abap2UI5 [(YouTube - 07.11.2024)](https://www.youtube.com/watch?v=0izPA2xrPPI)
+
+<details>
+<summary>More talks, features & blog posts (2023–2024)</summary>
+
+* Highlighted in the Boring Enterprise Nerdletter [(YouTube)](https://www.youtube.com/watch?v=I81z6W_BTIA&t=1010s) [(Newsletter - 11.12.2024)](https://boringenterprisenerds.substack.com/p/72-abap2ui5-aancos-crystal-ball-sapta)
 * Featured on SAP Developer News [(YouTube - 14.06.2024)](https://youtu.be/7n16u-Rx8IY?t=7)
 * Check out Cust&Code Videos with abap2UI5 [(YouTube - 20.05.2024)](https://www.youtube.com/watch?v=SD1vIt_ty0k)
 * Running abap2UI5 Backend in Browser [(LinkedIn - 02.04.2024)](https://www.linkedin.com/pulse/running-abap2ui5-backend-browser-lars-hvam-petersen-l8zff/?trackingId=4mhMb1v%2FSoa8SmDSiuCEpg%3D%3D)
@@ -96,6 +124,8 @@ You never touch JSON, HTTP, or JavaScript yourself. You implement `z2ui5_if_app~
 * Part of the SAP Developer Code Challenge [(SAP Community - 17.05.2023)](https://groups.community.sap.com/t5/application-development/sap-developer-code-challenge-open-source-abap-week-2/m-p/260727#M1372)
 * Highlighted in the Boring Enterprise Nerdletter [(YouTube)](https://www.youtube.com/watch?v=G62exySitCo&list=PLlxj8-g1r2GlVYXVQnnV5izKwKtEn6KIp&t=1008s) [(Newsletter - 08.03.2023)](https://boringenterprisenerds.substack.com/p/34-abap2ui5-sap-cva-burnout-c2c-shortwave)
 * Featured on SAP Developer News [(YouTube - 26.01.2023)](https://www.youtube.com/watch?v=6BDK55xYttM)
+
+</details>
 
 #### Credits
 This project thrives thanks to its [contributors](https://github.com/abap2UI5/abap2UI5/graphs/contributors) and these awesome tools:


### PR DESCRIPTION
Rework the How It Works section around the actual programming model: show the main() dispatcher lifecycle, replace the ASCII wire diagram with a Mermaid sequence diagram that GitHub renders natively, and list what the framework handles between roundtrips (state, two-way binding, events, rendering).

Also move How It Works directly after Quick Start, drop the empty 'Where to start' column from the learning-path table, add a small badge row, and collapse the 2023-2024 references into a details block so recent ones stay visible.


Claude-Session: https://claude.ai/code/session_01Ra3qweecSc1DdJ7fKjWRnh

# Description

<!-- A clear description of what this PR changes and why the change is needed. -->

## How to test

<!-- Steps to verify the change: app snippet, test to run, or scenario to click through. -->

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no
