### PR TITLE
Reformat method chaining calls for improved readability

### DIFF
--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -16,8 +16,7 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
     IF client->check_on_init( ).
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
-      view->ele( n   = `View`
-                  ns = `mvc`
+      view->ele( n = `View` ns = `mvc`
           )->att( n = `xmlns`         v = `sap.m`
           )->att( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
           )->att( n = `xmlns:core`    v = `sap.ui.core`
@@ -29,14 +28,11 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
               )->ele( `Page`
                   )->att( n = `title`  v = `abap2UI5 - Hello World`
 
-                  )->ele( n   = `SimpleForm`
-                           ns = `form`
+                  )->ele( n = `SimpleForm` ns = `form`
                       )->att( n = `editable`  v = `true`
-                      )->ele( n   = `content`
-                               ns = `form`
+                      )->ele( n = `content` ns = `form`
 
-                          )->tag( n   = `Title`
-                                   ns = `core`
+                          )->tag( n = `Title` ns = `core`
                               )->att( n = `text`  v = `Enter a value and send it to the server...`
 
                           )->tag( `Label`

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -312,8 +312,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
-    DATA(page) = view->ele( n   = `View`
-                             ns = `mvc`
+    DATA(page) = view->ele( n = `View` ns = `mvc`
         )->att( n = `xmlns`         v = `sap.m`
         )->att( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
         )->att( n = `xmlns:form`    v = `sap.ui.layout.form`
@@ -381,8 +380,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " A Button wraps its icon in button chrome that caps how large it renders;
     " a bare icon takes the size it is given, and 1.125rem is what makes the
     " title row read as icons rather than as shrunken buttons.
-    toolbar->tag( n  = `Icon`
-                  ns = `core`
+    toolbar->tag( n = `Icon` ns = `core`
         )->att( n = `src`      v = icon
         )->att( n = `size`     v = c_icon_size_header
         )->att( n = `class`    v = `sapUiTinyMarginBeginEnd`
@@ -549,8 +547,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " no slot of its own for the icon: every glyph of the icon font renders the
     " same width, so the links line up on the icon alone - a fixed slot only
     " tore a hole between the icon and the name it belongs to
-    result->tag( n   = `Icon`
-                  ns = `core`
+    result->tag( n = `Icon` ns = `core`
         )->att( n = `src`    v = icon
         )->att( n = `color`  v = c_icon_color
         )->att( n = `class`  v = `sapUiTinyMarginEnd` ).
@@ -640,8 +637,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " the popup is opened, which is exactly when somebody asks
     DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( ).
 
-    DATA(dialog) = popup->ele( n   = `FragmentDefinition`
-                                ns = `core`
+    DATA(dialog) = popup->ele( n = `FragmentDefinition` ns = `core`
         )->att( n = `xmlns`       v = `sap.m`
         )->att( n = `xmlns:core`  v = `sap.ui.core`
         )->att( n = `xmlns:form`  v = `sap.ui.layout.form`
@@ -732,8 +728,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
   METHOD create_layout_form.
 
-    result = view->ele( n   = `SimpleForm`
-                         ns = `form`
+    result = view->ele( n = `SimpleForm` ns = `form`
         )->att( n = `editable`                 v = `true`
         )->att( n = `layout`                   v = `ResponsiveGridLayout`
         )->att( n = `labelSpanXL`              v = `4`
@@ -749,8 +744,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
         )->att( n = `columnsL`                 v = `1`
         )->att( n = `columnsM`                 v = `1`
         )->att( n = `singleContainerFullSize`  v = `false`
-        )->ele( n   = `content`
-                 ns = `form` ).
+        )->ele( n = `content` ns = `form` ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

This PR reformats method chaining calls in the UI5 view builder to improve code readability and consistency. Specifically, it consolidates multi-line parameter declarations into single-line format where parameters fit comfortably on one line.

The changes affect method calls like `ele()` and `tag()` where named parameters `n` and `ns` are now placed on the same line instead of being split across multiple lines. This reduces visual clutter while maintaining code clarity.

**Files modified:**
- `src/01/04/z2ui5_cl_ui5_app_start.clas.abap` - 6 method call reformattings
- `src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap` - 5 method call reformattings

## How to test

No functional changes were made. Verify that:
1. The code compiles without errors
2. Existing unit tests pass
3. The UI5 views render identically to before the change

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_012zczYv1PeSxXMsV6Ee6bZL