### PR TITLE
Say in the interface that _event_client( ) is obsolete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,7 +623,9 @@ The following items may look like gaps but are intentional design choices:
   action object** with a clean, designed surface (e.g. reachable from the
   client, grouping toast/control/binding/keyboard actions). The idea is being
   observed against real usage first; the design comes later. Until then the
-  generic `follow_up_action` / `_event_client` remain the only API — do not
+  generic `follow_up_action` — as a statement to schedule an action, written
+  where its result is consumed to wire one — remains the only API (its
+  obsolete second name for the wired half is `_event_client`); do not
   re-introduce per-method wrappers on `z2ui5_if_client`. The reverted
   implementation (interface docs, delegations, byte-identity tests) is
   preserved in git history (`f1a1813`, reverted by `208b7ec`) and in the

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,22 @@ Legend
 
 unreleased
 ----------
+! _event_client( ) is obsolete - follow_up_action( ) is the same call in the
+  same position now, and the interface says so. Since follow_up_action( ) has
+  a RETURNING parameter, a call whose result is CONSUMED (the view-attribute
+  form v = client->follow_up_action( val = ... t_arg = ... )) takes its
+  IF result IS SUPPLIED branch straight to get_event_client( ) - the entire
+  body of _event_client( ), so the roundtrip-free wire it emits is identical.
+  One method both schedules a frontend action and wires one; the second name
+  was half of it. The one difference is follow_up_action( )'s leading CASE,
+  which claims cs_event-set_nav_routing / set_push_state /
+  set_app_state_active before that branch - those three are backend-side
+  navigation options rather than frontend handlers, so wiring one into a view
+  attribute never dispatched anything under either name. _event_client( )
+  stays in the public API and keeps working; the framework's own startup app
+  was renamed, the frozen src/99 image-editor popup keeps its call. The
+  abap2UI5-linter reports the leftovers as obsolete-frontend-event and
+  rewrites them with --fix
 ! small performance cleanups in the rendering/serialization hot paths, no
   behavior change: both view builders concatenate child elements through a
   string table instead of re-copying the accumulated XML per sibling,

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -243,11 +243,13 @@ ships for existing apps but is **frozen** — new apps and new code use
   (`Path not found @/1/wrapping`). Chain
   `parse( … )->to_abap_corresponding_only( )->to_abap( … )` and declare only
   the fields you actually use.
-- Roundtrip-free client actions: `client->_event_client( val = … t_arg = … )`
-  runs a whitelisted frontend action without a server call (toast from a row
-  value, client-side sort/filter via `binding_call`, …).
-- After the response, `client->follow_up_action( val = … t_arg = … )`
-  schedules a frontend action: focus (`cs_event-set_focus`), scroll, title,
+- Roundtrip-free client actions: `client->follow_up_action( val = … t_arg = … )`
+  written where its RESULT is consumed — in a view attribute — runs a
+  whitelisted frontend action without a server call (toast from a row value,
+  client-side sort/filter via `binding_call`, …). `client->_event_client( )`
+  is the obsolete name for exactly this and emits the identical wire.
+- After the response, `client->follow_up_action( val = … t_arg = … )` as a
+  STATEMENT schedules a frontend action: focus (`cs_event-set_focus`), scroll, title,
   clipboard, timers, keyboard shortcuts, `control_by_id` (call a public
   method on a control), `binding_call` (filter/sort an aggregation binding).
   The full catalog with per-action `t_arg` documentation sits on

--- a/docs/removal-plan.md
+++ b/docs/removal-plan.md
@@ -135,8 +135,10 @@ controls a public contract, so these break hand-written view XML. Regenerate
 
 > **Cannot go yet:** the `eF('…')` string parser in `core/actions/LegacyCustomJs.js`. It is
 > the legacy path only for *framework* follow-up actions (those are JSON since
-> #2501) — `_event_client( )` still emits the code form into view XML, so the
-> parser stays until that is JSON too.
+> #2501) — a WIRED action still emits the code form into view XML
+> (`get_event_client( )`, reached through `follow_up_action( )`'s
+> `IF result IS SUPPLIED` branch or through its obsolete second name
+> `_event_client( )`), so the parser stays until that is JSON too.
 >
 > **Cannot go yet:** the `z2ui5.*` global facade in `core/AppState.js`. It is a
 > documented public contract for apps reaching internals via `js_loader`.

--- a/src/02/z2ui5_cl_app_startup.clas.abap
+++ b/src/02/z2ui5_cl_app_startup.clas.abap
@@ -358,8 +358,8 @@ CLASS z2ui5_cl_app_startup IMPLEMENTATION.
           )->a( n = `text`
                 v = `Explore Code Samples`
           )->a( n = `press`
-                v = client->_event_client( val   = client->cs_event-open_new_tab
-                                           t_arg = VALUE #( ( get_app_url( lv_class_samples ) ) ) )
+                v = client->follow_up_action( val   = client->cs_event-open_new_tab
+                                              t_arg = VALUE #( ( get_app_url( lv_class_samples ) ) ) )
           )->a( n = `width`
                 v = `70%` ).
     ELSE.

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -305,6 +305,23 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE string.
 
+  "! obsolete - use follow_up_action( ), which is the same call in the same
+  "! position now. Since follow_up_action( ) has a RETURNING parameter, a call
+  "! whose result is CONSUMED - the view-attribute form
+  "! `v = client->follow_up_action( val = ... t_arg = ... )` - takes its
+  "! IF result IS SUPPLIED branch straight to get_event_client( ), which is
+  "! this method's entire body: the identical roundtrip-free wire, byte for
+  "! byte. One method therefore both schedules a frontend action and wires
+  "! one, and this one is a second name for half of it.
+  "!
+  "! The one difference is follow_up_action( )'s leading CASE, which claims
+  "! cs_event-set_nav_routing / set_push_state / set_app_state_active before
+  "! that branch. Those three are backend-side navigation options rather than
+  "! frontend handlers, so wiring one into a view attribute never dispatched
+  "! anything here either.
+  "!
+  "! It stays in the interface so existing apps keep compiling - rename the
+  "! calls at your leisure.
   METHODS _event_client
     IMPORTING
       val           TYPE clike
@@ -472,8 +489,11 @@ INTERFACE z2ui5_if_client
   "! t_arg = id, aggregation, method, params. method `filter`: params = path,
   "! operator, value1, value2 (empty values clear the filter); method `sort`:
   "! params = path, descending, group (abap_bool as `X`/``).
-  "! Each of these events also works roundtrip-free when wired in the view via
-  "! _event_client with the same t_arg (and view).
+  "! Each of these events also works roundtrip-free when WIRED IN THE VIEW:
+  "! write the same call where its result is consumed
+  "! (`)->a( n = `press` v = client->follow_up_action( val = ... t_arg = ... ) )`)
+  "! and the action runs in the browser without a server call. That is what
+  "! the obsolete _event_client( ) did, and the only thing it did.
   METHODS follow_up_action
     IMPORTING
       val           TYPE string


### PR DESCRIPTION
follow_up_action( ) has covered both halves since it gained its RETURNING
parameter: a call whose result is CONSUMED - the view-attribute form
v = client->follow_up_action( val = ... t_arg = ... ) - takes the
IF result IS SUPPLIED branch straight to mo_srv_event->get_event_client( ),
which is _event_client( )'s entire body. Same arguments, same wire, byte for
byte. One method both schedules a frontend action and wires one, so the
second name is a leftover, and the ABAP Doc now says so.

The one non-equivalence is documented with it: follow_up_action( )'s leading
CASE claims cs_event-set_nav_routing / set_push_state / set_app_state_active
before that branch. Those three are backend-side navigation options rather
than frontend handlers, so wiring one into a view attribute never dispatched
anything under either name.

The method itself stays in the public API and keeps working - the api-snapshot
is unchanged, only comments moved. The framework's own startup app is renamed;
the image-editor popup keeps its call because src/99 production code is frozen
(rule 1).

abaplint, api-snapshot, guide, visibility, frozen-paths and the unit suite all
pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BVsKKazPEJzd74dWfnvyGp