### PR TITLE
Close popups/popovers when displaying a new MAIN view

### DIFF
--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -108,7 +108,8 @@ sap.ui.define(
           // it is pushed to. This reaches what a fresh build alone does not:
           // a nested view re-displayed without its MAIN view (it inherits the
           // MAIN model by UI5 propagation) and a popup left open across a
-          // MAIN rebuild.
+          // roundtrip that rebuilt no view (one that DOES rebuild MAIN takes
+          // the standalone slots down with it - see actions/Slots).
           if (oResponse.MODELPRESENT) Slots.action("updateModel");
           // Phase 2: ONE history/hash sync per response. A ROUTER action only
           // travels when the roundtrip carries nav intent - its options were

--- a/app/webapp/core/actions/Slots.js
+++ b/app/webapp/core/actions/Slots.js
@@ -308,6 +308,17 @@ sap.ui.define(
           // slip past displayView's "a newer view took the slot" guard and
           // then crash THIS build on a duplicate id.
           ViewSlots.destroy("MAIN");
+          // A new MAIN view means a new screen, so the two STANDALONE slots
+          // go with it. They live outside the MAIN control tree and would
+          // otherwise float on top of a page they no longer belong to - a
+          // dialog of the previous screen over the new one. The backend
+          // relies on this and sends no destroy action for them next to a
+          // MAIN display (z2ui5_cl_core_action_front=>slots_serialize). A
+          // popup/popover the SAME response opens still opens: slot actions
+          // are serialized MAIN first, and each one is awaited before the
+          // next runs (View1._runSystemActions).
+          ViewSlots.destroy("POPUP");
+          ViewSlots.destroy("POPOVER");
           return displayView(
             xml,
             AppState.state.oResponse?.OVIEWMODEL,

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -268,6 +268,12 @@ ships for existing apps but is **frozen** — new apps and new code use
   never build your own toast/dialog for these.
 - Bind popup data exactly like main-view data; changed bound data reaches
   an open popup automatically.
+- A popup or popover is closed automatically by anything that replaces the
+  screen underneath it: a `client->view_display( )` in the same roundtrip
+  and a navigation to another app both take it down. Re-open it in that same
+  roundtrip if it is meant to stay — `view_display( )` first, then
+  `popup_display( )` — and call `popup_destroy( )` only when you close it
+  without rebuilding the view.
 
 ## 7. Multi-view, navigation, routing
 

--- a/node/tests/view1Events.spec.js
+++ b/node/tests/view1Events.spec.js
@@ -256,3 +256,80 @@ test.describe("_processAfterRendering (action-free responses)", () => {
     expect(syncs).toEqual([{ setNavRouting: "KEEP", id: "D3" }]);
   });
 });
+
+test.describe("a MAIN display takes the standalone slots with it", () => {
+  // A new main view is a new screen: POPUP and POPOVER live OUTSIDE the MAIN
+  // control tree, so nothing else closes them - a dialog of the previous
+  // screen would float on top of the new one. The backend relies on this and
+  // sends no teardown for them next to a MAIN display.
+  function loadSlots(requestSeq) {
+    const destroyed = [];
+    const pages = [];
+    const oView = { destroy: () => {} };
+    function JSONModel() {
+      this.attachPropertyChange = () => {};
+      this.destroy = () => {};
+      this.setSizeLimit = () => {};
+    }
+    const { module: Slots } = loadModule("core/actions/Slots.js", {
+      deps: {
+        "sap/ui/core/mvc/XMLView": { create: async () => oView },
+        "sap/ui/model/json/JSONModel": JSONModel,
+        "z2ui5/core/Server": { _requestSeq: requestSeq },
+        "z2ui5/core/Lib": {
+          effectiveSizeLimit: () => undefined,
+          isAlive: () => true,
+          logError: () => {},
+        },
+        "z2ui5/core/ViewSlots": {
+          slots: [],
+          getView: () => undefined,
+          getController: () => undefined,
+          setView: () => {},
+          destroy: (key) => destroyed.push(key),
+        },
+        "z2ui5/core/AppState": {
+          state: {
+            viewSizeLimits: {},
+            oApp: {
+              removeAllPages: () => {},
+              insertPage: (v) => pages.push(v),
+            },
+          },
+        },
+      },
+    });
+    return { Slots, destroyed, pages, oView };
+  }
+
+  test("displaying MAIN destroys MAIN, POPUP and POPOVER", async () => {
+    const { Slots, destroyed, pages, oView } = loadSlots(1);
+
+    await Slots.action("display", "MAIN", "<View/>", {}, 1);
+
+    expect(destroyed).toEqual(["MAIN", "POPUP", "POPOVER"]);
+    // the teardown is part of the build, not something that replaced it
+    expect(pages).toEqual([oView]);
+  });
+
+  test("displaying a POPUP leaves the other slots alone", async () => {
+    const { Slots, destroyed } = loadSlots(1);
+
+    // every display tears its OWN slot down first - it replaces it - but
+    // only MAIN stands for a whole new screen
+    await Slots.action("display", "POPUP", "<Dialog/>", {}, 1).catch(() => {});
+
+    expect(destroyed).toEqual(["POPUP"]);
+  });
+
+  test("a superseded MAIN display tears nothing down", async () => {
+    const { Slots, destroyed } = loadSlots(2);
+
+    // a newer parallel request already claimed the screen: this build is
+    // dropped before the teardown, so it cannot close a popup the newer
+    // response opened
+    await Slots.action("display", "MAIN", "<View/>", {}, 1);
+
+    expect(destroyed).toEqual([]);
+  });
+});

--- a/src/01/02/z2ui5_cl_core_action.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.abap
@@ -305,6 +305,10 @@ CLASS z2ui5_cl_core_action IMPLEMENTATION.
     " ANOTHER INSTANCE OF THE SAME CLASS - only then the teardown is queued
     " here, before the called app runs its main( ), so its own
     " popup_display( ) still replaces the destroy through slot_reset( ).
+    " Both directions pass through here (call and leave alike), so this is
+    " the ONE place that decides it - a back-navigation must not queue a
+    " teardown of its own on top, or every cross-class Back would carry two
+    " destroy actions for slots the frontend had already torn down.
     IF mo_app->mo_app IS BOUND
         AND z2ui5_cl_a2ui5_context=>rtti_get_classname_by_ref( val )
           = z2ui5_cl_a2ui5_context=>rtti_get_classname_by_ref( mo_app->mo_app ).

--- a/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action.clas.testclasses.abap
@@ -34,6 +34,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_stack_call         FOR TESTING RAISING cx_static_check.
     METHODS test_stack_call_cross_class FOR TESTING RAISING cx_static_check.
     METHODS test_stack_leave        FOR TESTING RAISING cx_static_check.
+    METHODS test_stack_leave_cross_class FOR TESTING RAISING cx_static_check.
     METHODS test_stack_leave_fresh_target FOR TESTING RAISING cx_static_check.
     METHODS test_stack_leave_ancestor_gone FOR TESTING RAISING cx_static_check.
     METHODS test_nav_mode_inherited FOR TESTING RAISING cx_static_check.
@@ -367,6 +368,32 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = `POPOVER|destroy`
                                         act = |{ lo_result->ms_next-t_action_front[ 2 ]-slot }\|| &&
                                               |{ lo_result->ms_next-t_action_front[ 2 ]-method }| ).
+
+  ENDMETHOD.
+
+  METHOD test_stack_leave_cross_class.
+
+    DATA lo_http TYPE REF TO z2ui5_cl_core_handler.
+    DATA lo_action TYPE REF TO z2ui5_cl_core_action.
+    DATA lo_result TYPE REF TO z2ui5_cl_core_action.
+
+    lo_http = NEW #( val = `` ).
+
+    lo_action = NEW #( val = lo_http ).
+    lo_action->mo_app->mo_app = NEW ltcl_test_app( ).
+    lo_action->mo_app->ms_draft-id = `CURRENT_DRAFT`.
+
+    " back-navigation to a DIFFERENT class - the response names another app,
+    " so the frontend tears the standalone slots down by itself (View1) and
+    " nothing about them travels. The back-navigation event does not queue a
+    " teardown of its own either (z2ui5_cl_core_handler=>main_process): every
+    " app switch ends up here, and this is the only place that knows whether
+    " the frontend can see it
+    lo_action->ms_next-o_app_leave = NEW ltcl_test_app2( ).
+
+    lo_result = lo_action->factory_stack_leave( ).
+
+    cl_abap_unit_assert=>assert_initial( lo_result->ms_next-t_action_front ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_action_front.clas.abap
+++ b/src/01/02/z2ui5_cl_core_action_front.clas.abap
@@ -344,6 +344,25 @@ CLASS z2ui5_cl_core_action_front IMPLEMENTATION.
 
   METHOD slots_serialize.
 
+    " A new MAIN view is a new screen, and the frontend takes the two
+    " STANDALONE slots down with it (actions/Slots displayMain) - they live
+    " outside the MAIN control tree and would otherwise float on top of a
+    " page they no longer belong to. So a destroy for them next to a MAIN
+    " display describes something that has already happened by the time it
+    " would run: it is dropped here instead of travelling with every
+    " roundtrip that rebuilds the view. Their DISPLAYS are untouched - the
+    " slot order below puts them behind MAIN, and each action is awaited
+    " before the next runs, so a popup this roundtrip opens still opens.
+    DATA(lv_main_displayed) = xsdbool( line_exists(
+        mo_action->ms_next-t_action_front[ slot   = z2ui5_if_client=>cs_view-main
+                                           method = z2ui5_if_core_types=>cs_slot_action-display ] ) ).
+    IF lv_main_displayed = abap_true.
+      DELETE mo_action->ms_next-t_action_front
+             WHERE method = z2ui5_if_core_types=>cs_slot_action-destroy
+               AND ( slot = z2ui5_if_client=>cs_view-popup
+                  OR slot = z2ui5_if_client=>cs_view-popover ).
+    ENDIF.
+
     " The view-lifecycle calls leave in SLOT order, never in the order the
     " app happened to make them - see the ABAP Doc.
     LOOP AT VALUE string_table( ( z2ui5_if_client=>cs_view-main )

--- a/src/01/02/z2ui5_cl_core_action_front.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_action_front.clas.testclasses.abap
@@ -17,8 +17,18 @@ CLASS ltcl_test_action_front DEFINITION FINAL
     METHODS test_box_icon_none        FOR TESTING RAISING cx_static_check.
     METHODS test_box_actions          FOR TESTING RAISING cx_static_check.
     METHODS test_box_msg_table_empty  FOR TESTING RAISING cx_static_check.
+    METHODS test_main_drops_teardowns FOR TESTING RAISING cx_static_check.
+    METHODS test_main_keeps_displays  FOR TESTING RAISING cx_static_check.
+    METHODS test_teardowns_no_main    FOR TESTING RAISING cx_static_check.
 
     METHODS queued
+      RETURNING
+        VALUE(result) TYPE string
+      RAISING
+        z2ui5_cx_ajson_error.
+
+    "! the SYSTEM actions the serialization produced, pipe-joined
+    METHODS serialized
       RETURNING
         VALUE(result) TYPE string
       RAISING
@@ -169,6 +179,64 @@ CLASS ltcl_test_action_front IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_initial(
         mo_action->ms_next-s_action-t_custom ).
+
+  ENDMETHOD.
+
+  METHOD serialized.
+
+    mo_cut->slots_serialize( ).
+
+    LOOP AT mo_action->ms_next-s_action-t_system INTO DATA(ls_action).
+      IF result IS NOT INITIAL.
+        result = result && `|`.
+      ENDIF.
+      result = result && ls_action-o_json->stringify( ).
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD test_main_drops_teardowns.
+
+    " a new MAIN view takes the standalone slots down on the frontend
+    " (actions/Slots), so their teardown is not sent next to it - whoever
+    " queued it: the app itself here, prepare_app_stack on an app switch
+    mo_cut->slot_destroy( z2ui5_if_client=>cs_view-popup ).
+    mo_cut->slot_destroy( z2ui5_if_client=>cs_view-popover ).
+    mo_cut->slot_display( slot = z2ui5_if_client=>cs_view-main
+                          xml  = `<View/>` ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["VIEW_SLOTS","display","MAIN","<View/>"]`
+        act = serialized( ) ).
+
+  ENDMETHOD.
+
+  METHOD test_main_keeps_displays.
+
+    " only the TEARDOWNS are derivable from the MAIN display - a popup this
+    " roundtrip opens still travels, and behind MAIN, so it opens on the new
+    " view instead of being torn down with the old one
+    mo_cut->slot_display( slot = z2ui5_if_client=>cs_view-popup
+                          xml  = `<Dialog/>` ).
+    mo_cut->slot_display( slot = z2ui5_if_client=>cs_view-main
+                          xml  = `<View/>` ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["VIEW_SLOTS","display","MAIN","<View/>"]|["VIEW_SLOTS","display","POPUP","<Dialog/>"]`
+        act = serialized( ) ).
+
+  ENDMETHOD.
+
+  METHOD test_teardowns_no_main.
+
+    " without a MAIN display nothing tears the standalone slots down on the
+    " frontend, so the teardown has to travel
+    mo_cut->slot_destroy( z2ui5_if_client=>cs_view-popup ).
+    mo_cut->slot_destroy( z2ui5_if_client=>cs_view-popover ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["VIEW_SLOTS","destroy","POPUP"]|["VIEW_SLOTS","destroy","POPOVER"]`
+        act = serialized( ) ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -806,8 +806,8 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     " the push - the frontend pushes into every open model-owning slot after
     " the system actions ran (View1). That covers the nested re-display
     " (inherits the MAIN model by propagation - three-column samples) and a
-    " popup left open across a MAIN rebuild alike, without spelling a
-    " derivable instruction into every model-carrying response.
+    " popup left open across a roundtrip that rebuilt no view alike, without
+    " spelling a derivable instruction into every model-carrying response.
 
     " last of all, so the route reflects everything this roundtrip did - the
     " slots that were built and the model that was pushed into them. Queued

--- a/src/01/02/z2ui5_cl_core_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_core_handler.clas.abap
@@ -857,10 +857,12 @@ CLASS z2ui5_cl_core_handler IMPLEMENTATION.
     " to the single top-level catch in z2ui5_cl_http_handler=>_main( ), which
     " turns them into a 500 response carrying the exception text
     IF mo_action->ms_actual-event = z2ui5_if_core_types=>cs_event_nav_app_leave.
-      li_client->popup_destroy( ).
-      " a popover floats next to the MAIN view exactly like a popup and
-      " survives the view replacement the same way - close it too
-      li_client->popover_destroy( ).
+      " no popup/popover teardown is queued here: the standalone slots die on
+      " every app switch anyway - implicitly on the frontend whenever the
+      " response names another app (View1), and through prepare_app_stack for
+      " the one hop the frontend cannot see, to another instance of the SAME
+      " class. Queuing it here on top only made the back-navigation response
+      " carry two destroy actions the frontend had already done itself
       li_client->nav_app_leave( ).
     ELSE.
       li_app->main( li_client ).

--- a/src/01/03/z2ui5_cl_app_slots_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_slots_js.clas.abap
@@ -335,6 +335,17 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `          // slip past displayView's "a newer view took the slot" guard and` && |\n| &&
              `          // then crash THIS build on a duplicate id.` && |\n| &&
              `          ViewSlots.destroy("MAIN");` && |\n| &&
+             `          // A new MAIN view means a new screen, so the two STANDALONE slots` && |\n| &&
+             `          // go with it. They live outside the MAIN control tree and would` && |\n| &&
+             `          // otherwise float on top of a page they no longer belong to - a` && |\n| &&
+             `          // dialog of the previous screen over the new one. The backend` && |\n| &&
+             `          // relies on this and sends no destroy action for them next to a` && |\n| &&
+             `          // MAIN display (z2ui5_cl_core_action_front=>slots_serialize). A` && |\n| &&
+             `          // popup/popover the SAME response opens still opens: slot actions` && |\n| &&
+             `          // are serialized MAIN first, and each one is awaited before the` && |\n| &&
+             `          // next runs (View1._runSystemActions).` && |\n| &&
+             `          ViewSlots.destroy("POPUP");` && |\n| &&
+             `          ViewSlots.destroy("POPOVER");` && |\n| &&
              `          return displayView(` && |\n| &&
              `            xml,` && |\n| &&
              `            AppState.state.oResponse?.OVIEWMODEL,` && |\n| &&
@@ -413,7 +424,8 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `    // resolveTrackedModel is what eB's model pick needs (View1.controller).` && |\n| &&
              `    // Everything else on this file is internal to the display machinery.` && |\n| &&
              `    return {` && |\n| &&
-             `      action,` && |\n| &&
+             `      action,` && |\n|.
+    result = result &&
              `      resolveTrackedModel,` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_view1_js.clas.abap
@@ -135,7 +135,8 @@ CLASS z2ui5_cl_app_view1_js IMPLEMENTATION.
              `          // it is pushed to. This reaches what a fresh build alone does not:` && |\n| &&
              `          // a nested view re-displayed without its MAIN view (it inherits the` && |\n| &&
              `          // MAIN model by UI5 propagation) and a popup left open across a` && |\n| &&
-             `          // MAIN rebuild.` && |\n| &&
+             `          // roundtrip that rebuilt no view (one that DOES rebuild MAIN takes` && |\n| &&
+             `          // the standalone slots down with it - see actions/Slots).` && |\n| &&
              `          if (oResponse.MODELPRESENT) Slots.action("updateModel");` && |\n| &&
              `          // Phase 2: ONE history/hash sync per response. A ROUTER action only` && |\n| &&
              `          // travels when the roundtrip carries nav intent - its options were` && |\n| &&

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -131,6 +131,9 @@ INTERFACE z2ui5_if_client
 
   METHODS view_destroy.
 
+  "! Display the MAIN view. A new main view is a new screen, so an open
+  "! popup and popover go with it - re-open one in the same roundtrip if it
+  "! is meant to survive ( the frontend builds MAIN first, then the popup ).
   METHODS view_display
     IMPORTING
       val                           TYPE clike


### PR DESCRIPTION
## Description

When a new MAIN view is displayed, it represents a new screen. Popups and popovers are standalone UI elements that live outside the MAIN control tree and would otherwise float on top of the new screen, creating a confusing UX where dialogs from the previous screen appear over the new one.

This change implements automatic cleanup of standalone slots (POPUP and POPOVER) when a new MAIN view is displayed:

- **Frontend (Slots.js)**: When `displayMain` is called, it now explicitly destroys POPUP and POPOVER slots before displaying the new view
- **Backend (z2ui5_cl_core_action_front)**: The `slots_serialize` method now omits destroy actions for POPUP and POPOVER when a MAIN display is present in the same response, since the frontend handles this automatically
- **Handler cleanup**: Removed redundant popup/popover destroy calls from the app-leave navigation handler, as the frontend now handles this implicitly on every app switch
- **Documentation**: Updated API docs and code comments to clarify this behavior

The key insight is that this cleanup happens on the frontend automatically whenever a new MAIN view is displayed, so the backend doesn't need to send explicit destroy actions for these slots in that case. However, if a popup/popover is opened in the same roundtrip as the MAIN display, it still opens correctly because slot actions are serialized with MAIN first and each is awaited before the next runs.

## How to test

- Run `npm run verify:full` (app/webapp/ changed)
- Run `npm run verify` for ABAP tests
- New unit tests added in:
  - `node/tests/view1Events.spec.js`: Tests for standalone slot cleanup on MAIN display
  - `z2ui5_cl_core_action_front.clas.testclasses.abap`: Tests for serialization logic
  - `z2ui5_cl_core_action.clas.testclasses.abap`: Test for cross-class navigation

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively (added documentation to `view_display`)
- [x] Changes were made via abapGit: no (manual ABAP edits in testclasses and implementation)

https://claude.ai/code/session_015WFibwo3PX1pHg7LM2Fpym