### PR TITLE
feat: add get_event( ) shortcut to the client interface

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -22,7 +22,7 @@ Quick orientation while it loads:
   `_bind_edit` is obsolete). Row-template fields bind as `` `{UPPERCASE}` ``.
   Never write a model path as a text literal.
 - Events: `client->_event( `NAME` )`, dispatch via
-  `CASE client->get( )-event.`; client-resolved args are `$`-prefixed.
+  `CASE client->get_event( ).`; client-resolved args are `$`-prefixed.
   Push data changes with `client->view_model_update( )`.
 - Business logic is computed in ABAP, never in frontend formatters (thin
   frontend). UI5 1.71 is the compatibility floor — check "available since".

--- a/.github/api-snapshot.json
+++ b/.github/api-snapshot.json
@@ -79,6 +79,7 @@
   "z2ui5_if_client.intf.abap#methods:popover_display": "methods popover_display importing xml type clike by_id type clike",
   "z2ui5_if_client.intf.abap#methods:popover_destroy": "methods popover_destroy",
   "z2ui5_if_client.intf.abap#methods:get": "methods get returning value(result) type z2ui5_if_types=>ty_s_get",
+  "z2ui5_if_client.intf.abap#methods:get_event": "methods get_event returning value(result) type string",
   "z2ui5_if_client.intf.abap#methods:get_event_arg": "methods get_event_arg importing v type i default 1 returning value(result) type string",
   "z2ui5_if_client.intf.abap#methods:get_app": "methods get_app importing id type clike optional returning value(result) type ref to z2ui5_if_app",
   "z2ui5_if_client.intf.abap#methods:_event_nav_app_leave": "methods _event_nav_app_leave returning value(result) type string",

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -102,7 +102,7 @@ CLASS zcl_my_app IMPLEMENTATION.
 
   METHOD on_event.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
       WHEN `SAVE`.
         " bound data (name, t_items) already carries the user's input here,
         " and the changed model is pushed back automatically
@@ -122,7 +122,7 @@ ENDCLASS.
 Conventions that keep apps uniform (proven in the samples-controls corpus):
 `main` is a pure dispatcher; methods follow in call order with `model_init`
 last; add `model_init`/`on_event` only when the app has data/events; always
-dispatch events with `CASE client->get( )-event.` even for a single event.
+dispatch events with `CASE client->get_event( ).` even for a single event.
 **The `check_on_navigated( )` branch is part of the canonical dispatcher, not
 an option**: without it the view is only ever built on `check_on_init`, so
 navigating away (`nav_app_call`) and back leaves the app blank — the
@@ -220,7 +220,7 @@ ships for existing apps but is **frozen** — new apps and new code use
 ## 5. Events
 
 - Wire: `)->a( n = `press` v = client->_event( `SAVE` ) )`.
-- Read in `on_event` via `CASE client->get( )-event.`.
+- Read in `on_event` via `CASE client->get_event( ).`.
 - **Pass values into an event** with `t_arg`; read them back with
   `client->get_event_arg( )` (index only for position 2+). A value resolved
   on the client must be `$`-prefixed — `` `${PRODUCT}` `` (row field),

--- a/node/srv/zcl_tst_nav_hub.clas.abap
+++ b/node/srv/zcl_tst_nav_hub.clas.abap
@@ -26,7 +26,7 @@ CLASS zcl_tst_nav_hub IMPLEMENTATION.
       view_display( ).
 
     ELSEIF client->check_on_event( ) IS NOT INITIAL.
-      CASE client->get( )-event.
+      CASE client->get_event( ).
         WHEN `INC`.
           counter = counter + 1.
           view_display( ).

--- a/node/srv/zcl_tst_nav_hub_keep.clas.abap
+++ b/node/srv/zcl_tst_nav_hub_keep.clas.abap
@@ -26,7 +26,7 @@ CLASS zcl_tst_nav_hub_keep IMPLEMENTATION.
       view_display( ).
 
     ELSEIF client->check_on_event( ) IS NOT INITIAL.
-      CASE client->get( )-event.
+      CASE client->get_event( ).
         WHEN `INC`.
           counter = counter + 1.
           view_display( ).

--- a/src/01/02/z2ui5_cl_core_client.clas.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.abap
@@ -154,6 +154,13 @@ CLASS z2ui5_cl_core_client IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD z2ui5_if_client~get_event.
+
+    result = mo_action->ms_actual-event.
+
+  ENDMETHOD.
+
+
   METHOD z2ui5_if_client~get_event_arg.
 
     TRY.

--- a/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_core_client.clas.testclasses.abap
@@ -67,6 +67,7 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_nav_leave_r_data_unbound FOR TESTING RAISING cx_static_check.
     METHODS test_check_app_prev_stack FOR TESTING RAISING cx_static_check.
     METHODS test_set_push_state       FOR TESTING RAISING cx_static_check.
+    METHODS test_get_event            FOR TESTING RAISING cx_static_check.
     METHODS test_get_event_arg        FOR TESTING RAISING cx_static_check.
     METHODS test_set_app_state_active FOR TESTING RAISING cx_static_check.
     METHODS test_omit_initial_paths   FOR TESTING RAISING cx_static_check.
@@ -754,6 +755,20 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = `mystate`
                                         act = mo_action->ms_next-s_nav-set_push_state ).
+
+  ENDMETHOD.
+
+
+  METHOD test_get_event.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+
+    mo_action->ms_actual-event = `BUTTON_PRESS`.
+
+    li_client ?= mo_client.
+
+    cl_abap_unit_assert=>assert_equals( exp = `BUTTON_PRESS`
+                                        act = li_client->get_event( ) ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -131,7 +131,7 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
 
     DATA li_app_config TYPE REF TO z2ui5_if_app.
 
-    CASE client->get( )-event.
+    CASE client->get_event( ).
 
       WHEN cs_event-set_config.
         CREATE OBJECT li_app_config TYPE (`Z2UI5_CL_APP_ICF_CONFIG`).

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -211,6 +211,13 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE z2ui5_if_types=>ty_s_get.
 
+  "! The name of the event that triggered this roundtrip - empty when no
+  "! event is being handled (e.g. on the initial call). Shortcut for
+  "! get( )-event, made for the dispatcher idiom CASE client->get_event( ).
+  METHODS get_event
+    RETURNING
+      VALUE(result) TYPE string.
+
   METHODS get_event_arg
     IMPORTING
       v             TYPE i DEFAULT 1


### PR DESCRIPTION
Reading the triggering event is by far the most common client call
(CASE client->get( )-event. in every dispatcher), yet it required
fetching the whole ty_s_get structure. Add a dedicated accessor,
analogous to the existing get_event_arg( ):

- z2ui5_if_client: new method get_event returning the event name
- z2ui5_cl_core_client: implementation + unit test
- API snapshot regenerated for the new public symbol
- docs (building-apps guide, build-an-app skill) and in-repo
  consumers (startup app, node test apps) switched to the new call;
  the frozen src/99 package is untouched

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016KuvJ2RAaZWi32pqbxjncD