### PR TITLE
Clean up nested view slots when destroying MAIN

### DIFF
--- a/app/webapp/core/ViewSlots.js
+++ b/app/webapp/core/ViewSlots.js
@@ -21,6 +21,9 @@ sap.ui.define(
         // holds its own JSON model - NEST/NEST2 are inserted into
         // the MAIN control tree and inherit theirs by UI5 propagation
         ownsModel: true,
+        // ...and they die with it: destroy() routes these through the same
+        // teardown before MAIN goes down (see there)
+        dependentSlots: ["NEST", "NEST2"],
         prop: "oView",
         controllerProp: "oController",
       },
@@ -169,6 +172,16 @@ sap.ui.define(
     function destroy(key) {
       const slot = byKey(key);
       if (!slot) return;
+      // The nested views live INSIDE the MAIN control tree, so MAIN's
+      // view.destroy() below would cascade to their controls anyway - but
+      // the slot references and the messaging registration would stay
+      // behind, leaving getView("NEST") truthy long after an app switch
+      // (stale shortcut slot scopes, developer tools showing the previous
+      // app's nest XML). Route the dependent slots through this same
+      // teardown first, BEFORE the open-check: it keeps unregisterObject
+      // symmetric to attachSharedModels and clears a stale nest reference
+      // even when MAIN itself is already gone.
+      for (const dep of slot.dependentSlots ?? []) destroy(dep);
       const view = AppState.state[slot.prop];
       if (!view) return;
       if (slot.fragmentId) {

--- a/node/tests/viewSlots.spec.js
+++ b/node/tests/viewSlots.spec.js
@@ -237,4 +237,50 @@ test.describe("destroy", () => {
     ViewSlots.destroy("MAIN");
     expect(unregisterCalls).toEqual([view]);
   });
+
+  test("MAIN teardown also destroys, unregisters and clears the nests", () => {
+    // The nested views sit inside the MAIN control tree - UI5 would destroy
+    // their controls with MAIN either way, but the slot references and the
+    // messaging registrations must not stay behind (an app switch replaces
+    // MAIN without an explicit nest destroy from the backend).
+    const { ViewSlots, z2ui5, unregisterCalls } = load();
+    const calls = [];
+    const mainView = { destroy: () => calls.push("MAIN") };
+    const nestView = { destroy: () => calls.push("NEST") };
+    const nest2View = { destroy: () => calls.push("NEST2") };
+    z2ui5.oView = mainView;
+    z2ui5.oViewNest = nestView;
+    z2ui5.oViewNest2 = nest2View;
+    ViewSlots.destroy("MAIN");
+    // nests leave first - their unregister needs the live view
+    expect(calls).toEqual(["NEST", "NEST2", "MAIN"]);
+    expect(z2ui5.oViewNest).toBeNull();
+    expect(z2ui5.oViewNest2).toBeNull();
+    expect(z2ui5.oView).toBeNull();
+    expect(unregisterCalls).toEqual([nestView, nest2View, mainView]);
+  });
+
+  test("clears a stale nest reference even when MAIN is already gone", () => {
+    const { ViewSlots, z2ui5 } = load();
+    const calls = [];
+    z2ui5.oViewNest = { destroy: () => calls.push("NEST") };
+    ViewSlots.destroy("MAIN");
+    expect(calls).toEqual(["NEST"]);
+    expect(z2ui5.oViewNest).toBeNull();
+  });
+
+  test("destroying a nest directly leaves MAIN and the other nest alone", () => {
+    const { ViewSlots, z2ui5 } = load();
+    const calls = [];
+    const mainView = { destroy: () => calls.push("MAIN") };
+    const nest2View = { destroy: () => calls.push("NEST2") };
+    z2ui5.oView = mainView;
+    z2ui5.oViewNest = { destroy: () => calls.push("NEST") };
+    z2ui5.oViewNest2 = nest2View;
+    ViewSlots.destroy("NEST");
+    expect(calls).toEqual(["NEST"]);
+    expect(z2ui5.oViewNest).toBeNull();
+    expect(z2ui5.oView).toBe(mainView);
+    expect(z2ui5.oViewNest2).toBe(nest2View);
+  });
 });

--- a/src/01/03/z2ui5_cl_app_viewslots_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_viewslots_js.clas.abap
@@ -48,6 +48,9 @@ CLASS z2ui5_cl_app_viewslots_js IMPLEMENTATION.
              `        // holds its own JSON model - NEST/NEST2 are inserted into` && |\n| &&
              `        // the MAIN control tree and inherit theirs by UI5 propagation` && |\n| &&
              `        ownsModel: true,` && |\n| &&
+             `        // ...and they die with it: destroy() routes these through the same` && |\n| &&
+             `        // teardown before MAIN goes down (see there)` && |\n| &&
+             `        dependentSlots: ["NEST", "NEST2"],` && |\n| &&
              `        prop: "oView",` && |\n| &&
              `        controllerProp: "oController",` && |\n| &&
              `      },` && |\n| &&
@@ -196,6 +199,16 @@ CLASS z2ui5_cl_app_viewslots_js IMPLEMENTATION.
              `    function destroy(key) {` && |\n| &&
              `      const slot = byKey(key);` && |\n| &&
              `      if (!slot) return;` && |\n| &&
+             `      // The nested views live INSIDE the MAIN control tree, so MAIN's` && |\n| &&
+             `      // view.destroy() below would cascade to their controls anyway - but` && |\n| &&
+             `      // the slot references and the messaging registration would stay` && |\n| &&
+             `      // behind, leaving getView("NEST") truthy long after an app switch` && |\n| &&
+             `      // (stale shortcut slot scopes, developer tools showing the previous` && |\n| &&
+             `      // app's nest XML). Route the dependent slots through this same` && |\n| &&
+             `      // teardown first, BEFORE the open-check: it keeps unregisterObject` && |\n| &&
+             `      // symmetric to attachSharedModels and clears a stale nest reference` && |\n| &&
+             `      // even when MAIN itself is already gone.` && |\n| &&
+             `      for (const dep of slot.dependentSlots ?? []) destroy(dep);` && |\n| &&
              `      const view = AppState.state[slot.prop];` && |\n| &&
              `      if (!view) return;` && |\n| &&
              `      if (slot.fragmentId) {` && |\n| &&


### PR DESCRIPTION
# Description

When the MAIN view slot is destroyed (typically during an app switch), nested view slots (NEST, NEST2) must also be properly cleaned up. Previously, while UI5 would cascade the control destruction, the slot references and messaging registrations would remain, leaving stale references that could cause issues.

This change ensures that:
1. Nested slots are destroyed before MAIN, allowing their unregister handlers to access the live view
2. Slot references are cleared even if MAIN is already gone
3. Direct destruction of a nested slot only affects that slot, leaving MAIN and other nests intact

The implementation adds a `dependentSlots` configuration to the MAIN slot and routes dependent slots through the same teardown logic before destroying the parent.

## How to test

The change is covered by three new unit tests in `viewSlots.spec.js`:
- "MAIN teardown also destroys, unregisters and clears the nests" - verifies cascading destruction order and cleanup
- "clears a stale nest reference even when MAIN is already gone" - verifies robustness when parent is missing
- "destroying a nest directly leaves MAIN and the other nest alone" - verifies isolation of direct nest destruction

Run `npm run verify` to confirm all tests pass.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01JCTJJGc3XJYDzHtjJPjW1u