### PR TITLE
Escape embedded text resources for the JS literal that carries them

### DIFF
--- a/.github/app2abap/trans2abap.js
+++ b/.github/app2abap/trans2abap.js
@@ -106,14 +106,18 @@ function generateClassName(filePath) {
 // custom-js suffix from the exit configuration, hence the two parameters.
 function buildPreloadClass(entries) {
     const entryLines = entries.map(({ urlPath, className, isJs, isComponent, isStyleCss }) => {
+        // A .js entry is a function body - the source is JavaScript and goes in
+        // verbatim. Every other entry is a text resource embedded as a
+        // single-quoted JS string literal, so its content must be escaped for
+        // that literal (see escape_js_literal below).
         if (isStyleCss) {
-            return `|      "${urlPath}": '{ styles_css }',| && |\\n|`;
+            return `|      "${urlPath}": '{ escape_js_literal( styles_css ) }',| && |\\n|`;
         }
         if (isJs) {
             const suffix = isComponent ? `{ custom_js }` : '';
             return `|      "${urlPath}": function()\\{{ ${className}=>get( ) }${suffix}\\},| && |\\n|`;
         }
-        return `|      "${urlPath}": '{ ${className}=>get( ) }',| && |\\n|`;
+        return `|      "${urlPath}": '{ escape_js_literal( ${className}=>get( ) ) }',| && |\\n|`;
     });
     const joined = entryLines.join(' &&\n             ');
     return `* =====================================================================
@@ -139,6 +143,13 @@ CLASS z2ui5_cl_app_preload DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    CLASS-METHODS escape_js_literal
+      IMPORTING
+        val           TYPE string
+      RETURNING
+        VALUE(result) TYPE string.
+
 ENDCLASS.
 
 
@@ -147,6 +158,42 @@ CLASS z2ui5_cl_app_preload IMPLEMENTATION.
   METHOD get.
 
     result = ${joined}.
+
+  ENDMETHOD.
+
+  METHOD escape_js_literal.
+
+    " Every non-.js resource in get( ) is embedded as a JavaScript
+    " single-quoted string literal, inside the single <script> block that
+    " defines onInitComponent (z2ui5_cl_http_handler=>_http_get). Its content
+    " is arbitrary text and does carry apostrophes - a UI5 expression binding
+    " in a fragment (title="\{= \${/appName} ? 'a' : 'b' }") writes them, and so
+    " does a customer's own styles_css from the exit. An unescaped one ends the
+    " literal early, which is a syntax error for the whole block: the browser
+    " then never defines onInitComponent, the bootstrap call fails and the page
+    " stays blank. Escape for the literal here instead of banning the
+    " characters in the frontend sources.
+    " Backslash goes first so it cannot escape the backslashes added below it.
+    result = replace( val  = val
+                      sub  = \`\\\`
+                      with = \`\\\\\`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = \`'\`
+                      with = \`\\'\`
+                      occ  = 0 ).
+    " a raw line break ends a JS string literal just like an apostrophe does -
+    " only styles_css can carry one, the generated resources are single-line.
+    " char constants come from the context class - the one place allowed to
+    " reference cl_abap_char_utilities (see "Utilities" in AGENTS.md)
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)
+                      with = \`\\r\`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_newline
+                      with = \`\\n\`
+                      occ  = 0 ).
 
   ENDMETHOD.
 

--- a/src/01/03/z2ui5_cl_app_preload.clas.abap
+++ b/src/01/03/z2ui5_cl_app_preload.clas.abap
@@ -21,6 +21,13 @@ CLASS z2ui5_cl_app_preload DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    CLASS-METHODS escape_js_literal
+      IMPORTING
+        val           TYPE string
+      RETURNING
+        VALUE(result) TYPE string.
+
 ENDCLASS.
 
 
@@ -61,7 +68,7 @@ CLASS z2ui5_cl_app_preload IMPLEMENTATION.
              |      "z2ui5/core/actions/Variants.js": function()\{{ z2ui5_cl_app_variants_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/actions/ViewOps.js": function()\{{ z2ui5_cl_app_viewops_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/AppState.js": function()\{{ z2ui5_cl_app_appstate_js=>get( ) }\},| && |\n| &&
-             |      "z2ui5/core/DeveloperTools.fragment.xml": '{ z2ui5_cl_app_developertool_xml=>get( ) }',| && |\n| &&
+             |      "z2ui5/core/DeveloperTools.fragment.xml": '{ escape_js_literal( z2ui5_cl_app_developertool_xml=>get( ) ) }',| && |\n| &&
              |      "z2ui5/core/DeveloperTools.js": function()\{{ z2ui5_cl_app_developertools_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/ErrorView.js": function()\{{ z2ui5_cl_app_errorview_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/FrontendAction.js": function()\{{ z2ui5_cl_app_frontendaction_js=>get( ) }\},| && |\n| &&
@@ -71,12 +78,48 @@ CLASS z2ui5_cl_app_preload IMPLEMENTATION.
              |      "z2ui5/core/Server.js": function()\{{ z2ui5_cl_app_server_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/Session.js": function()\{{ z2ui5_cl_app_session_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/core/ViewSlots.js": function()\{{ z2ui5_cl_app_viewslots_js=>get( ) }\},| && |\n| &&
-             |      "z2ui5/css/style.css": '{ styles_css }',| && |\n| &&
-             |      "z2ui5/manifest.json": '{ z2ui5_cl_app_manifest_json=>get( ) }',| && |\n| &&
+             |      "z2ui5/css/style.css": '{ escape_js_literal( styles_css ) }',| && |\n| &&
+             |      "z2ui5/manifest.json": '{ escape_js_literal( z2ui5_cl_app_manifest_json=>get( ) ) }',| && |\n| &&
              |      "z2ui5/model/formatter.js": function()\{{ z2ui5_cl_app_formatter_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/model/models.js": function()\{{ z2ui5_cl_app_models_js=>get( ) }\},| && |\n| &&
              |      "z2ui5/Util.js": function()\{{ z2ui5_cl_app_util_js=>get( ) }\},| && |\n| &&
-             |      "z2ui5/view/App.view.xml": '{ z2ui5_cl_app_app_xml=>get( ) }',| && |\n|.
+             |      "z2ui5/view/App.view.xml": '{ escape_js_literal( z2ui5_cl_app_app_xml=>get( ) ) }',| && |\n|.
+
+  ENDMETHOD.
+
+  METHOD escape_js_literal.
+
+    " Every non-.js resource in get( ) is embedded as a JavaScript
+    " single-quoted string literal, inside the single <script> block that
+    " defines onInitComponent (z2ui5_cl_http_handler=>_http_get). Its content
+    " is arbitrary text and does carry apostrophes - a UI5 expression binding
+    " in a fragment (title="{= ${/appName} ? 'a' : 'b' }") writes them, and so
+    " does a customer's own styles_css from the exit. An unescaped one ends the
+    " literal early, which is a syntax error for the whole block: the browser
+    " then never defines onInitComponent, the bootstrap call fails and the page
+    " stays blank. Escape for the literal here instead of banning the
+    " characters in the frontend sources.
+    " Backslash goes first so it cannot escape the backslashes added below it.
+    result = replace( val  = val
+                      sub  = `\`
+                      with = `\\`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = `'`
+                      with = `\'`
+                      occ  = 0 ).
+    " a raw line break ends a JS string literal just like an apostrophe does -
+    " only styles_css can carry one, the generated resources are single-line.
+    " char constants come from the context class - the one place allowed to
+    " reference cl_abap_char_utilities (see "Utilities" in AGENTS.md)
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_cr_lf(1)
+                      with = `\r`
+                      occ  = 0 ).
+    result = replace( val  = result
+                      sub  = z2ui5_cl_a2ui5_context=>cv_char_util_newline
+                      with = `\n`
+                      occ  = 0 ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_http_handler.clas.testclasses.abap
@@ -17,6 +17,8 @@ CLASS ltcl_test_http_handler DEFINITION FINAL
     METHODS test_csrf_cross_origin FOR TESTING RAISING cx_static_check.
     METHODS test_csrf_no_headers   FOR TESTING RAISING cx_static_check.
     METHODS test_csrf_referer      FOR TESTING RAISING cx_static_check.
+    METHODS test_preload_escaping  FOR TESTING RAISING cx_static_check.
+    METHODS test_preload_literals  FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 
@@ -261,6 +263,92 @@ CLASS ltcl_test_http_handler IMPLEMENTATION.
                             host    = `app.corp:44300` ).
 
     cl_abap_unit_assert=>assert_true( lv_rejected ).
+
+  ENDMETHOD.
+
+  " The next two tests exercise z2ui5_cl_app_preload rather than this class.
+  " That class is generated (see .github/app2abap/trans2abap.js) and its
+  " package is wiped on every regeneration, so it cannot carry a test include
+  " of its own - and _http_get( ) above is the consumer that breaks: it drops
+  " the preload into the one <script> block that defines onInitComponent.
+
+  METHOD test_preload_escaping.
+
+    " styles_css comes from the exit unfiltered and lands inside a JS
+    " single-quoted string literal, so an apostrophe, a backslash or a line
+    " break in a customer's own CSS has to arrive escaped.
+    DATA lv_css TYPE string.
+    DATA temp30 TYPE xsdboolean.
+    DATA temp31 TYPE xsdboolean.
+    DATA temp32 TYPE xsdboolean.
+    DATA temp33 TYPE xsdboolean.
+
+    lv_css = `.a::after { content: 'x'; }` && |\n| && `.b { background: url("i\c.png"); }`.
+
+    DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = lv_css
+                                                  custom_js  = `` ).
+
+    temp30 = xsdbool( lv_preload CS `content: \'x\';` ).
+    cl_abap_unit_assert=>assert_true( temp30 ).
+
+    temp31 = xsdbool( lv_preload CS `}\n.b` ).
+    cl_abap_unit_assert=>assert_true( temp31 ).
+
+    temp32 = xsdbool( lv_preload CS `url("i\\c.png")` ).
+    cl_abap_unit_assert=>assert_true( temp32 ).
+
+    " and nothing raw survives next to the escaped copies
+    temp33 = xsdbool( lv_preload CS `content: 'x';` ).
+    cl_abap_unit_assert=>assert_false( temp33 ).
+
+  ENDMETHOD.
+
+  METHOD test_preload_literals.
+
+    " Every non-.js resource is embedded as a JS single-quoted string literal.
+    " On such a line, once the escaped apostrophes are taken out, the only ones
+    " left must be the two delimiters - one extra ends its literal early, and
+    " that is a syntax error for the whole <script> block, so onInitComponent
+    " is never defined and the page stays blank. A UI5 expression binding is
+    " the everyday source of such an apostrophe:
+    "   title="{= ${/appName} ? 'a' : 'b' }"
+    " The .js entries are skipped on purpose: their content is the function
+    " body, JavaScript rather than a string, and its apostrophes are its own.
+    DATA lt_lines  TYPE string_table.
+    DATA lt_quotes TYPE string_table.
+    DATA lv_rest   TYPE string.
+    DATA lv_checked TYPE i.
+
+    DATA(lv_preload) = z2ui5_cl_app_preload=>get( styles_css = `.a { content: 'x'; }`
+                                                  custom_js  = `` ).
+
+    SPLIT lv_preload AT |\n| INTO TABLE lt_lines.
+
+    LOOP AT lt_lines INTO DATA(lv_line).
+
+      IF lv_line NP `      "z2ui5/*": '*',`.
+        CONTINUE.
+      ENDIF.
+
+      lv_rest = replace( val  = lv_line
+                         sub  = `\'`
+                         with = ``
+                         occ  = 0 ).
+
+      " n separators produce n + 1 parts, so two delimiters leave three parts
+      SPLIT lv_rest AT `'` INTO TABLE lt_quotes.
+      cl_abap_unit_assert=>assert_equals(
+          exp = 3
+          act = lines( lt_quotes )
+          msg = `a preload text resource carries an unescaped apostrophe` ).
+
+      lv_checked = lv_checked + 1.
+
+    ENDLOOP.
+
+    " guard the guard: the entries have to be there at all
+    cl_abap_unit_assert=>assert_differs( exp = 0
+                                         act = lv_checked ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

The GET page is currently broken — the app never boots and the browser reports:

```
Uncaught SyntaxError: Unexpected identifier 'abap2UI5'
Uncaught (in promise) ReferenceError: onInitComponent is not defined
```

`z2ui5_cl_app_preload` embeds every non-`.js` frontend resource as a JavaScript **single-quoted string literal**, with the content interpolated unescaped. Until now no XML, JSON or CSS file contained an apostrophe, so the omission stayed invisible.

#2563 turned the Developer Tools dialog title into a UI5 expression binding:

```
title="{= ${/appName} ? 'abap2UI5 - Developer Tools - ' + ${/appName} : 'abap2UI5 - Developer Tools' }"
```

Its apostrophes end the literal early:

```js
"z2ui5/core/DeveloperTools.fragment.xml": '<...title="{= ${/appName} ? 'abap2UI5 - D...
                                                                     ^ literal ends here
```

That is a syntax error for the **whole** `<script>` block — the only one that defines `onInitComponent` (`z2ui5_cl_http_handler=>_http_get`) — so the bootstrap's `data-sap-ui-oninit` call finds nothing and the page stays blank. Both reported errors are this one cause.

`escape_js_literal( )` now escapes backslash, apostrophe and line breaks before the content goes into the literal.

**Second, older bug fixed along the way:** `styles_css` reaches the same literal straight from the exit configuration, equally unescaped. A customer stylesheet containing an apostrophe — or simply spanning more than one line — has been able to blank the page the same way all along. It routes through the same escaping now.

The fix is in the generator (`.github/app2abap/trans2abap.js`); `src/01/03/` is the regenerated output, not a manual edit. No `app/webapp/` source changed — the fragment keeps the title exactly as #2563 wrote it, and it now round-trips byte-for-byte to the browser.

## How to test

Against the dev server (`npm run express`), fetching `/` and parsing the inline script:

```
status: 200 bytes: 416384
RESULT: inline script parses as JavaScript
dialog title binding: {= ${/appName} ? 'abap2UI5 - Developer Tools - ' + ${/appName} : 'abap2UI5 - Developer Tools' }
round-trips to source file: true
manifest parses as JSON: true
```

Before the fix the same check reports `SyntaxError: Unexpected identifier 'abap2UI5'`.

Clicking through: start any app, open the Developer Tools dialog — the title names the running app, as #2563 intended.

Two ABAP tests guard it, both verified to fail without the fix (by stripping the escaping from the downported copy and re-running the suite):

- `test_preload_escaping` — a stylesheet carrying an apostrophe, a backslash and a line break arrives escaped, with nothing raw left over
- `test_preload_literals` — the invariant: on every text-resource line, once the escaped apostrophes are removed, the only ones left are the two delimiters. `.js` entries are skipped on purpose, since their content is a function body whose apostrophes are its own

They live in the HTTP handler's test include because the preload class is generated and its package is wiped on every regeneration, so it cannot carry a test include of its own — and `_http_get( )` is the consumer that breaks.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — passes; `app/webapp/` is unchanged, so the frontend gates do not apply
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md) — `src/01/03/` changed only as generator output via `npm run app2abap`; the drift gate passes
- [x] Public API in `src/02/` only changed additively — no production change in `src/02/`, test include only
- [ ] Changes were made via abapGit: yes / **no**

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1hRY7Lpk1SXRaWvbLLMko)_