### PR TITLE
Optimize rendering and serialization hot paths

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,13 @@ Legend
 
 unreleased
 ----------
+! small performance cleanups in the rendering/serialization hot paths, no
+  behavior change: both view builders concatenate child elements through a
+  string table instead of re-copying the accumulated XML per sibling,
+  z2ui5_cl_ai_xml=>xml_escape no longer builds its escape table on every
+  attribute (chained replaces, same as z2ui5_cl_ui5_view_builder), and the
+  event serializer runs its positional-placeholder regex only for arguments
+  that start with a brace instead of on every argument
 + the src/99 test classes are back and run in CI: all 27 deleted
   testclasses (util, pop, cx) are restored, the two disabled xml_view
   suites are re-enabled, and the pop tests assert against the

--- a/src/01/02/z2ui5_cl_core_srv_event.clas.abap
+++ b/src/01/02/z2ui5_cl_core_srv_event.clas.abap
@@ -281,10 +281,8 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
     REPLACE ALL OCCURRENCES OF z2ui5_cl_a2ui5_context=>cv_char_util_newline IN result WITH `\n`.
     " a standalone CR (not part of CR+LF, already collapsed above) is a JS
     " line terminator too and would break the '...' literal
-    DATA(lv_cr) = substring( val = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf
-                             off = 0
-                             len = 1 ).
-    REPLACE ALL OCCURRENCES OF lv_cr IN result WITH `\r`.
+    REPLACE ALL OCCURRENCES OF z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)
+            IN result WITH `\r`.
 
   ENDMETHOD.
 
@@ -310,9 +308,14 @@ CLASS z2ui5_cl_core_srv_event IMPLEMENTATION.
       " still be quoted - the `{`-raw exception below is only for real
       " bindings/object literals like {/PATH} or {..}. {0/field} (relative
       " binding) keeps a `/` after the digits and is therefore not matched, so
-      " it stays raw as before.
-      FIND REGEX `^\{[0-9]+[?}]` IN lv_new ##REGEX_POSIX.
-      DATA(lv_is_placeholder) = xsdbool( sy-subrc = 0 ).
+      " it stays raw as before. The regex only matters for values starting
+      " with `{` (any other value is quoted by the first condition group
+      " below anyway), so it only runs for those instead of on every argument.
+      DATA(lv_is_placeholder) = abap_false.
+      IF lv_new(1) = `{`.
+        FIND REGEX `^\{[0-9]+[?}]` IN lv_new ##REGEX_POSIX.
+        lv_is_placeholder = xsdbool( sy-subrc = 0 ).
+      ENDIF.
       IF (     lv_new(1) <> `$`
            AND lv_new(1) <> `{`
            AND lv_new NP `.eB(*`

--- a/src/02/z2ui5_cl_ai_xml.clas.abap
+++ b/src/02/z2ui5_cl_ai_xml.clas.abap
@@ -216,10 +216,14 @@ CLASS z2ui5_cl_ai_xml IMPLEMENTATION.
 
   METHOD render.
 
-    DATA(inner) = ``.
+    " collect the children in a table and concatenate once - the string
+    " template accumulator would re-copy everything rendered so far on every
+    " sibling, which grows quadratic on wide views
+    DATA lt_inner TYPE string_table.
     LOOP AT t_child INTO DATA(child).
-      inner = |{ inner }{ child->render( ) }|.
+      INSERT child->render( ) INTO TABLE lt_inner.
     ENDLOOP.
+    DATA(inner) = concat_lines_of( lt_inner ).
 
     " empty builder root - render only the children
     IF name IS INITIAL.
@@ -250,23 +254,37 @@ CLASS z2ui5_cl_ai_xml IMPLEMENTATION.
     " turn a literal LF/CR/TAB into a plain space and silently drop the line
     " breaks of e.g. a two-line noDataText. The char constants come from the
     " context class - the one place allowed to reference cl_abap_char_utilities
-    " (see "Utilities" in AGENTS.md).
-    DATA(lt_escape) = VALUE ty_t_pair(
-        ( n = `&`                                                v = `&amp;` )
-        ( n = `<`                                                v = `&lt;` )
-        ( n = `>`                                                v = `&gt;` )
-        ( n = `"`                                                v = `&quot;` )
-        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_newline        v = `&#xA;` )
-        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)       v = `&#xD;` )
-        ( n = z2ui5_cl_a2ui5_context=>cv_char_util_horizontal_tab v = `&#x9;` ) ).
-
-    result = val.
-    LOOP AT lt_escape INTO DATA(escape).
-      result = replace( val  = result
-                        sub  = escape-n
-                        with = escape-v
-                        occ  = 0 ).
-    ENDLOOP.
+    " (see "Utilities" in AGENTS.md). Chained replaces, no per-call escape
+    " table: this method runs once per attribute of every rendered view
+    " (same implementation as z2ui5_cl_ui5_view_builder=>xml_escape).
+    result = replace( val  = val
+                      sub  = `&`
+                      with = `&amp;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = `<`
+                      with = `&lt;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = `>`
+                      with = `&gt;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = `"`
+                      with = `&quot;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_newline
+                      with = `&#xA;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)
+                      with = `&#xD;`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_horizontal_tab
+                      with = `&#x9;`
+                      occ  = 0 ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_ui5_view_builder.clas.abap
+++ b/src/02/z2ui5_cl_ui5_view_builder.clas.abap
@@ -206,10 +206,14 @@ CLASS z2ui5_cl_ui5_view_builder IMPLEMENTATION.
 
   METHOD render.
 
-    DATA(inner) = ``.
+    " collect the children in a table and concatenate once - the string
+    " template accumulator would re-copy everything rendered so far on every
+    " sibling, which grows quadratic on wide views
+    DATA lt_inner TYPE string_table.
     LOOP AT t_child INTO DATA(child).
-      inner = |{ inner }{ child->render( ) }|.
+      INSERT child->render( ) INTO TABLE lt_inner.
     ENDLOOP.
+    DATA(inner) = concat_lines_of( lt_inner ).
 
     " empty builder root - render only the children
     IF name IS INITIAL.


### PR DESCRIPTION
# Description

This PR contains performance optimizations in the rendering and serialization hot paths with no behavior changes:

1. **View builder rendering**: Both `z2ui5_cl_ai_xml` and `z2ui5_cl_ui5_view_builder` now collect child elements in a string table and concatenate once, instead of re-copying the accumulated XML on every sibling. This eliminates quadratic string growth on wide views.

2. **XML escaping**: `z2ui5_cl_ai_xml=>xml_escape` now uses chained `replace()` calls instead of building an escape table on every invocation. This method runs once per attribute of every rendered view, so the optimization is significant. Implementation now matches `z2ui5_cl_ui5_view_builder=>xml_escape`.

3. **Event serialization**: `z2ui5_cl_core_srv_event` now only runs the positional-placeholder regex for arguments that start with a brace, instead of on every argument. Also simplified substring extraction for CR character handling.

These are targeted optimizations in frequently-called methods with no functional changes.

## How to test

- Existing unit tests cover these methods and should pass without modification
- Render a view with many sibling elements to verify no regression in output
- Run the test suite to confirm all behavior is preserved

## Checklist

- [ ] `npm run verify` passes
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [ ] Public API in `src/02/` unchanged (internal optimizations only)
- [ ] Changes made via abapGit: yes

https://claude.ai/code/session_01XeEdiHePwpVavbzYCQ9EpY