### PR TITLE
Fix developer tools showing stale popup/popover tabs after frontend close

### DIFF
--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -48,6 +48,14 @@
 //   oOwnerComponent, oDeviceModel (Component / App.controller)
 //   oView, oViewNest, oViewNest2, oViewPopup, oViewPopover
 //                     the five view slots, written by ViewSlots.setView
+//   slotXml           the view XML each slot was filled with, per slot key -
+//                     recorded by ViewSlots.setView and dropped by
+//                     ViewSlots.destroy, so it tracks the slot itself no
+//                     matter who tore it down (backend action or a
+//                     roundtrip-free frontend close). The developer tools
+//                     read a slot's source from here: a fragment or a view
+//                     built from a `definition` keeps no viewContent of its
+//                     own
 //   oController, oControllerNest, oControllerNest2, oControllerPopup,
 //   oControllerPopover  controller instance per slot (App.controller)
 //   oLaunchpad        FLP services when running inside the launchpad, else
@@ -115,6 +123,7 @@ sap.ui.define([], () => {
       oControllerNest2: null,
       oControllerPopup: null,
       oControllerPopover: null,
+      slotXml: {},
       oLaunchpad: null,
 
       // Roundtrip state

--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -133,32 +133,23 @@ sap.ui.define(
       return err.title ? `${err.title}\n\n${err.text}` : err.text;
     }
 
-    // The view XML of the last response, read back out of the system action
-    // that displayed the slot: ["VIEW_SLOTS","display","<slot>","<xml>",
-    // {options}?]. Only used as a fallback for the case where the slot
-    // holds no live view to read the content off.
-    function getResponseXml(slotKey) {
-      const systemJs = AppState.state.oResponse?.S_ACTION?.T_SYSTEM;
-      if (!systemJs) return undefined;
-      for (const item of systemJs) {
-        // a system action arrives as a real JSON array; the stringified
-        // form stays readable for a skewed backend
-        let args = item;
-        if (!Array.isArray(args)) {
-          try {
-            args = JSON.parse(item);
-          } catch {
-            continue;
-          }
-        }
-        if (!Array.isArray(args)) continue;
-        // a skewed backend may still send the CONTROL_GLOBAL-prefixed form
-        const a = args[0] === "CONTROL_GLOBAL" ? args.slice(1) : args;
-        if (a[0] === "VIEW_SLOTS" && a[1] === "display" && a[2] === slotKey) {
-          return a[3];
-        }
-      }
-      return undefined;
+    // The view XML a slot currently holds: the live view's own viewContent
+    // when UI5 kept it, else the source ViewSlots recorded when the slot was
+    // filled (a fragment or a `definition`-built view keeps none).
+    //
+    // Read from the SLOT, never from the last response: a slot lives and dies
+    // by ViewSlots.setView/destroy, and both ways of tearing one down end up
+    // there - the backend's ["VIEW_SLOTS","destroy",...] action and the
+    // roundtrip-free frontend close (cs_event-popup_close / popover_close,
+    // which the backend formats as that very same action). Scraping the last
+    // response's display action instead made the frontend close look like a
+    // popup that was still open: no roundtrip happens, so the response that
+    // opened it stayed the current one.
+    function getSlotXml(slotKey) {
+      return (
+        getViewContent(ViewSlots.getView(slotKey)) ||
+        ViewSlots.getViewXml(slotKey)
+      );
     }
 
     // Preload the sap.ui.codeeditor modules used by the fragment. On older
@@ -194,21 +185,18 @@ sap.ui.define(
     };
 
     const xmlSources = {
-      // Prefer the actual viewContent string; fall back to the XML that
-      // arrived in the last server response.
       VIEW: () => ({
-        xml:
-          getViewContent(ViewSlots.getView("MAIN")) || getResponseXml("MAIN"),
+        xml: getSlotXml("MAIN"),
         rendered: getRenderedContent(ViewSlots.getView("MAIN")),
       }),
-      POPUP: () => ({ xml: getResponseXml("POPUP") }),
-      POPOVER: () => ({ xml: getResponseXml("POPOVER") }),
+      POPUP: () => ({ xml: getSlotXml("POPUP") }),
+      POPOVER: () => ({ xml: getSlotXml("POPOVER") }),
       NEST1: () => ({
-        xml: getViewContent(ViewSlots.getView("NEST")),
+        xml: getSlotXml("NEST"),
         rendered: getRenderedContent(ViewSlots.getView("NEST")),
       }),
       NEST2: () => ({
-        xml: getViewContent(ViewSlots.getView("NEST2")),
+        xml: getSlotXml("NEST2"),
         rendered: getRenderedContent(ViewSlots.getView("NEST2")),
       }),
     };
@@ -376,10 +364,9 @@ sap.ui.define(
           "VIEW MODEL",
           json(() => jsonSources.MODEL()),
         );
-        // gate on the live slot too - the response only carries the XML in
-        // the roundtrip that opened the popup/popover, but the live model is
-        // exportable for as long as one is open
-        if (getResponseXml("POPUP") || ViewSlots.getView("POPUP")) {
+        // one gate for both slots and both close paths: the slot holds an
+        // XML for exactly as long as it is filled
+        if (getSlotXml("POPUP")) {
           push(
             "POPUP",
             xml(() => xmlSources.POPUP().xml),
@@ -389,7 +376,7 @@ sap.ui.define(
             json(() => jsonSources.POPUP_MODEL()),
           );
         }
-        if (getResponseXml("POPOVER") || ViewSlots.getView("POPOVER")) {
+        if (getSlotXml("POPOVER")) {
           push(
             "POPOVER",
             xml(() => xmlSources.POPOVER().xml),
@@ -401,13 +388,13 @@ sap.ui.define(
         }
         // the nested views carry no model tab of their own - they inherit
         // the MAIN view's model by propagation, so only the XML is shown
-        if (getViewContent(ViewSlots.getView("NEST"))) {
+        if (getSlotXml("NEST")) {
           push(
             "NEST1",
             xml(() => xmlSources.NEST1().xml),
           );
         }
-        if (getViewContent(ViewSlots.getView("NEST2"))) {
+        if (getSlotXml("NEST2")) {
           push(
             "NEST2",
             xml(() => xmlSources.NEST2().xml),
@@ -629,17 +616,13 @@ sap.ui.define(
             previousValue: value,
             isTemplating: false,
             templatingSource: false,
-            activeNest1: Boolean(getViewContent(ViewSlots.getView("NEST"))),
-            activeNest2: Boolean(getViewContent(ViewSlots.getView("NEST2"))),
-            // The response only carries the fragment XML in the roundtrip
-            // that opened the popup/popover - also check the live slot so
-            // the tabs stay usable while one is open after later roundtrips.
-            activePopup: Boolean(
-              getResponseXml("POPUP") || ViewSlots.getView("POPUP"),
-            ),
-            activePopover: Boolean(
-              getResponseXml("POPOVER") || ViewSlots.getView("POPOVER"),
-            ),
+            activeNest1: Boolean(getSlotXml("NEST")),
+            activeNest2: Boolean(getSlotXml("NEST2")),
+            // Filled for as long as the slot is - the tabs appear with the
+            // popup/popover and go with it, whether the backend tore it down
+            // or the app closed it in the browser without a roundtrip.
+            activePopup: Boolean(getSlotXml("POPUP")),
+            activePopover: Boolean(getSlotXml("POPOVER")),
             // the model tabs grey out when the slot's model holds no data
             hasViewModel: hasModelData(ViewSlots.getView("MAIN")),
             hasPopupModel: hasModelData(ViewSlots.getView("POPUP")),

--- a/app/webapp/core/ViewSlots.js
+++ b/app/webapp/core/ViewSlots.js
@@ -72,11 +72,31 @@ sap.ui.define(
       return slot ? AppState.state[slot.prop] : undefined;
     }
 
-    function setView(key, view) {
+    // Fill a slot. `xml` is the view XML the slot was built from; it is
+    // recorded next to the live instance because neither a Fragment nor an
+    // XMLView created from a `definition` keeps its source (mProperties.
+    // viewContent stays empty), and the developer tools have no other way
+    // back to it. Recorded HERE and dropped in destroy(), so the record
+    // follows the slot itself - not the response that happened to fill it.
+    function setView(key, view, xml) {
       const slot = byKey(key);
       if (!slot) return;
       AppState.state[slot.prop] = view;
+      slotXmlStore()[key] = xml;
       attachSharedModels(view);
+    }
+
+    // The XML a slot currently holds, undefined once it was torn down.
+    function getViewXml(key) {
+      return slotXmlStore()[key];
+    }
+
+    // The record lives on AppState (so an app restart resets it with
+    // everything else); create it on first use so a state object that
+    // predates the field still works.
+    function slotXmlStore() {
+      if (!AppState.state.slotXml) AppState.state.slotXml = {};
+      return AppState.state.slotXml;
     }
 
     // Attach the models every slot shares: the one device model (created
@@ -182,6 +202,12 @@ sap.ui.define(
       // symmetric to attachSharedModels and clears a stale nest reference
       // even when MAIN itself is already gone.
       for (const dep of slot.dependentSlots ?? []) destroy(dep);
+      // Drop the recorded XML BEFORE the empty-slot exit below: a slot whose
+      // live instance is already gone (an app restart reset AppState, a
+      // fragment load that failed after recording) must not keep a stale
+      // source behind - the developer tools read "is this slot filled" off
+      // this record.
+      delete slotXmlStore()[key];
       const view = AppState.state[slot.prop];
       if (!view) return;
       if (slot.fragmentId) {
@@ -212,6 +238,7 @@ sap.ui.define(
     return {
       slots,
       getView,
+      getViewXml,
       setView,
       getController,
       keyOfController,

--- a/app/webapp/core/actions/Slots.js
+++ b/app/webapp/core/actions/Slots.js
@@ -123,7 +123,7 @@ sap.ui.define(
       // The shared device + message models are attached inside
       // ViewSlots.setView (the single funnel), so error paths that
       // destroy a view without reaching setView never register it.
-      ViewSlots.setView("POPUP", oFragment);
+      ViewSlots.setView("POPUP", oFragment, xml);
       oFragment.open();
     }
 
@@ -152,7 +152,7 @@ sap.ui.define(
         oFragment.destroy();
         return;
       }
-      ViewSlots.setView("POPOVER", oFragment);
+      ViewSlots.setView("POPOVER", oFragment, xml);
       // The anchor may not be in the DOM yet: a response can build the MAIN
       // view and open a popover on one of its controls in the SAME
       // roundtrip - the build is awaited, but its rendering happens later.
@@ -224,7 +224,7 @@ sap.ui.define(
         oView.destroy();
         return;
       }
-      ViewSlots.setView(slotKey, oView);
+      ViewSlots.setView(slotKey, oView, xml);
     }
 
     // Replace the main app view with the XML coming from the backend.
@@ -281,7 +281,7 @@ sap.ui.define(
         return;
       }
 
-      ViewSlots.setView("MAIN", oView);
+      ViewSlots.setView("MAIN", oView, xml);
       if (switchPath) oView.setModel(oViewModel, "http");
       AppState.state.oApp.removeAllPages();
       AppState.state.oApp.insertPage(oView);

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,17 @@ Legend
 
 unreleased
 ----------
+* the developer tools kept showing the POPUP/POPOVER tabs of a dialog an app
+  had closed in the browser without a roundtrip
+  (follow_up_action( cs_event-popup_close / popover_close )). Both close
+  paths always ran the same code - the backend formats either close as the
+  ["VIEW_SLOTS","destroy","<slot>"] action that popup_destroy( ) queues, and
+  it lands in ViewSlots.destroy either way - but the developer tools did not
+  read the slot: they scraped the last response for the display action that
+  had opened it, and a roundtrip-free close leaves that response current.
+  ViewSlots now records the XML a slot was filled with next to the live
+  instance (setView) and drops it in destroy( ), so the tools read the slot
+  itself for all five slots and both close paths look the same
 ! _event_client( ) is obsolete - follow_up_action( ) is the same call in the
   same position now, and the interface says so. Since follow_up_action( ) has
   a RETURNING parameter, a call whose result is CONSUMED (the view-attribute

--- a/node/tests/developerTools.spec.js
+++ b/node/tests/developerTools.spec.js
@@ -25,6 +25,7 @@ function fakeXmlView(viewContent) {
 
 function loadDeveloperTools({
   views = {},
+  slotXml = {},
   oResponse = null,
   responseData = null,
   errors,
@@ -38,7 +39,12 @@ function loadDeveloperTools({
     state: { oResponse, responseData, oBody: null, errors, lastError },
     getGlobal: () => undefined,
   };
-  const ViewSlots = { getView: (key) => views[key] };
+  // The slot registry is the developer tools' only source for what a slot
+  // holds: the live instance and the XML it was filled with.
+  const ViewSlots = {
+    getView: (key) => views[key],
+    getViewXml: (key) => slotXml[key],
+  };
   const ErrorView = {
     handleLogout: () => logoutCalls?.push(true),
     reopenErrorDialog: () => reopenCalls?.push(true),
@@ -110,40 +116,57 @@ test.describe("View tab", () => {
     expect(modelData.editor_visible).toBe(true);
   });
 
-  test("falls back to the last response XML when the view keeps none", () => {
+  test("falls back to the XML the slot was filled with", () => {
+    // A view built from a `definition` keeps no viewContent - ViewSlots
+    // recorded the source when it filled the slot.
     const { DeveloperTools } = loadDeveloperTools({
       views: { MAIN: fakeXmlView(undefined) },
-      // the XML rides on the system action that displayed the slot - a real
-      // nested array on the wire
-      oResponse: {
-        S_ACTION: {
-          T_SYSTEM: [
-            ["CONTROL_GLOBAL", "VIEW_SLOTS", "destroy", "MAIN"],
-            ["CONTROL_GLOBAL", "VIEW_SLOTS", "display", "MAIN", "<Page/>"],
-          ],
-        },
-      },
+      slotXml: { MAIN: "<Page/>" },
     });
     const { oEvent, modelData } = fakeSelectEvent("VIEW");
     DeveloperTools.onItemSelect(oEvent);
     expect(modelData.value).toBe("<Page/>");
     expect(modelData.type).toBe("xml");
   });
+});
 
-  test("still reads the stringified action form of a skewed backend", () => {
+test.describe("popup / popover tabs", () => {
+  // Regression guard: the tabs used to be derived from the last response's
+  // ["VIEW_SLOTS","display","POPUP",...] action. A frontend close
+  // (cs_event-popup_close) does no roundtrip, so that response stayed the
+  // current one and the developer tools kept showing a popup that was long
+  // destroyed. They read the slot itself now, so both close paths - the
+  // backend's destroy action and the roundtrip-free one - look the same.
+  test("show the fragment XML while the slot is filled", () => {
     const { DeveloperTools } = loadDeveloperTools({
-      views: { MAIN: fakeXmlView(undefined) },
+      views: { POPUP: fakeXmlView(undefined) },
+      slotXml: { POPUP: "<Dialog/>" },
+    });
+    const { oEvent, modelData } = fakeSelectEvent("POPUP");
+    DeveloperTools.onItemSelect(oEvent);
+    expect(modelData.value).toBe("<Dialog/>");
+    expect(modelData.type).toBe("xml");
+  });
+
+  test("are empty once the slot was torn down without a roundtrip", () => {
+    // ViewSlots.destroy cleared both the live view and the recorded XML,
+    // while oResponse still carries the display action that opened it
+    const { DeveloperTools } = loadDeveloperTools({
+      views: {},
+      slotXml: {},
       oResponse: {
         S_ACTION: {
           T_SYSTEM: [
-            '["CONTROL_GLOBAL","VIEW_SLOTS","display","MAIN","<Page/>"]',
+            ["CONTROL_GLOBAL", "VIEW_SLOTS", "display", "POPUP", "<Dialog/>"],
           ],
         },
       },
     });
-    const { oEvent, modelData } = fakeSelectEvent("VIEW");
+    const { oEvent, modelData } = fakeSelectEvent("POPUP");
     DeveloperTools.onItemSelect(oEvent);
-    expect(modelData.value).toBe("<Page/>");
+    expect(modelData.value).toBe("");
+    const exported = DeveloperTools.buildExport("");
+    expect(exported).not.toContain("POPUP");
   });
 });
 

--- a/node/tests/viewSlots.spec.js
+++ b/node/tests/viewSlots.spec.js
@@ -87,6 +87,13 @@ test.describe("view and controller access", () => {
     expect(registerCalls).toEqual([[view, true]]);
   });
 
+  test("setView records the XML the slot was filled with", () => {
+    const { ViewSlots } = load();
+    ViewSlots.setView("POPUP", { setModel() {} }, "<Dialog/>");
+    expect(ViewSlots.getViewXml("POPUP")).toBe("<Dialog/>");
+    expect(ViewSlots.getViewXml("POPOVER")).toBeUndefined();
+  });
+
   test("keyOfController finds the slot a controller serves", () => {
     const { ViewSlots, z2ui5 } = load();
     const controller = {};
@@ -228,6 +235,36 @@ test.describe("destroy", () => {
     ViewSlots.destroy("POPUP");
     ViewSlots.destroy("UNKNOWN");
     expect(z2ui5.oViewPopup).toBeUndefined();
+  });
+
+  test("drops the recorded XML, whoever triggered the teardown", () => {
+    // The backend's ["VIEW_SLOTS","destroy","POPUP"] action and the
+    // roundtrip-free frontend close (cs_event-popup_close, which the backend
+    // formats as that same action) both land here - so the record cannot
+    // survive one of them and not the other.
+    const { ViewSlots } = load();
+    ViewSlots.setView("POPUP", { setModel() {}, destroy() {} }, "<Dialog/>");
+    ViewSlots.destroy("POPUP");
+    expect(ViewSlots.getViewXml("POPUP")).toBeUndefined();
+  });
+
+  test("drops the recorded XML of a slot whose view is already gone", () => {
+    // A fragment load that failed after recording, or a state reset that
+    // nulled the live instances: the record must not outlive the slot.
+    const { ViewSlots, z2ui5 } = load();
+    ViewSlots.setView("POPOVER", { setModel() {} }, "<Popover/>");
+    z2ui5.oViewPopover = null;
+    ViewSlots.destroy("POPOVER");
+    expect(ViewSlots.getViewXml("POPOVER")).toBeUndefined();
+  });
+
+  test("MAIN teardown drops the nests' recorded XML too", () => {
+    const { ViewSlots } = load();
+    ViewSlots.setView("MAIN", { setModel() {}, destroy() {} }, "<Page/>");
+    ViewSlots.setView("NEST", { setModel() {}, destroy() {} }, "<Nest/>");
+    ViewSlots.destroy("MAIN");
+    expect(ViewSlots.getViewXml("MAIN")).toBeUndefined();
+    expect(ViewSlots.getViewXml("NEST")).toBeUndefined();
   });
 
   test("unregisters the view from the messaging facade before destroy", () => {

--- a/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_appstate_js.clas.abap
@@ -75,6 +75,14 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `//   oOwnerComponent, oDeviceModel (Component / App.controller)` && |\n| &&
              `//   oView, oViewNest, oViewNest2, oViewPopup, oViewPopover` && |\n| &&
              `//                     the five view slots, written by ViewSlots.setView` && |\n| &&
+             `//   slotXml           the view XML each slot was filled with, per slot key -` && |\n| &&
+             `//                     recorded by ViewSlots.setView and dropped by` && |\n| &&
+             `//                     ViewSlots.destroy, so it tracks the slot itself no` && |\n| &&
+             `//                     matter who tore it down (backend action or a` && |\n| &&
+             `//                     roundtrip-free frontend close). The developer tools` && |\n| &&
+             `//                     read a slot's source from here: a fragment or a view` && |\n| &&
+             `//                     built from a ``definition`` keeps no viewContent of its` && |\n| &&
+             `//                     own` && |\n| &&
              `//   oController, oControllerNest, oControllerNest2, oControllerPopup,` && |\n| &&
              `//   oControllerPopover  controller instance per slot (App.controller)` && |\n| &&
              `//   oLaunchpad        FLP services when running inside the launchpad, else` && |\n| &&
@@ -142,6 +150,7 @@ CLASS z2ui5_cl_app_appstate_js IMPLEMENTATION.
              `      oControllerNest2: null,` && |\n| &&
              `      oControllerPopup: null,` && |\n| &&
              `      oControllerPopover: null,` && |\n| &&
+             `      slotXml: {},` && |\n| &&
              `      oLaunchpad: null,` && |\n| &&
              `` && |\n| &&
              `      // Roundtrip state` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -160,32 +160,23 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `      return err.title ? ``${err.title}\n\n${err.text}`` : err.text;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    // The view XML of the last response, read back out of the system action` && |\n| &&
-             `    // that displayed the slot: ["VIEW_SLOTS","display","<slot>","<xml>",` && |\n| &&
-             `    // {options}?]. Only used as a fallback for the case where the slot` && |\n| &&
-             `    // holds no live view to read the content off.` && |\n| &&
-             `    function getResponseXml(slotKey) {` && |\n| &&
-             `      const systemJs = AppState.state.oResponse?.S_ACTION?.T_SYSTEM;` && |\n| &&
-             `      if (!systemJs) return undefined;` && |\n| &&
-             `      for (const item of systemJs) {` && |\n| &&
-             `        // a system action arrives as a real JSON array; the stringified` && |\n| &&
-             `        // form stays readable for a skewed backend` && |\n| &&
-             `        let args = item;` && |\n| &&
-             `        if (!Array.isArray(args)) {` && |\n| &&
-             `          try {` && |\n| &&
-             `            args = JSON.parse(item);` && |\n| &&
-             `          } catch {` && |\n| &&
-             `            continue;` && |\n| &&
-             `          }` && |\n| &&
-             `        }` && |\n| &&
-             `        if (!Array.isArray(args)) continue;` && |\n| &&
-             `        // a skewed backend may still send the CONTROL_GLOBAL-prefixed form` && |\n| &&
-             `        const a = args[0] === "CONTROL_GLOBAL" ? args.slice(1) : args;` && |\n| &&
-             `        if (a[0] === "VIEW_SLOTS" && a[1] === "display" && a[2] === slotKey) {` && |\n| &&
-             `          return a[3];` && |\n| &&
-             `        }` && |\n| &&
-             `      }` && |\n| &&
-             `      return undefined;` && |\n| &&
+             `    // The view XML a slot currently holds: the live view's own viewContent` && |\n| &&
+             `    // when UI5 kept it, else the source ViewSlots recorded when the slot was` && |\n| &&
+             `    // filled (a fragment or a ``definition``-built view keeps none).` && |\n| &&
+             `    //` && |\n| &&
+             `    // Read from the SLOT, never from the last response: a slot lives and dies` && |\n| &&
+             `    // by ViewSlots.setView/destroy, and both ways of tearing one down end up` && |\n| &&
+             `    // there - the backend's ["VIEW_SLOTS","destroy",...] action and the` && |\n| &&
+             `    // roundtrip-free frontend close (cs_event-popup_close / popover_close,` && |\n| &&
+             `    // which the backend formats as that very same action). Scraping the last` && |\n| &&
+             `    // response's display action instead made the frontend close look like a` && |\n| &&
+             `    // popup that was still open: no roundtrip happens, so the response that` && |\n| &&
+             `    // opened it stayed the current one.` && |\n| &&
+             `    function getSlotXml(slotKey) {` && |\n| &&
+             `      return (` && |\n| &&
+             `        getViewContent(ViewSlots.getView(slotKey)) ||` && |\n| &&
+             `        ViewSlots.getViewXml(slotKey)` && |\n| &&
+             `      );` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Preload the sap.ui.codeeditor modules used by the fragment. On older` && |\n| &&
@@ -221,21 +212,18 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `    };` && |\n| &&
              `` && |\n| &&
              `    const xmlSources = {` && |\n| &&
-             `      // Prefer the actual viewContent string; fall back to the XML that` && |\n| &&
-             `      // arrived in the last server response.` && |\n| &&
              `      VIEW: () => ({` && |\n| &&
-             `        xml:` && |\n| &&
-             `          getViewContent(ViewSlots.getView("MAIN")) || getResponseXml("MAIN"),` && |\n| &&
+             `        xml: getSlotXml("MAIN"),` && |\n| &&
              `        rendered: getRenderedContent(ViewSlots.getView("MAIN")),` && |\n| &&
              `      }),` && |\n| &&
-             `      POPUP: () => ({ xml: getResponseXml("POPUP") }),` && |\n| &&
-             `      POPOVER: () => ({ xml: getResponseXml("POPOVER") }),` && |\n| &&
+             `      POPUP: () => ({ xml: getSlotXml("POPUP") }),` && |\n| &&
+             `      POPOVER: () => ({ xml: getSlotXml("POPOVER") }),` && |\n| &&
              `      NEST1: () => ({` && |\n| &&
-             `        xml: getViewContent(ViewSlots.getView("NEST")),` && |\n| &&
+             `        xml: getSlotXml("NEST"),` && |\n| &&
              `        rendered: getRenderedContent(ViewSlots.getView("NEST")),` && |\n| &&
              `      }),` && |\n| &&
              `      NEST2: () => ({` && |\n| &&
-             `        xml: getViewContent(ViewSlots.getView("NEST2")),` && |\n| &&
+             `        xml: getSlotXml("NEST2"),` && |\n| &&
              `        rendered: getRenderedContent(ViewSlots.getView("NEST2")),` && |\n| &&
              `      }),` && |\n| &&
              `    };` && |\n| &&
@@ -403,10 +391,9 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `          "VIEW MODEL",` && |\n| &&
              `          json(() => jsonSources.MODEL()),` && |\n| &&
              `        );` && |\n| &&
-             `        // gate on the live slot too - the response only carries the XML in` && |\n| &&
-             `        // the roundtrip that opened the popup/popover, but the live model is` && |\n| &&
-             `        // exportable for as long as one is open` && |\n| &&
-             `        if (getResponseXml("POPUP") || ViewSlots.getView("POPUP")) {` && |\n| &&
+             `        // one gate for both slots and both close paths: the slot holds an` && |\n| &&
+             `        // XML for exactly as long as it is filled` && |\n| &&
+             `        if (getSlotXml("POPUP")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "POPUP",` && |\n| &&
              `            xml(() => xmlSources.POPUP().xml),` && |\n| &&
@@ -416,7 +403,7 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `            json(() => jsonSources.POPUP_MODEL()),` && |\n| &&
              `          );` && |\n| &&
              `        }` && |\n| &&
-             `        if (getResponseXml("POPOVER") || ViewSlots.getView("POPOVER")) {` && |\n| &&
+             `        if (getSlotXml("POPOVER")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "POPOVER",` && |\n| &&
              `            xml(() => xmlSources.POPOVER().xml),` && |\n| &&
@@ -424,21 +411,21 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `          push(` && |\n| &&
              `            "POPOVER MODEL",` && |\n| &&
              `            json(() => jsonSources.POPOVER_MODEL()),` && |\n| &&
-             `          );` && |\n|.
-    result = result &&
+             `          );` && |\n| &&
              `        }` && |\n| &&
              `        // the nested views carry no model tab of their own - they inherit` && |\n| &&
              `        // the MAIN view's model by propagation, so only the XML is shown` && |\n| &&
-             `        if (getViewContent(ViewSlots.getView("NEST"))) {` && |\n| &&
+             `        if (getSlotXml("NEST")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "NEST1",` && |\n| &&
              `            xml(() => xmlSources.NEST1().xml),` && |\n| &&
              `          );` && |\n| &&
              `        }` && |\n| &&
-             `        if (getViewContent(ViewSlots.getView("NEST2"))) {` && |\n| &&
+             `        if (getSlotXml("NEST2")) {` && |\n| &&
              `          push(` && |\n| &&
              `            "NEST2",` && |\n| &&
-             `            xml(() => xmlSources.NEST2().xml),` && |\n| &&
+             `            xml(() => xmlSources.NEST2().xml),` && |\n|.
+    result = result &&
              `          );` && |\n| &&
              `        }` && |\n| &&
              `        return sections.join("\n\n") || "(nothing to export)";` && |\n| &&
@@ -657,17 +644,13 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `            previousValue: value,` && |\n| &&
              `            isTemplating: false,` && |\n| &&
              `            templatingSource: false,` && |\n| &&
-             `            activeNest1: Boolean(getViewContent(ViewSlots.getView("NEST"))),` && |\n| &&
-             `            activeNest2: Boolean(getViewContent(ViewSlots.getView("NEST2"))),` && |\n| &&
-             `            // The response only carries the fragment XML in the roundtrip` && |\n| &&
-             `            // that opened the popup/popover - also check the live slot so` && |\n| &&
-             `            // the tabs stay usable while one is open after later roundtrips.` && |\n| &&
-             `            activePopup: Boolean(` && |\n| &&
-             `              getResponseXml("POPUP") || ViewSlots.getView("POPUP"),` && |\n| &&
-             `            ),` && |\n| &&
-             `            activePopover: Boolean(` && |\n| &&
-             `              getResponseXml("POPOVER") || ViewSlots.getView("POPOVER"),` && |\n| &&
-             `            ),` && |\n| &&
+             `            activeNest1: Boolean(getSlotXml("NEST")),` && |\n| &&
+             `            activeNest2: Boolean(getSlotXml("NEST2")),` && |\n| &&
+             `            // Filled for as long as the slot is - the tabs appear with the` && |\n| &&
+             `            // popup/popover and go with it, whether the backend tore it down` && |\n| &&
+             `            // or the app closed it in the browser without a roundtrip.` && |\n| &&
+             `            activePopup: Boolean(getSlotXml("POPUP")),` && |\n| &&
+             `            activePopover: Boolean(getSlotXml("POPOVER")),` && |\n| &&
              `            // the model tabs grey out when the slot's model holds no data` && |\n| &&
              `            hasViewModel: hasModelData(ViewSlots.getView("MAIN")),` && |\n| &&
              `            hasPopupModel: hasModelData(ViewSlots.getView("POPUP")),` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_slots_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_slots_js.clas.abap
@@ -150,7 +150,7 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `      // The shared device + message models are attached inside` && |\n| &&
              `      // ViewSlots.setView (the single funnel), so error paths that` && |\n| &&
              `      // destroy a view without reaching setView never register it.` && |\n| &&
-             `      ViewSlots.setView("POPUP", oFragment);` && |\n| &&
+             `      ViewSlots.setView("POPUP", oFragment, xml);` && |\n| &&
              `      oFragment.open();` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
@@ -179,7 +179,7 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `        oFragment.destroy();` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      ViewSlots.setView("POPOVER", oFragment);` && |\n| &&
+             `      ViewSlots.setView("POPOVER", oFragment, xml);` && |\n| &&
              `      // The anchor may not be in the DOM yet: a response can build the MAIN` && |\n| &&
              `      // view and open a popover on one of its controls in the SAME` && |\n| &&
              `      // roundtrip - the build is awaited, but its rendering happens later.` && |\n| &&
@@ -251,7 +251,7 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `        oView.destroy();` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
-             `      ViewSlots.setView(slotKey, oView);` && |\n| &&
+             `      ViewSlots.setView(slotKey, oView, xml);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Replace the main app view with the XML coming from the backend.` && |\n| &&
@@ -308,7 +308,7 @@ CLASS z2ui5_cl_app_slots_js IMPLEMENTATION.
              `        return;` && |\n| &&
              `      }` && |\n| &&
              `` && |\n| &&
-             `      ViewSlots.setView("MAIN", oView);` && |\n| &&
+             `      ViewSlots.setView("MAIN", oView, xml);` && |\n| &&
              `      if (switchPath) oView.setModel(oViewModel, "http");` && |\n| &&
              `      AppState.state.oApp.removeAllPages();` && |\n| &&
              `      AppState.state.oApp.insertPage(oView);` && |\n| &&

--- a/src/01/03/z2ui5_cl_app_viewslots_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_viewslots_js.clas.abap
@@ -99,11 +99,31 @@ CLASS z2ui5_cl_app_viewslots_js IMPLEMENTATION.
              `      return slot ? AppState.state[slot.prop] : undefined;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    function setView(key, view) {` && |\n| &&
+             `    // Fill a slot. ``xml`` is the view XML the slot was built from; it is` && |\n| &&
+             `    // recorded next to the live instance because neither a Fragment nor an` && |\n| &&
+             `    // XMLView created from a ``definition`` keeps its source (mProperties.` && |\n| &&
+             `    // viewContent stays empty), and the developer tools have no other way` && |\n| &&
+             `    // back to it. Recorded HERE and dropped in destroy(), so the record` && |\n| &&
+             `    // follows the slot itself - not the response that happened to fill it.` && |\n| &&
+             `    function setView(key, view, xml) {` && |\n| &&
              `      const slot = byKey(key);` && |\n| &&
              `      if (!slot) return;` && |\n| &&
              `      AppState.state[slot.prop] = view;` && |\n| &&
+             `      slotXmlStore()[key] = xml;` && |\n| &&
              `      attachSharedModels(view);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // The XML a slot currently holds, undefined once it was torn down.` && |\n| &&
+             `    function getViewXml(key) {` && |\n| &&
+             `      return slotXmlStore()[key];` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    // The record lives on AppState (so an app restart resets it with` && |\n| &&
+             `    // everything else); create it on first use so a state object that` && |\n| &&
+             `    // predates the field still works.` && |\n| &&
+             `    function slotXmlStore() {` && |\n| &&
+             `      if (!AppState.state.slotXml) AppState.state.slotXml = {};` && |\n| &&
+             `      return AppState.state.slotXml;` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    // Attach the models every slot shares: the one device model (created` && |\n| &&
@@ -209,6 +229,12 @@ CLASS z2ui5_cl_app_viewslots_js IMPLEMENTATION.
              `      // symmetric to attachSharedModels and clears a stale nest reference` && |\n| &&
              `      // even when MAIN itself is already gone.` && |\n| &&
              `      for (const dep of slot.dependentSlots ?? []) destroy(dep);` && |\n| &&
+             `      // Drop the recorded XML BEFORE the empty-slot exit below: a slot whose` && |\n| &&
+             `      // live instance is already gone (an app restart reset AppState, a` && |\n| &&
+             `      // fragment load that failed after recording) must not keep a stale` && |\n| &&
+             `      // source behind - the developer tools read "is this slot filled" off` && |\n| &&
+             `      // this record.` && |\n| &&
+             `      delete slotXmlStore()[key];` && |\n| &&
              `      const view = AppState.state[slot.prop];` && |\n| &&
              `      if (!view) return;` && |\n| &&
              `      if (slot.fragmentId) {` && |\n| &&
@@ -239,6 +265,7 @@ CLASS z2ui5_cl_app_viewslots_js IMPLEMENTATION.
              `    return {` && |\n| &&
              `      slots,` && |\n| &&
              `      getView,` && |\n| &&
+             `      getViewXml,` && |\n| &&
              `      setView,` && |\n| &&
              `      getController,` && |\n| &&
              `      keyOfController,` && |\n| &&


### PR DESCRIPTION
## Description

The developer tools kept displaying POPUP/POPOVER tabs for dialogs that an app had closed in the browser without a roundtrip (via `cs_event-popup_close` / `popover_close`). Both close paths execute the same backend code—the backend formats either close as a `["VIEW_SLOTS","destroy","<slot>"]` action—but the developer tools were reading the wrong source.

**Root cause:** The developer tools scraped the last response's `["VIEW_SLOTS","display",...]` action to determine if a popup/popover was open. A roundtrip-free frontend close leaves that response current, so the tools incorrectly showed the dialog as still open even though `ViewSlots.destroy()` had already torn it down.

**Solution:** ViewSlots now records the XML each slot was filled with (via `setView(key, view, xml)`) and drops it in `destroy()`. The developer tools read the slot itself instead of the response, so both close paths—backend destroy action and roundtrip-free frontend close—look identical. This also simplifies the code by eliminating the complex response-scraping logic in `getResponseXml()`.

### Changes:
- **ViewSlots.js**: Added `slotXmlStore()` to track slot XML, `getViewXml()` to retrieve it, and updated `setView()` to record XML and `destroy()` to clear it
- **DeveloperTools.js**: Replaced `getResponseXml()` with `getSlotXml()` that reads from the slot itself; updated all slot checks (POPUP, POPOVER, NEST, NEST2) to use the new function
- **Slots.js**: Updated all `setView()` calls to pass the XML parameter
- **AppState.js**: Documented the new `slotXml` field
- **Tests**: Updated developer tools tests to use the new slot-based approach and added ViewSlots tests for XML recording/cleanup

## How to test

1. Run `npm run verify:full` (app/webapp/ changed)
2. Existing unit tests pass and cover the new behavior:
   - `developerTools.spec.js`: Tests that popup/popover tabs show while slot is filled and disappear after destroy
   - `viewSlots.spec.js`: Tests that XML is recorded on setView and cleared on destroy
3. Manual test: Open a popup/popover in the app, close it via the browser (not backend), and verify the developer tools no longer show those tabs

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: no

https://claude.ai/code/session_01EabdBV6Fk7tbAnSzWnwgPW