### PR TITLE
Refactor page header to use customHeader Bar instead of Page title

### DIFF
--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -322,10 +322,10 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
         )->a( n = `height`        v = `100%`
 
         )->ele( `Shell`
-        )->ele( `Page`
-            )->a( n = `title`          v = `abap2UI5 - Build UI5 Apps Purely in ABAP`
-            )->a( n = `showNavButton`  v = `false` ).
+        )->ele( `Page` ).
 
+    " no title on the Page: the title row is built as a Bar in its custom
+    " header, which is what render_header_toolbar( ) does - see there
     render_header_toolbar( page ).
 
     DATA(form) = create_layout_form( page ).
@@ -339,21 +339,35 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
   METHOD render_header_toolbar.
 
-    " icons only, the way the samples app carries them - the title row is not
-    " the place for labels, and what each one does is in its tooltip.
+    " The title row, built the way the three overview apps of the family build
+    " theirs (z2ui5_cl_smp_app_000=>render_header): a sap.m.Bar in the page's
+    " customHeader rather than the Page's own title and headerContent. Same
+    " controls either way - a Page renders its stock header as a Bar too - but
+    " the title becomes a Title control in contentLeft, and a Bar child carries
+    " the margin that sets it off from the window edge. The stock Page title
+    " sits flush against it, which reads as if the heading belonged to the
+    " browser rather than to the page.
+    DATA(bar) = page->ele( `customHeader` )->ele( `Bar` ).
+
+    bar->ele( `contentLeft`
+        )->tag( `Title`
+            )->a( n = `text`   v = `abap2UI5 - Build UI5 Apps Purely in ABAP`
+            )->a( n = `level`  v = `H2` ).
+
+    " right: icons only, the way the samples app carries them - the title row
+    " is not the place for labels, and what each one does is in its tooltip.
     "
-    " ONLY INLINE CONTROLS BELONG IN HERE. sap.m.Page forwards headerContent
-    " into the contentRight aggregation of its internal sap.m.Bar, and that
-    " container became a flex box only after 1.71: on the oldest release
-    " abap2UI5 supports, .sapMBarRight is a plain absolutely positioned block
-    " that lays its children out in normal flow. A block-level child - and
-    " both ToolbarSpacer and ToolbarSeparator render a <div> - therefore
-    " starts a new line, and everything from that line on is cut away by the
+    " ONLY INLINE CONTROLS BELONG IN HERE. A sap.m.Bar's content containers
+    " became flex boxes only after 1.71: on the oldest release abap2UI5
+    " supports, .sapMBarRight is a plain absolutely positioned block that lays
+    " its children out in normal flow. A block-level child - and both
+    " ToolbarSpacer and ToolbarSeparator render a <div> - therefore starts a
+    " new line, and everything from that line on is cut away by the
     " overflow:hidden the container carries at the bar's height of 3rem. On
     " 1.71 that silently swallowed the documentation and repository icons,
     " while newer releases showed all of them.
     " No ToolbarSpacer either: contentRight is right-aligned on its own.
-    DATA(toolbar) = page->ele( `headerContent` ).
+    DATA(toolbar) = bar->ele( `contentRight` ).
 
     " first what this system is: the information popup, and the configuration
     " when it is installed. Sliders rather than a monitor on the first one -


### PR DESCRIPTION
# Description

Refactors the application header rendering to use a `sap.m.Bar` in the page's `customHeader` aggregation instead of relying on the `Page` control's built-in `title` property. This aligns with the pattern used by other overview apps in the family (z2ui5_cl_smp_app_000).

**Key changes:**
- Removed `title` and `showNavButton` attributes from the `Page` element
- Created a `Bar` control in `customHeader` with a `Title` control in `contentLeft` for the application heading
- Moved toolbar icons from `headerContent` to the Bar's `contentRight` aggregation
- Updated comments to explain the rationale: the custom Bar approach provides proper margin spacing and prevents the heading from appearing flush against the window edge

**Why this change:**
The stock Page title renders flush against the window edge, which can visually suggest the heading belongs to the browser rather than the page. Using a Bar in customHeader (as the samples apps do) provides proper spacing and a more polished appearance. Additionally, this approach ensures consistent styling across the application family.

## How to test

1. Run the application and verify the header displays correctly with proper spacing
2. Confirm the application title "abap2UI5 - Build UI5 Apps Purely in ABAP" appears in the header
3. Verify all toolbar icons (information, configuration, etc.) are visible and functional in the right section of the header
4. Test on older UI5 versions (1.71+) to ensure toolbar icons display correctly without overflow issues

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [ ] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [ ] Public API in `src/02/` only changed additively
- [ ] Changes were made via abapGit: yes / no

https://claude.ai/code/session_01AatT5g7XQH5xShky1E99Nf