### PR TITLE
Rename the view builder's att( ) to a( ) and write down the chain layout

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -18,6 +18,13 @@ Quick orientation while it loads:
   everything else PROTECTED.
 - Build views with `z2ui5_cl_ai_xml` (`open`/`leaf`/`a`/`shut`/`stringify`).
   The legacy `z2ui5_cl_xml_view` is frozen — never use it in new code.
+- The chain's layout is strict, not taste: the `)` rides with the arrow
+  (`)->`), every `open` indents its children one level (4 spaces) and `shut`
+  closes at the `open`'s column, a control's `a( )`s sit one level in with
+  their `v =` aligned, and blank lines separate blocks — never a control from
+  its own `a( )`s, never consecutive `leaf`s. Full rules: "Formatting the
+  chain" in §3 of the guide. Same layout for the framework's own
+  `z2ui5_cl_ui5_view_builder` (`ele`/`tag`/`a`/`end`).
 - Bind with `client->_bind( var )` (also for display-only;
   `_bind_edit` is obsolete). Row-template fields bind as `` `{UPPERCASE}` ``.
   Never write a model path as a text literal.

--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -21,10 +21,12 @@ Quick orientation while it loads:
 - The chain's layout is strict, not taste: the `)` rides with the arrow
   (`)->`), every `open` indents its children one level (4 spaces) and `shut`
   closes at the `open`'s column, a control's `a( )`s sit one level in with
-  their `v =` aligned, and blank lines separate blocks — never a control from
-  its own `a( )`s, never consecutive `leaf`s. Full rules: "Formatting the
-  chain" in §3 of the guide. Same layout for the framework's own
-  `z2ui5_cl_ui5_view_builder` (`ele`/`tag`/`a`/`end`).
+  their `v =` aligned. **A blank line marks a descent and nothing else** — it
+  follows a control's attribute block, before its first child; never after an
+  attribute-less one-liner `open`, never between a control and its own
+  `a( )`s, never between consecutive `leaf`s. Full rules and a worked example:
+  "Formatting the chain" in §3 of the guide. Same layout for the framework's
+  own `z2ui5_cl_ui5_view_builder` (`ele`/`tag`/`a`/`end`).
 - Bind with `client->_bind( var )` (also for display-only;
   `_bind_edit` is obsolete). Row-template fields bind as `` `{UPPERCASE}` ``.
   Never write a model path as a text literal.

--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -21,10 +21,11 @@ Quick orientation while it loads:
 - The chain's layout is strict, not taste: the `)` rides with the arrow
   (`)->`), every `open` indents its children one level (4 spaces) and `shut`
   closes at the `open`'s column, a control's `a( )`s sit one level in with
-  their `v =` aligned. **A blank line marks a descent and nothing else** — it
-  follows a control's attribute block, before its first child; never after an
-  attribute-less one-liner `open`, never between a control and its own
-  `a( )`s, never between consecutive `leaf`s. Full rules and a worked example:
+  their `v =` aligned. **A blank line opens a block, and there are exactly
+  two: the content of a control that carries attributes, and a run of
+  `leaf`s.** Nothing else gets one — not between a control and its own
+  `a( )`s, not between consecutive `leaf`s, not after a bare `open` that only
+  descends into another `open`. Full rules and a worked example:
   "Formatting the chain" in §3 of the guide. Same layout for the framework's
   own `z2ui5_cl_ui5_view_builder` (`ele`/`tag`/`a`/`end`).
 - Bind with `client->_bind( var )` (also for display-only;

--- a/.github/abaplint/auto_abaplint_fix.jsonc
+++ b/.github/abaplint/auto_abaplint_fix.jsonc
@@ -26,7 +26,7 @@
     "in_statement_indentation": true,
     "indentation": true,
     "double_space": true,
-    // The two shipped apps write the view builder's att( ) as one line per
+    // The two shipped apps write the view builder's a( ) as one line per
     // attribute - `n` and its value side by side, value column aligned. Both
     // rules below undo that: line_break_multiple_parameters splits any call
     // with more than one parameter, align_parameters then re-indents the

--- a/.github/api-snapshot.json
+++ b/.github/api-snapshot.json
@@ -13,7 +13,7 @@
   "z2ui5_cl_ui5_view_builder.clas.abap#class-methods:factory": "class-methods factory returning value(result) type ref to z2ui5_cl_ui5_view_builder",
   "z2ui5_cl_ui5_view_builder.clas.abap#methods:ele": "methods ele importing n type string ns type string optional returning value(result) type ref to z2ui5_cl_ui5_view_builder",
   "z2ui5_cl_ui5_view_builder.clas.abap#methods:tag": "methods tag importing n type string ns type string optional returning value(result) type ref to z2ui5_cl_ui5_view_builder",
-  "z2ui5_cl_ui5_view_builder.clas.abap#methods:att": "methods att importing n type string v type string optional b type abap_bool optional returning value(result) type ref to z2ui5_cl_ui5_view_builder",
+  "z2ui5_cl_ui5_view_builder.clas.abap#methods:a": "methods a importing n type string v type string optional b type abap_bool optional returning value(result) type ref to z2ui5_cl_ui5_view_builder",
   "z2ui5_cl_ui5_view_builder.clas.abap#methods:end": "methods end returning value(result) type ref to z2ui5_cl_ui5_view_builder",
   "z2ui5_cl_ui5_view_builder.clas.abap#methods:stringify": "methods stringify returning value(result) type string",
   "z2ui5_if_app.intf.abap#interfaces:if_serializable_object": "interfaces if_serializable_object",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ App state is persisted between roundtrips via the draft service (`z2ui5_cl_ui5_s
 ### Key Design Patterns
 
 - **Factory:** `z2ui5_cl_ui5_http_handler=>factory()` / `factory_cloud()` for on-premise vs. cloud
-- **Generic View Builder:** `z2ui5_cl_ui5_view_builder=>factory()` + `ele`/`tag`/`att`/`end`/`stringify` builds any UI5 XML view 1:1 (see `src/02/z2ui5_cl_ui5_view_builder.clas.abap`)
+- **Generic View Builder:** `z2ui5_cl_ui5_view_builder=>factory()` + `ele`/`tag`/`a`/`end`/`stringify` builds any UI5 XML view 1:1 (see `src/02/z2ui5_cl_ui5_view_builder.clas.abap`)
 - **Event Routing:** `client->_event('ID')` registers; `client->check_on_event('ID')` checks
 - **App Navigation:** `client->nav_app_call(app)` pushes; `client->nav_app_leave()` pops (executed in a loop within one roundtrip)
 - **Multi-View:** Main view, nested views (nest/nest2), popups, and popovers simultaneously

--- a/changelog.txt
+++ b/changelog.txt
@@ -123,16 +123,22 @@ unreleased
 ! z2ui5_cl_ui5_view_builder=>new( ) is now factory( ) - the same name the
   predecessor z2ui5_cl_ai_xml uses, so both builders start a view the same
   way and the method no longer shares its name with the NEW operator
-! z2ui5_cl_ui5_view_builder sets every attribute through att( ), and att( )
+! z2ui5_cl_ui5_view_builder=>att( ) is now a( ) - the same one-letter verb
+  the predecessor z2ui5_cl_ai_xml uses, so an attribute is written the same
+  way in both builders and the attribute call stays short enough to sit
+  beside its control. Recorded in the API snapshot as a removal plus an
+  addition; like =>factory( ) above this is a rename inside a class that was
+  added after v1.142.0 and has never been part of a release
+! z2ui5_cl_ui5_view_builder sets every attribute through a( ), and a( )
   now lands on the element it FOLLOWS: the child just added by ele( ) or
   tag( ), or the node itself while it has no children yet. tag( ) is
   therefore the form for any leaf, whatever its attributes are - it used to
-  be that an att( ) after a tag( ) attached to the parent, so a leaf could
+  be that an a( ) after a tag( ) attached to the parent, so a leaf could
   carry literals only, and only through the t_att table. That table is gone,
   with it the public type ty_t_attr that existed to type it and the
   protected parse_attr( ) that split its `key=value` strings on the first
   `=`; a bind or an event now works on a tag( ) like any other value. What
-  the rule costs is its flip side: once an element has a child, att( ) can
+  the rule costs is its flip side: once an element has a child, a( ) can
   no longer reach it, so an element gets its attributes before its first
   child - the test that pinned the opposite (att_after_children) is gone
   with the behavior. The two removals are recorded in the API snapshot; the

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -159,6 +159,42 @@ The legacy fluent builder `z2ui5_cl_xml_view` (one method per control) still
 ships for existing apps but is **frozen** — new apps and new code use
 `z2ui5_cl_ai_xml`.
 
+### Formatting the chain (strict — reviewers check these)
+
+A chain is read far more often than it is written, and its layout is the only
+thing that still makes it legible as the XML tree it stands for. The rules
+below are the ones the sample repositories are ported and reviewed against;
+`.github/abaplint/auto_abaplint_fix.jsonc` excludes the shipped apps from
+`align_parameters` / `line_break_multiple_parameters` so the auto-formatter
+does not undo them.
+
+- **The closing paren rides with the arrow.** Never leave a `)` alone at the
+  end of a line — carry it to the **start of the next segment**, so every
+  continuation reads `)->`. With the `a( )` chain there is no nested `VALUE`,
+  so the whole view ends in a single `` ).`` (not `) ).`).
+- **Indent after every `open`.** Each `open( )` shifts its children's `)->`
+  one level (4 spaces) to the right, `shut( )` shifts back left, and the `)->`
+  of a `shut` sits in the same column as the `open` it closes.
+- **A control's `a( )` lines sit one level (4 spaces) in from the control's
+  own `)->` line** — one attribute per line, `v =` column aligned across the
+  block.
+- **Blank lines** (a control's own `a( )`s never count — they belong to it):
+  - **never** between consecutive `leaf`s, and **never** after a one-liner
+    `open` (an aggregation or container with no attributes) before its first
+    child;
+  - a blank **does** separate an `open` that *has* attributes from its first
+    child, and separates a new `open`/`leaf` block from the previous sibling;
+  - a blank **before** every `shut`; **none** after a `shut` or between two
+    `shut`s;
+  - **none** between a control and its own `a( )`s.
+- Long text or binding values split with `&&` — an `.abap` line is capped at
+  255 characters.
+
+The framework's own generic builder `z2ui5_cl_ui5_view_builder`
+(`ele`/`tag`/`a`/`end`) is laid out by exactly the same rules: `ele` indents
+like `open`, `tag` behaves like `leaf`, `end` closes like `shut`, and the
+attribute verb is the same `a( )`.
+
 ## 4. Data binding
 
 - `client->_bind( var )` binds a PUBLIC attribute: the value renders into

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -84,7 +84,9 @@ CLASS zcl_my_app IMPLEMENTATION.
 
             )->open( `List`
                 )->a( n = `items` v = client->_bind( t_items )
+
                 )->open( `items`
+
                     )->leaf( `StandardListItem`
                         )->a( n = `title` v = `{PRODUCT}`
                         )->a( n = `info`  v = `{QUANTITY}`
@@ -178,43 +180,52 @@ does not undo them.
 - **A control's `a( )` lines sit one level (4 spaces) in from the control's
   own `)->` line** — one attribute per line, `v =` column aligned across the
   block.
-- **A blank line marks a descent, and nothing else** — it separates a
-  control's attribute block from the **child** that follows it. Everything
-  else in the chain runs without blanks. In detail:
-  - **blank** after the last `a( )` of a control, before its first child
-    (`open` or `leaf`) — the attributes belong to the parent, the next line
-    starts its content;
-  - **none** after a one-liner `open` (an aggregation or container with no
-    attributes) before its first child — there is no attribute block to close;
-  - **none** between a control and its own `a( )`s;
-  - **none between consecutive `leaf`s** — a row of leafs is one block,
-    whether or not they carry attributes. This is the rule that overrules
-    "separate a sibling": only a *container* block (an `open` … `shut`) is
-    separated from the sibling before it;
+- **A blank line opens a block — nothing else in the chain gets one.** A
+  block is a run of lines that is read as one thing, and there are exactly
+  two of them:
+  1. **the content of a control that carries attributes** — a blank after its
+     last `a( )`, before its first child. The attribute lines are the
+     control's own head; the content starts below them;
+  2. **a run of `leaf`s** — a blank before the first one, none between them.
+     A form's fields, a toolbar's buttons, a list's items belong together and
+     are read as one block, whether or not each carries attributes.
+
+  Everything else runs without a blank:
+  - **none** between a control and its own `a( )`s — they are its head, not
+    its content;
+  - **none between consecutive `leaf`s** — see block 2. This overrules
+    "separate a sibling": only a *container* block is set off from the
+    sibling before it;
+  - **none** after a bare `open` whose first child is another `open` — a
+    `Shell` → `Page` scaffold is one path down, not two blocks;
   - **blank before every `shut`**; none after a `shut` or between two `shut`s.
 - Long text or binding values split with `&&` — an `.abap` line is capped at
   255 characters.
 
-The two spots the blank-line rule is most often gotten wrong — an
-attribute-less container, and a row of leafs:
+The two blocks, and the scaffold that is neither:
 
 ```abap
-    )->open( n = `SimpleForm` ns = `form`
-        )->a( n = `editable` v = `true`
-                                       " <- blank: SimpleForm's attrs end here
-        )->open( n = `content` ns = `form`
-            )->leaf( n = `Title` ns = `core`
-                )->a( n = `text`  v = `Your data`
-            )->leaf( `Label`
-                )->a( n = `text`  v = `Name`
-            )->leaf( `Input`
-                )->a( n = `value` v = client->_bind( name ) ).
+    )->open( `Shell`                       " bare open into another open -
+        )->open( `Page`                    " one path down, no blank
+            )->a( n = `title` v = `My App`
+                                           " block 1: Page's content starts
+            )->open( n = `SimpleForm` ns = `form`
+                )->a( n = `editable` v = `true`
+                                           " block 1: SimpleForm's content
+                )->open( n = `content` ns = `form`
+                                           " block 2: the run of leafs
+                    )->leaf( n = `Title` ns = `core`
+                        )->a( n = `text`  v = `Your data`
+                    )->leaf( `Label`
+                        )->a( n = `text`  v = `Name`
+                    )->leaf( `Input`
+                        )->a( n = `value` v = client->_bind( name ) ).
 ```
 
-`content` carries no attributes, so nothing separates it from `Title`; the
-three leafs are one block, so nothing separates them from each other either.
-The same view with a blank line after `content` and between the leafs reads
-as four unrelated fragments instead of one form.
+The blank above `Title` is what makes the three fields read as the form's
+content rather than as a continuation of the `content` aggregation; the
+missing blanks between them are what keep the three together. Blanks in both
+places, or in neither, and the same view reads as a pile of fragments.
 
 The framework's own generic builder `z2ui5_cl_ui5_view_builder`
 (`ele`/`tag`/`a`/`end`) is laid out by exactly the same rules: `ele` indents

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -178,17 +178,43 @@ does not undo them.
 - **A control's `a( )` lines sit one level (4 spaces) in from the control's
   own `)->` line** — one attribute per line, `v =` column aligned across the
   block.
-- **Blank lines** (a control's own `a( )`s never count — they belong to it):
-  - **never** between consecutive `leaf`s, and **never** after a one-liner
-    `open` (an aggregation or container with no attributes) before its first
-    child;
-  - a blank **does** separate an `open` that *has* attributes from its first
-    child, and separates a new `open`/`leaf` block from the previous sibling;
-  - a blank **before** every `shut`; **none** after a `shut` or between two
-    `shut`s;
-  - **none** between a control and its own `a( )`s.
+- **A blank line marks a descent, and nothing else** — it separates a
+  control's attribute block from the **child** that follows it. Everything
+  else in the chain runs without blanks. In detail:
+  - **blank** after the last `a( )` of a control, before its first child
+    (`open` or `leaf`) — the attributes belong to the parent, the next line
+    starts its content;
+  - **none** after a one-liner `open` (an aggregation or container with no
+    attributes) before its first child — there is no attribute block to close;
+  - **none** between a control and its own `a( )`s;
+  - **none between consecutive `leaf`s** — a row of leafs is one block,
+    whether or not they carry attributes. This is the rule that overrules
+    "separate a sibling": only a *container* block (an `open` … `shut`) is
+    separated from the sibling before it;
+  - **blank before every `shut`**; none after a `shut` or between two `shut`s.
 - Long text or binding values split with `&&` — an `.abap` line is capped at
   255 characters.
+
+The two spots the blank-line rule is most often gotten wrong — an
+attribute-less container, and a row of leafs:
+
+```abap
+    )->open( n = `SimpleForm` ns = `form`
+        )->a( n = `editable` v = `true`
+                                       " <- blank: SimpleForm's attrs end here
+        )->open( n = `content` ns = `form`
+            )->leaf( n = `Title` ns = `core`
+                )->a( n = `text`  v = `Your data`
+            )->leaf( `Label`
+                )->a( n = `text`  v = `Name`
+            )->leaf( `Input`
+                )->a( n = `value` v = client->_bind( name ) ).
+```
+
+`content` carries no attributes, so nothing separates it from `Title`; the
+three leafs are one block, so nothing separates them from each other either.
+The same view with a blank line after `content` and between the leafs reads
+as four unrelated fragments instead of one form.
 
 The framework's own generic builder `z2ui5_cl_ui5_view_builder`
 (`ele`/`tag`/`a`/`end`) is laid out by exactly the same rules: `ele` indents

--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -32,6 +32,7 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
                       )->a( n = `editable`  v = `true`
 
                       )->ele( n = `content` ns = `form`
+
                           )->tag( n = `Title` ns = `core`
                               )->a( n = `text`  v = `Enter a value and send it to the server...`
                           )->tag( `Label`

--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -30,17 +30,14 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
 
                   )->ele( n = `SimpleForm` ns = `form`
                       )->a( n = `editable`  v = `true`
-                      )->ele( n = `content` ns = `form`
 
+                      )->ele( n = `content` ns = `form`
                           )->tag( n = `Title` ns = `core`
                               )->a( n = `text`  v = `Enter a value and send it to the server...`
-
                           )->tag( `Label`
                               )->a( n = `text`  v = `Name`
-
                           )->tag( `Input`
                               )->a( n = `value`  v = client->_bind( name )
-
                           )->tag( `Button`
                               )->a( n = `text`   v = `Post`
                               )->a( n = `press`  v = client->_event( `BUTTON_POST` ) ).

--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -17,33 +17,33 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
       view->ele( n = `View` ns = `mvc`
-          )->att( n = `xmlns`         v = `sap.m`
-          )->att( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
-          )->att( n = `xmlns:core`    v = `sap.ui.core`
-          )->att( n = `xmlns:form`    v = `sap.ui.layout.form`
-          )->att( n = `displayBlock`  v = `true`
-          )->att( n = `height`        v = `100%`
+          )->a( n = `xmlns`         v = `sap.m`
+          )->a( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
+          )->a( n = `xmlns:core`    v = `sap.ui.core`
+          )->a( n = `xmlns:form`    v = `sap.ui.layout.form`
+          )->a( n = `displayBlock`  v = `true`
+          )->a( n = `height`        v = `100%`
 
           )->ele( `Shell`
               )->ele( `Page`
-                  )->att( n = `title`  v = `abap2UI5 - Hello World`
+                  )->a( n = `title`  v = `abap2UI5 - Hello World`
 
                   )->ele( n = `SimpleForm` ns = `form`
-                      )->att( n = `editable`  v = `true`
+                      )->a( n = `editable`  v = `true`
                       )->ele( n = `content` ns = `form`
 
                           )->tag( n = `Title` ns = `core`
-                              )->att( n = `text`  v = `Enter a value and send it to the server...`
+                              )->a( n = `text`  v = `Enter a value and send it to the server...`
 
                           )->tag( `Label`
-                              )->att( n = `text`  v = `Name`
+                              )->a( n = `text`  v = `Name`
 
                           )->tag( `Input`
-                              )->att( n = `value`  v = client->_bind( name )
+                              )->a( n = `value`  v = client->_bind( name )
 
                           )->tag( `Button`
-                              )->att( n = `text`   v = `Post`
-                              )->att( n = `press`  v = client->_event( `BUTTON_POST` ) ).
+                              )->a( n = `text`   v = `Post`
+                              )->a( n = `press`  v = client->_event( `BUTTON_POST` ) ).
 
       client->view_display( view->stringify( ) ).
 

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -314,16 +314,16 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     DATA(page) = view->ele( n = `View` ns = `mvc`
-        )->att( n = `xmlns`         v = `sap.m`
-        )->att( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
-        )->att( n = `xmlns:form`    v = `sap.ui.layout.form`
-        )->att( n = `xmlns:core`    v = `sap.ui.core`
-        )->att( n = `displayBlock`  v = `true`
-        )->att( n = `height`        v = `100%`
+        )->a( n = `xmlns`         v = `sap.m`
+        )->a( n = `xmlns:mvc`     v = `sap.ui.core.mvc`
+        )->a( n = `xmlns:form`    v = `sap.ui.layout.form`
+        )->a( n = `xmlns:core`    v = `sap.ui.core`
+        )->a( n = `displayBlock`  v = `true`
+        )->a( n = `height`        v = `100%`
         )->ele( `Shell`
         )->ele( `Page`
-            )->att( n = `title`          v = `abap2UI5 - Build UI5 Apps Purely in ABAP`
-            )->att( n = `showNavButton`  v = `false` ).
+            )->a( n = `title`          v = `abap2UI5 - Build UI5 Apps Purely in ABAP`
+            )->a( n = `showNavButton`  v = `false` ).
 
     render_header_toolbar( page ).
 
@@ -396,12 +396,12 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " a bare icon takes the size it is given, and 1.125rem is what makes the
     " title row read as icons rather than as shrunken buttons.
     toolbar->tag( n = `Icon` ns = `core`
-        )->att( n = `src`      v = icon
-        )->att( n = `size`     v = c_icon_size_header
-        )->att( n = `class`    v = class
-        )->att( n = `color`    v = c_icon_color
-        )->att( n = `tooltip`  v = tooltip
-        )->att( n = `press`    v = press ).
+        )->a( n = `src`      v = icon
+        )->a( n = `size`     v = c_icon_size_header
+        )->a( n = `class`    v = class
+        )->a( n = `color`    v = c_icon_color
+        )->a( n = `tooltip`  v = tooltip
+        )->a( n = `press`    v = press ).
 
   ENDMETHOD.
 
@@ -420,8 +420,8 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
                      href    = `https://github.com/abap2UI5/abap2UI5`
                      new_tab = abap_true
       )->tag( `Text`
-          )->att( n = `text`   v = `The repository itself - source code, issues, releases, and what abapGit installs from`
-          )->att( n = `class`  v = `sapUiSmallMarginBegin` ).
+          )->a( n = `text`   v = `The repository itself - source code, issues, releases, and what abapGit installs from`
+          )->a( n = `class`  v = `sapUiSmallMarginBegin` ).
 
     render_icon_row( form    = form
                      label   = `Docs`
@@ -430,8 +430,8 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
                      href    = `https://abap2UI5.org`
                      new_tab = abap_true
       )->tag( `Text`
-          )->att( n = `text`   v = `Guides, tutorials and the API reference - from your first app to the full client API`
-          )->att( n = `class`  v = `sapUiSmallMarginBegin` ).
+          )->a( n = `text`   v = `Guides, tutorials and the API reference - from your first app to the full client API`
+          )->a( n = `class`  v = `sapUiSmallMarginBegin` ).
 
   ENDMETHOD.
 
@@ -440,48 +440,48 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     render_section( form  = form
                     title = `Quickstart - your first app in 5 steps` ).
 
-    form->tag( `Label` )->att( n = `text`  v = `Step 1`
-      )->tag( `Text` )->att( n = `text`   v = `Create a new class in your ABAP system`
-      )->tag( `Label` )->att( n = `text`  v = `Step 2`
-      )->tag( `Text` )->att( n = `text`   v = `Add the interface Z2UI5_IF_APP - that is all it takes`
-      )->tag( `Label` )->att( n = `text`  v = `Step 3`
-      )->tag( `Text` )->att( n = `text`   v = `Define the view and implement the behavior - in pure ABAP` ).
+    form->tag( `Label` )->a( n = `text`  v = `Step 1`
+      )->tag( `Text` )->a( n = `text`   v = `Create a new class in your ABAP system`
+      )->tag( `Label` )->a( n = `text`  v = `Step 2`
+      )->tag( `Text` )->a( n = `text`   v = `Add the interface Z2UI5_IF_APP - that is all it takes`
+      )->tag( `Label` )->a( n = `text`  v = `Step 3`
+      )->tag( `Text` )->a( n = `text`   v = `Define the view and implement the behavior - in pure ABAP` ).
 
     render_link( form = form
                  text = `See a complete example: Hello World`
                  href = `https://github.com/abap2UI5/abap2UI5/blob/main/src/02/z2ui5_cl_ui5_app_hi_world.clas.abap` ).
 
-    form->tag( `Label` )->att( n = `text`  v = `Step 4` ).
+    form->tag( `Label` )->a( n = `text`  v = `Step 4` ).
 
     IF ms_home-class_editable = abap_true.
       form->tag( `Input`
-          )->att( n = `id`              v = c_id_input
-          )->att( n = `placeholder`     v = `Enter your class name and press 'Check'`
-          )->att( n = `enabled`         v = client->_bind( ms_home-class_editable )
-          )->att( n = `value`           v = client->_bind( ms_home-classname )
-          )->att( n = `valueState`      v = client->_bind( ms_home-class_value_state )
-          )->att( n = `valueStateText`  v = client->_bind( ms_home-class_value_state_text )
-          )->att( n = `submit`          v = client->_event( ms_home-btn_event_id )
-          )->att( n = `width`           v = `70%` ).
+          )->a( n = `id`              v = c_id_input
+          )->a( n = `placeholder`     v = `Enter your class name and press 'Check'`
+          )->a( n = `enabled`         v = client->_bind( ms_home-class_editable )
+          )->a( n = `value`           v = client->_bind( ms_home-classname )
+          )->a( n = `valueState`      v = client->_bind( ms_home-class_value_state )
+          )->a( n = `valueStateText`  v = client->_bind( ms_home-class_value_state_text )
+          )->a( n = `submit`          v = client->_event( ms_home-btn_event_id )
+          )->a( n = `width`           v = `70%` ).
     ELSE.
-      form->tag( `Text` )->att( n = `text`  v = ms_home-classname ).
+      form->tag( `Text` )->a( n = `text`  v = ms_home-classname ).
     ENDIF.
 
     form->tag( `Label` ).
     form->tag( `Button`
-        )->att( n = `press`  v = client->_event( ms_home-btn_event_id )
-        )->att( n = `text`   v = client->_bind( ms_home-btn_text )
-        )->att( n = `icon`   v = client->_bind( ms_home-btn_icon )
-        )->att( n = `width`  v = `70%` ).
+        )->a( n = `press`  v = client->_event( ms_home-btn_event_id )
+        )->a( n = `text`   v = client->_bind( ms_home-btn_text )
+        )->a( n = `icon`   v = client->_bind( ms_home-btn_icon )
+        )->a( n = `width`  v = `70%` ).
 
     " not render_link: this one is bound and additionally disabled until the
     " class name was checked
-    form->tag( `Label` )->att( n = `text`  v = `Step 5`
+    form->tag( `Label` )->a( n = `text`  v = `Step 5`
       )->tag( `Link`
-          )->att( n = `text`     v = `Open your application in a new tab`
-          )->att( n = `target`   v = `_blank`
-          )->att( n = `href`     v = client->_bind( ms_home-url )
-          )->att( n = `enabled`  v = client->_bind( ms_home-link_enabled ) ).
+          )->a( n = `text`     v = `Open your application in a new tab`
+          )->a( n = `target`   v = `_blank`
+          )->a( n = `href`     v = client->_bind( ms_home-url )
+          )->a( n = `enabled`  v = client->_bind( ms_home-link_enabled ) ).
 
     " the five steps are one thought - let it end before the next headline.
     " Four rows, not one: this is the break between doing something and reading
@@ -548,29 +548,29 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
     form->tag( `Label` ).
     IF label IS NOT INITIAL.
-      form->att( n = `text`  v = label ).
+      form->a( n = `text`  v = label ).
     ENDIF.
 
     result = form->ele( `HBox`
-        )->att( n = `alignItems`  v = `Center`
-        )->att( n = `wrap`        v = `Wrap` ).
+        )->a( n = `alignItems`  v = `Center`
+        )->a( n = `wrap`        v = `Wrap` ).
 
     " no slot of its own for the icon: every glyph of the icon font renders the
     " same width, so the links line up on the icon alone - a fixed slot only
     " tore a hole between the icon and the name it belongs to
     result->tag( n = `Icon` ns = `core`
-        )->att( n = `src`    v = icon
-        )->att( n = `color`  v = c_icon_color
-        )->att( n = `class`  v = `sapUiTinyMarginEnd` ).
+        )->a( n = `src`    v = icon
+        )->a( n = `color`  v = c_icon_color
+        )->a( n = `class`  v = `sapUiTinyMarginEnd` ).
 
     result->tag( `Link`
-        )->att( n = `text`   v = text
-        )->att( n = `href`   v = href
-        )->att( n = `width`  v = c_link_width ).
+        )->a( n = `text`   v = text
+        )->a( n = `href`   v = href
+        )->a( n = `width`  v = c_link_width ).
 
     " the Link is still the last child, so this attribute lands on it
     IF new_tab = abap_true.
-      result->att( n = `target`  v = `_blank` ).
+      result->a( n = `target`  v = `_blank` ).
     ENDIF.
 
   ENDMETHOD.
@@ -609,21 +609,21 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " what colours icon and text with it - Success green, Warning orange.
     IF lv_class IS INITIAL.
       row->tag( `ObjectStatus`
-          )->att( n = `text`     v = `not installed`
-          )->att( n = `icon`     v = `sap-icon://download`
-          )->att( n = `state`    v = `Warning`
-          )->att( n = `tooltip`  v = `Not installed on this system - the link opens the repository on GitHub, ready to pull with abapGit` ).
+          )->a( n = `text`     v = `not installed`
+          )->a( n = `icon`     v = `sap-icon://download`
+          )->a( n = `state`    v = `Warning`
+          )->a( n = `tooltip`  v = `Not installed on this system - the link opens the repository on GitHub, ready to pull with abapGit` ).
     ELSE.
       row->tag( `ObjectStatus`
-          )->att( n = `text`     v = `installed`
-          )->att( n = `icon`     v = `sap-icon://accept`
-          )->att( n = `state`    v = `Success`
-          )->att( n = `tooltip`  v = `Installed on this system - the link opens its overview app in a new tab` ).
+          )->a( n = `text`     v = `installed`
+          )->a( n = `icon`     v = `sap-icon://accept`
+          )->a( n = `state`    v = `Success`
+          )->a( n = `tooltip`  v = `Installed on this system - the link opens its overview app in a new tab` ).
     ENDIF.
 
     row->tag( `Text`
-        )->att( n = `text`   v = descr
-        )->att( n = `class`  v = `sapUiSmallMarginBegin` ).
+        )->a( n = `text`   v = descr
+        )->a( n = `class`  v = `sapUiSmallMarginBegin` ).
 
   ENDMETHOD.
 
@@ -649,12 +649,12 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     DATA(popup) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     DATA(dialog) = popup->ele( n = `FragmentDefinition` ns = `core`
-        )->att( n = `xmlns`       v = `sap.m`
-        )->att( n = `xmlns:core`  v = `sap.ui.core`
-        )->att( n = `xmlns:form`  v = `sap.ui.layout.form`
+        )->a( n = `xmlns`       v = `sap.m`
+        )->a( n = `xmlns:core`  v = `sap.ui.core`
+        )->a( n = `xmlns:form`  v = `sap.ui.layout.form`
         )->ele( `Dialog`
-            )->att( n = `title`       v = `abap2UI5 - System Information`
-            )->att( n = `afterClose`  v = client->_event( c_event_close ) ).
+            )->a( n = `title`       v = `abap2UI5 - System Information`
+            )->a( n = `afterClose`  v = client->_event( c_event_close ) ).
 
     DATA(content) = dialog->ele( `content` ).
 
@@ -665,23 +665,23 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " is not guessable, and a popup that stayed silent about it would read as
     " if the frontend facts were simply gone
     content->tag( `MessageStrip`
-        )->att( n = `text`      v = `Frontend information - UI5 version, theme, device, requests and logs - is in the developer tools: Ctrl+F12`
-        )->att( n = `type`      v = `Information`
-        )->att( n = `showIcon`  v = `true`
-        )->att( n = `class`     v = `sapUiSmallMarginBeginEnd sapUiTinyMarginTop` ).
+        )->a( n = `text`      v = `Frontend information - UI5 version, theme, device, requests and logs - is in the developer tools: Ctrl+F12`
+        )->a( n = `type`      v = `Information`
+        )->a( n = `showIcon`  v = `true`
+        )->a( n = `class`     v = `sapUiSmallMarginBeginEnd sapUiTinyMarginTop` ).
 
     DATA(form) = create_layout_form( content ).
     DATA(ls_client) = client->get( ).
 
-    form->tag( `Label` )->att( n = `text`  v = `Launchpad active` ).
+    form->tag( `Label` )->a( n = `text`  v = `Launchpad active` ).
     form->tag( `CheckBox`
-        )->att( n = `selected`  b = ls_client-check_launchpad_active
-        )->att( n = `enabled`   v = `false` ).
+        )->a( n = `selected`  b = ls_client-check_launchpad_active
+        )->a( n = `enabled`   v = `false` ).
 
-    form->tag( `Label` )->att( n = `text`  v = `ABAP for Cloud` ).
+    form->tag( `Label` )->a( n = `text`  v = `ABAP for Cloud` ).
     form->tag( `CheckBox`
-        )->att( n = `selected`  b = z2ui5_cl_ui5_util_context=>check_abap_cloud( )
-        )->att( n = `enabled`   v = `false` ).
+        )->a( n = `selected`  b = z2ui5_cl_ui5_util_context=>check_abap_cloud( )
+        )->a( n = `enabled`   v = `false` ).
     render_text( form  = form
                  label = `User Exit`
                  text  = z2ui5_cl_ui5_user_exit=>get_user_exit_class( ) ).
@@ -696,9 +696,9 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
     dialog->ele( `endButton`
         )->tag( `Button`
-            )->att( n = `text`   v = `Close`
-            )->att( n = `press`  v = client->_event( c_event_close )
-            )->att( n = `type`   v = `Emphasized` ).
+            )->a( n = `text`   v = `Close`
+            )->a( n = `press`  v = client->_event( c_event_close )
+            )->a( n = `type`   v = `Emphasized` ).
 
     client->popup_display( popup->stringify( ) ).
 
@@ -714,9 +714,9 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " section apart from the one above without a separator line.
     form->ele( `Toolbar`
         )->tag( `Title`
-            )->att( n = `text`   v = title
-            )->att( n = `level`  v = `H3`
-            )->att( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
+            )->a( n = `text`   v = title
+            )->a( n = `level`  v = `H3`
+            )->a( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
       )->end( ).
 
   ENDMETHOD.
@@ -731,41 +731,41 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
     form->tag( `Label` ).
     IF label IS NOT INITIAL.
-      form->att( n = `text`  v = label ).
+      form->a( n = `text`  v = label ).
     ENDIF.
 
     form->tag( `Link`
-        )->att( n = `text`    v = text
-        )->att( n = `target`  v = `_blank`
-        )->att( n = `href`    v = href ).
+        )->a( n = `text`    v = text
+        )->a( n = `target`  v = `_blank`
+        )->a( n = `href`    v = href ).
 
   ENDMETHOD.
 
   METHOD render_text.
 
-    form->tag( `Label` )->att( n = `text`  v = label
-      )->tag( `Text` )->att( n = `text`  v = text ).
+    form->tag( `Label` )->a( n = `text`  v = label
+      )->tag( `Text` )->a( n = `text`  v = text ).
 
   ENDMETHOD.
 
   METHOD create_layout_form.
 
     result = view->ele( n = `SimpleForm` ns = `form`
-        )->att( n = `editable`                 v = `true`
-        )->att( n = `layout`                   v = `ResponsiveGridLayout`
-        )->att( n = `labelSpanXL`              v = `4`
-        )->att( n = `labelSpanL`               v = `3`
-        )->att( n = `labelSpanM`               v = `4`
-        )->att( n = `labelSpanS`               v = `12`
-        )->att( n = `adjustLabelSpan`          v = `false`
-        )->att( n = `emptySpanXL`              v = `0`
-        )->att( n = `emptySpanL`               v = `4`
-        )->att( n = `emptySpanM`               v = `0`
-        )->att( n = `emptySpanS`               v = `0`
-        )->att( n = `columnsXL`                v = `1`
-        )->att( n = `columnsL`                 v = `1`
-        )->att( n = `columnsM`                 v = `1`
-        )->att( n = `singleContainerFullSize`  v = `false`
+        )->a( n = `editable`                 v = `true`
+        )->a( n = `layout`                   v = `ResponsiveGridLayout`
+        )->a( n = `labelSpanXL`              v = `4`
+        )->a( n = `labelSpanL`               v = `3`
+        )->a( n = `labelSpanM`               v = `4`
+        )->a( n = `labelSpanS`               v = `12`
+        )->a( n = `adjustLabelSpan`          v = `false`
+        )->a( n = `emptySpanXL`              v = `0`
+        )->a( n = `emptySpanL`               v = `4`
+        )->a( n = `emptySpanM`               v = `0`
+        )->a( n = `emptySpanS`               v = `0`
+        )->a( n = `columnsXL`                v = `1`
+        )->a( n = `columnsL`                 v = `1`
+        )->a( n = `columnsM`                 v = `1`
+        )->a( n = `singleContainerFullSize`  v = `false`
         )->ele( n = `content` ns = `form` ).
 
   ENDMETHOD.

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -320,6 +320,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
         )->a( n = `xmlns:core`    v = `sap.ui.core`
         )->a( n = `displayBlock`  v = `true`
         )->a( n = `height`        v = `100%`
+
         )->ele( `Shell`
         )->ele( `Page`
             )->a( n = `title`          v = `abap2UI5 - Build UI5 Apps Purely in ABAP`
@@ -652,6 +653,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
         )->a( n = `xmlns`       v = `sap.m`
         )->a( n = `xmlns:core`  v = `sap.ui.core`
         )->a( n = `xmlns:form`  v = `sap.ui.layout.form`
+
         )->ele( `Dialog`
             )->a( n = `title`       v = `abap2UI5 - System Information`
             )->a( n = `afterClose`  v = client->_event( c_event_close ) ).

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -697,6 +697,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
                  text  = |{ lo_draft->count_entries( ) } / { lo_draft->count_entries_total( ) }| ).
 
     dialog->ele( `endButton`
+
         )->tag( `Button`
             )->a( n = `text`   v = `Close`
             )->a( n = `press`  v = client->_event( c_event_close )
@@ -715,11 +716,13 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " pulls it over the rows it introduces; the top/bottom pair is what sets one
     " section apart from the one above without a separator line.
     form->ele( `Toolbar`
+
         )->tag( `Title`
             )->a( n = `text`   v = title
             )->a( n = `level`  v = `H3`
             )->a( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
-      )->end( ).
+
+    )->end( ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_ui5_view_builder.clas.abap
+++ b/src/02/z2ui5_cl_ui5_view_builder.clas.abap
@@ -1,20 +1,20 @@
 "! Generic UI5 XML view builder - translate a UI5 XML view 1:1 by method
-"! chaining. The four navigating methods are three-letter abbreviations of the
-"! term they stand for:
+"! chaining. The navigating methods are abbreviations of the term they stand
+"! for - the attribute verb is the single `a`, exactly as in z2ui5_cl_ai_xml:
 "!   factory         a new empty builder root
 "!   ele - element   add a child element and DESCEND into it (returns the child)
 "!   tag - tag       add a child element and STAY here (returns the same node)
-"!   att - attribute set an attribute on the element it follows
+"!   a   - attribute set an attribute on the element it follows
 "!   end - end       ascend to the parent element (returns the parent)
 "!   stringify       render the whole view, always from the root
 "! Element = n (name), namespace prefix = ns (e.g. `f`, `core`, `l`).
-"! There is exactly one rule: att( ) applies to the element the chain is
+"! There is exactly one rule: a( ) applies to the element the chain is
 "! POINTING AT - the child just added by ele( )/tag( ), or the node itself
-"! while it has no children yet. So an att( ) always follows the control it
+"! while it has no children yet. So an a( ) always follows the control it
 "! belongs to, no matter whether that control was opened with ele( ) or added
-"! with tag( ), and every attribute is set by its own att( ).
+"! with tag( ), and every attribute is set by its own a( ).
 "! Reach for tag( ) on a leaf and for ele( )/end( ) on a container. The flip
-"! side of the rule: once an element has a child, att( ) can no longer reach
+"! side of the rule: once an element has a child, a( ) can no longer reach
 "! it - give an element its attributes before its first child.
 "! Every ele( ) may be closed by an end( );
 "! a trailing end( ) at the end of the chain can be omitted, because stringify( )
@@ -23,13 +23,13 @@
 "! exactly like a real UI5 view:
 "!   DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 "!   view->ele( n = `View` ns = `mvc`
-"!       )->att( n = `xmlns`     v = `sap.m`
-"!       )->att( n = `xmlns:mvc` v = `sap.ui.core.mvc` ) ...
+"!       )->a( n = `xmlns`     v = `sap.m`
+"!       )->a( n = `xmlns:mvc` v = `sap.ui.core.mvc` ) ...
 "! `v` may be any string expression (literal, a client bind/event, || template).
 "! For a boolean pass b instead of v - it renders `true` / `false`, so an ABAP
 "! flag reaches the view without a conversion of its own:
-"!   )->att( n = `editable` b = mv_edit_mode
-"!   )->att( n = `visible`  b = xsdbool( lines( mt_item ) > 0 ) )
+"!   )->a( n = `editable` b = mv_edit_mode
+"!   )->a( n = `visible`  b = xsdbool( lines( mt_item ) > 0 ) )
 CLASS z2ui5_cl_ui5_view_builder DEFINITION PUBLIC CREATE PRIVATE.
 
   PUBLIC SECTION.
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_ui5_view_builder DEFINITION PUBLIC CREATE PRIVATE.
         VALUE(result) TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     "! add a child element and descend into it - the returned reference is the
-    "! new element, so a following att( ) lands on it
+    "! new element, so a following a( ) lands on it
     METHODS ele
       IMPORTING
         n             TYPE string
@@ -50,7 +50,7 @@ CLASS z2ui5_cl_ui5_view_builder DEFINITION PUBLIC CREATE PRIVATE.
         VALUE(result) TYPE REF TO z2ui5_cl_ui5_view_builder.
 
     "! add a child element and STAY on the current one, so the next tag( ) or
-    "! ele( ) becomes its sibling and no end( ) is needed. A following att( )
+    "! ele( ) becomes its sibling and no end( ) is needed. A following a( )
     "! still lands on the tag, because it is now this node's last child - the
     "! form for a leaf, whatever its attributes are.
     METHODS tag
@@ -65,7 +65,7 @@ CLASS z2ui5_cl_ui5_view_builder DEFINITION PUBLIC CREATE PRIVATE.
     "! Pass either v (any string expression) or b (an ABAP boolean, rendered
     "! as `true` / `false`) - exactly one of the two, never both and never
     "! neither.
-    METHODS att
+    METHODS a
       IMPORTING
         n             TYPE string
         v             TYPE string    OPTIONAL
@@ -146,11 +146,11 @@ CLASS z2ui5_cl_ui5_view_builder IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD att.
+  METHOD a.
 
     " one rule: the attribute lands on the element the chain is pointing at -
     " the child just added by ele( )/tag( ), or this node itself while it has
-    " no children yet. That way att( ) follows the control it belongs to
+    " no children yet. That way a( ) follows the control it belongs to
     " whether that control was opened with ele( ) or added with tag( ).
     " fail fast instead of dropping silently: on the empty builder root there
     " is no element to attach to, and a duplicate name renders invalid XML

--- a/src/02/z2ui5_cl_ui5_view_builder.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_ui5_view_builder.clas.testclasses.abap
@@ -4,9 +4,9 @@ CLASS ltcl_builder DEFINITION FINAL FOR TESTING
 
   PRIVATE SECTION.
     METHODS render_nested_view FOR TESTING.
-    METHODS att_after_ele_hits_the_element FOR TESTING.
-    METHODS att_after_tag_hits_the_tag FOR TESTING.
-    METHODS att_after_end_hits_closed_ele FOR TESTING.
+    METHODS a_after_ele_hits_the_element FOR TESTING.
+    METHODS a_after_tag_hits_the_tag FOR TESTING.
+    METHODS a_after_end_hits_closed_ele FOR TESTING.
     METHODS tag_stays_and_siblings FOR TESTING.
     METHODS trailing_end_is_optional FOR TESTING.
     METHODS escape_attribute_value FOR TESTING.
@@ -23,11 +23,11 @@ CLASS ltcl_builder IMPLEMENTATION.
 
     view->ele( n  = `View`
                ns = `mvc`
-        )->att( n = `xmlns`
+        )->a( n = `xmlns`
                 v = `sap.m`
 
         )->tag( `Text`
-            )->att( n = `text`
+            )->a( n = `text`
                     v = `Hello`
 
         )->ele( `Panel`
@@ -40,17 +40,17 @@ CLASS ltcl_builder IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD att_after_ele_hits_the_element.
+  METHOD a_after_ele_hits_the_element.
 
-    " ele( ) descends into a node that has no children yet, so att( ) sets the
+    " ele( ) descends into a node that has no children yet, so a( ) sets the
     " attribute on that node itself
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Page`
-        )->att( n = `title`
+        )->a( n = `title`
                 v = `Home`
         )->ele( `Panel`
-            )->att( n = `width`
+            )->a( n = `width`
                     v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -60,16 +60,16 @@ CLASS ltcl_builder IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD att_after_tag_hits_the_tag.
+  METHOD a_after_tag_hits_the_tag.
 
     " tag( ) does not move, but the tag is now this node's last child, so the
-    " att( ) still reaches it - this is what makes tag( ) usable for a leaf
+    " a( ) still reaches it - this is what makes tag( ) usable for a leaf
     " that carries attributes
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Panel`
         )->tag( `Title`
-            )->att( n = `width`
+            )->a( n = `width`
                     v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -79,10 +79,10 @@ CLASS ltcl_builder IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD att_after_end_hits_closed_ele.
+  METHOD a_after_end_hits_closed_ele.
 
     " after end( ) the chain stands on the parent, whose last child is the
-    " container just closed - so att( ) attaches to that container, not to the
+    " container just closed - so a( ) attaches to that container, not to the
     " parent. The flip side of the rule: an element that already has children
     " can no longer be given an attribute
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
@@ -91,7 +91,7 @@ CLASS ltcl_builder IMPLEMENTATION.
         )->ele( `Panel`
             )->tag( `Title`
         )->end(
-        )->att( n = `width`
+        )->a( n = `width`
                 v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -104,16 +104,16 @@ CLASS ltcl_builder IMPLEMENTATION.
   METHOD tag_stays_and_siblings.
 
     " tag( ) does not move, so siblings follow directly and no end( ) is
-    " needed - each att( ) block travels with the tag it follows
+    " needed - each a( ) block travels with the tag it follows
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Page`
         )->tag( `Text`
-            )->att( n = `text`
+            )->a( n = `text`
                     v = `first`
         )->tag( n  = `Text`
                 ns = `m`
-            )->att( n = `text`
+            )->a( n = `text`
                     v = `second`
         )->tag( `ToolbarSpacer` ).
 
@@ -145,7 +145,7 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->tag( `Text`
-        )->att( n = `text`
+        )->a( n = `text`
                 v = `a<b>&"c` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -162,7 +162,7 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->tag( `Text`
-        )->att( n = `text`
+        )->a( n = `text`
                 v = |line1{ z2ui5_cl_ui5_util_context=>cv_char_util_newline }line2{ z2ui5_cl_ui5_util_context=>cv_char_util_horizontal_tab }end| ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -179,9 +179,9 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Panel`
-        )->att( n = `visible`
+        )->a( n = `visible`
                 b = abap_true
-        )->att( n = `expanded`
+        )->a( n = `expanded`
                 b = abap_false ).
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/02/z2ui5_cl_ui5_view_builder.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_ui5_view_builder.clas.testclasses.abap
@@ -23,11 +23,11 @@ CLASS ltcl_builder IMPLEMENTATION.
 
     view->ele( n  = `View`
                ns = `mvc`
-        )->a( n = `xmlns`
+        )->a( n   = `xmlns`
                 v = `sap.m`
 
         )->tag( `Text`
-            )->a( n = `text`
+            )->a( n   = `text`
                     v = `Hello`
 
         )->ele( `Panel`
@@ -47,10 +47,10 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Page`
-        )->a( n = `title`
+        )->a( n   = `title`
                 v = `Home`
         )->ele( `Panel`
-            )->a( n = `width`
+            )->a( n   = `width`
                     v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -69,7 +69,7 @@ CLASS ltcl_builder IMPLEMENTATION.
 
     view->ele( `Panel`
         )->tag( `Title`
-            )->a( n = `width`
+            )->a( n   = `width`
                     v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -91,7 +91,7 @@ CLASS ltcl_builder IMPLEMENTATION.
         )->ele( `Panel`
             )->tag( `Title`
         )->end(
-        )->a( n = `width`
+        )->a( n   = `width`
                 v = `100%` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -109,11 +109,11 @@ CLASS ltcl_builder IMPLEMENTATION.
 
     view->ele( `Page`
         )->tag( `Text`
-            )->a( n = `text`
+            )->a( n   = `text`
                     v = `first`
         )->tag( n  = `Text`
                 ns = `m`
-            )->a( n = `text`
+            )->a( n   = `text`
                     v = `second`
         )->tag( `ToolbarSpacer` ).
 
@@ -145,7 +145,7 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->tag( `Text`
-        )->a( n = `text`
+        )->a( n   = `text`
                 v = `a<b>&"c` ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -162,7 +162,7 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->tag( `Text`
-        )->a( n = `text`
+        )->a( n   = `text`
                 v = |line1{ z2ui5_cl_ui5_util_context=>cv_char_util_newline }line2{ z2ui5_cl_ui5_util_context=>cv_char_util_horizontal_tab }end| ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -179,9 +179,9 @@ CLASS ltcl_builder IMPLEMENTATION.
     DATA(view) = z2ui5_cl_ui5_view_builder=>factory( ).
 
     view->ele( `Panel`
-        )->a( n = `visible`
+        )->a( n   = `visible`
                 b = abap_true
-        )->a( n = `expanded`
+        )->a( n   = `expanded`
                 b = abap_false ).
 
     cl_abap_unit_assert=>assert_equals(


### PR DESCRIPTION
z2ui5_cl_ui5_view_builder set attributes through att( ) while its predecessor z2ui5_cl_ai_xml uses the single-letter a( ). Two builders, two spellings for the same verb, and the longer one pushes every attribute line two columns further from the control it belongs to. att( ) is now a( ) in both the class and its two callers (the start page and the hello-world app); the API snapshot records the removal plus the addition. Like the =>new( ) to =>factory( ) rename before it, this is a rename inside a class added after v1.142.0 that has never been part of a release, so no downstream app can hold the old name.

The layout of the builder chain was only ever carried by example. The formatting rules the sample repositories are ported and reviewed against - the closing paren riding with the arrow, one indent level per open( ), the a( ) block one level in with its v = column aligned, and which blank lines belong where - are now written down in section 3 of docs/agents/building-apps.md, with the short form in the build-an-app skill that points at it. Same rules for the framework's own builder, where ele indents like open, tag behaves like leaf and end closes like shut.


Claude-Session: https://claude.ai/code/session_01UTLV6ghZkpsHPXTm8uwaoF

# Description

<!-- A clear description of what this PR changes and why the change is needed. -->

## How to test

<!-- Steps to verify the change: app snippet, test to run, or scenario to click through. -->

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no
