### PR TITLE
Show running app name in Developer Tools dialog title

### DIFF
--- a/app/webapp/core/DeveloperTools.fragment.xml
+++ b/app/webapp/core/DeveloperTools.fragment.xml
@@ -4,7 +4,7 @@
     xmlns:ce="sap.ui.codeeditor"
 >
     <Dialog
-        title="abap2UI5 - Developer Tools"
+        title="{= ${/appName} ? 'abap2UI5 - Developer Tools - ' + ${/appName} : 'abap2UI5 - Developer Tools' }"
         stretch="true"
         escapeHandler=".onEscape"
     >

--- a/app/webapp/core/DeveloperTools.js
+++ b/app/webapp/core/DeveloperTools.js
@@ -488,10 +488,16 @@ sap.ui.define(
         );
       },
 
+      // The class name of the running app, as the backend reported it in the
+      // last response. Empty before the first response arrived.
+      getAppName() {
+        return AppState.state.responseData?.S_FRONT?.APP || "";
+      },
+
       // The ADT REST endpoint that renders the running app's ABAP class
       // source. Empty when the app class name is unknown (no response yet).
       getAbapSourceUrl() {
-        const appName = AppState.state.responseData?.S_FRONT?.APP || "";
+        const appName = this.getAppName();
         if (!appName) return "";
         const appId = encodeURIComponent(appName);
         return `${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main`;
@@ -605,6 +611,10 @@ sap.ui.define(
           const value = toJson(AppState.state.responseData);
           const oData = {
             selectedTab: selectedTab,
+            // the dialog title always names the app the tools are looking at -
+            // every tab below shows that app's data, and after a navigation
+            // the previous app's name is the first thing that would mislead
+            appName: this.getAppName(),
             type: "json",
             source_visible: false,
             editor_visible: true,

--- a/node/tests/developerTools.spec.js
+++ b/node/tests/developerTools.spec.js
@@ -34,6 +34,10 @@ function loadDeveloperTools({
   reopenCalls,
   fragment,
   windowStub,
+  // extra sap.ui.define dependencies / sandbox globals - only show() needs
+  // them (JSONModel, Lib, sap.ui.require), every other test runs without
+  extraDeps = {},
+  extraSandbox = {},
 } = {}) {
   const AppState = {
     state: { oResponse, responseData, oBody: null, errors, lastError },
@@ -60,6 +64,7 @@ function loadDeveloperTools({
       "z2ui5/core/ViewSlots": ViewSlots,
       "z2ui5/core/AppState": AppState,
       "z2ui5/core/ErrorView": ErrorView,
+      ...extraDeps,
     },
     sandbox: {
       XMLSerializer: class {
@@ -84,6 +89,7 @@ function loadDeveloperTools({
         location: { origin: "https://sap.example.com" },
         open() {},
       },
+      ...extraSandbox,
     },
   });
   return { DeveloperTools: module };
@@ -368,6 +374,43 @@ test.describe("Close / Escape returns to the error popup", () => {
     expect(destroyed).toBe(true);
     expect(DeveloperTools.oDialog).toBe(null);
     expect(reopenCalls).toEqual([]);
+  });
+});
+
+test.describe("Dialog title names the running app", () => {
+  const APP = "Z2UI5_CL_MY_APP";
+
+  // The fragment binds the title to /appName, so show() must seed it - the
+  // tools are opened over whatever app is running, and every tab shows that
+  // app's data.
+  const openTools = async (responseData) => {
+    const models = [];
+    const { DeveloperTools } = loadDeveloperTools({
+      responseData,
+      fragment: { load: async () => ({ setModel: (m) => models.push(m), open() {} }) },
+      extraDeps: {
+        "z2ui5/core/Lib": { isDestroyed: () => false, logError() {} },
+        "sap/ui/model/json/JSONModel": class {
+          constructor(data) {
+            this.data = data;
+          }
+          getData() {
+            return this.data;
+          }
+        },
+      },
+      extraSandbox: { sap: { ui: { require: (_mods, resolve) => resolve() } } },
+    });
+    await DeveloperTools.show();
+    return models[0]?.getData();
+  };
+
+  test("show() seeds the app class name into the model", async () => {
+    expect((await openTools({ S_FRONT: { APP: APP } })).appName).toBe(APP);
+  });
+
+  test("show() leaves it empty before the first response", async () => {
+    expect((await openTools({ S_FRONT: {} })).appName).toBe("");
   });
 });
 

--- a/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertool_xml.clas.abap
@@ -31,7 +31,7 @@ CLASS z2ui5_cl_app_developertool_xml IMPLEMENTATION.
              `    xmlns:ce="sap.ui.codeeditor"` &&
              `>` &&
              `    <Dialog` &&
-             `        title="abap2UI5 - Developer Tools"` &&
+             `        title="{= ${/appName} ? 'abap2UI5 - Developer Tools - ' + ${/appName} : 'abap2UI5 - Developer Tools' }"` &&
              `        stretch="true"` &&
              `        escapeHandler=".onEscape"` &&
              `    >` &&

--- a/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
+++ b/src/01/03/z2ui5_cl_app_developertools_js.clas.abap
@@ -516,10 +516,16 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `        );` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
+             `      // The class name of the running app, as the backend reported it in the` && |\n| &&
+             `      // last response. Empty before the first response arrived.` && |\n| &&
+             `      getAppName() {` && |\n| &&
+             `        return AppState.state.responseData?.S_FRONT?.APP || "";` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
              `      // The ADT REST endpoint that renders the running app's ABAP class` && |\n| &&
              `      // source. Empty when the app class name is unknown (no response yet).` && |\n| &&
              `      getAbapSourceUrl() {` && |\n| &&
-             `        const appName = AppState.state.responseData?.S_FRONT?.APP || "";` && |\n| &&
+             `        const appName = this.getAppName();` && |\n| &&
              `        if (!appName) return "";` && |\n| &&
              `        const appId = encodeURIComponent(appName);` && |\n| &&
              `        return ``${window.location.origin}/sap/bc/adt/oo/classes/${appId}/source/main``;` && |\n| &&
@@ -633,6 +639,10 @@ CLASS z2ui5_cl_app_developertools_js IMPLEMENTATION.
              `          const value = toJson(AppState.state.responseData);` && |\n| &&
              `          const oData = {` && |\n| &&
              `            selectedTab: selectedTab,` && |\n| &&
+             `            // the dialog title always names the app the tools are looking at -` && |\n| &&
+             `            // every tab below shows that app's data, and after a navigation` && |\n| &&
+             `            // the previous app's name is the first thing that would mislead` && |\n| &&
+             `            appName: this.getAppName(),` && |\n| &&
              `            type: "json",` && |\n| &&
              `            source_visible: false,` && |\n| &&
              `            editor_visible: true,` && |\n| &&


### PR DESCRIPTION
# Description

The Developer Tools dialog now displays the name of the currently running app in its title bar. This helps users identify which app's data they're inspecting, especially when working with multiple tabs or after navigation.

## Changes

- Added `getAppName()` method to extract the app class name from the response data
- Updated the dialog title binding to conditionally include the app name: "abap2UI5 - Developer Tools - {APP_NAME}" when available
- Seeded the `appName` property into the model data when `show()` is called
- Refactored `getAbapSourceUrl()` to use the new `getAppName()` method to avoid duplication

## How to test

1. Open the Developer Tools on any running app
2. Verify the dialog title shows "abap2UI5 - Developer Tools - Z2UI5_CL_MY_APP" (or the actual app class name)
3. Before the first response arrives, the title should show just "abap2UI5 - Developer Tools"
4. Run the new test suite: "Dialog title names the running app" verifies both scenarios

## Checklist

- [x] `npm run verify:full` passes (app/webapp/ changed)
- [x] Unit tests added (new test.describe block with two test cases)
- [x] No manual edits under src/00/01/, src/00/02/ (only src/01/03/ auto-generated)
- [x] No public API changes
- [x] Changes made via abapGit: no (manual edits to source files)

https://claude.ai/code/session_01Lf8xZ1QLytB6KGjZgAPL2z