### PR TITLE
Document chain formatting rules and trailing whitespace checks

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: abap-check
-description: The catalogue of ABAP problems a green CI does not catch - abapGit round-trip and import failures (BOM, line endings, EOF newline, 255-character lines, metadata sidecars for CLAS and for DDLS/BDEF/TABL), activation errors abaplint does not model (class_constructor visibility, LOCAL FRIENDS, generic types on older releases, RAP and CDS), extended-check (SLIN/ATC) traps, downport and transpiler traps, and runtime breakage that only shows on a real system. Use before finishing any change under src/, after editing a .clas.xml or any other metadata sidecar, when a pull into a system produced unexpected diffs, an import error or an activation error - and add the case here whenever a new one is found.
+description: The catalogue of ABAP problems a green CI does not catch - abapGit round-trip and import failures (BOM, line endings, trailing whitespace, EOF newline, 255-character lines, metadata sidecars for CLAS and for DDLS/BDEF/TABL), activation errors abaplint does not model (class_constructor visibility, LOCAL FRIENDS, generic types on older releases, RAP and CDS), extended-check (SLIN/ATC) traps, downport and transpiler traps, and runtime breakage that only shows on a real system. Use before finishing any change under src/, after editing a .clas.xml or any other metadata sidecar, when a pull into a system produced unexpected diffs, an import error or an activation error - and add the case here whenever a new one is found.
 ---
 
 # What a green CI does not prove
@@ -156,9 +156,38 @@ below, one step earlier.
   entry is stale. The gate cannot know which components have a description in
   the system — you have to look.
 
-Deliberately **not** gated: trailing whitespace. abaplint's `whitespace_end`
-owns it for `src/01` and `src/02`, and the historical blanks in mirrored
-`src/00` and frozen `src/99` are not ours to fix.
+### Trailing whitespace — owned by a rule that is not in every repository
+
+The ABAP editor strips a trailing blank when it saves, so a line that ends in
+one comes back different on the next pull — the same defect as the rest of
+this section, and the one most likely to be *written* here, because reflowing
+a chain or a string template leaves blanks behind that no diff view shows.
+
+It is not in the abapGit gate: in **this** repository abaplint's
+`whitespace_end` already owns it for `src/01` and `src/02`, and the historical
+blanks in mirrored `src/00` and frozen `src/99` are not ours to fix.
+
+**That rule is per repository, and it is not everywhere.** `abap2UI5/samples`
+had no `whitespace_end` in its `abaplint.jsonc` at all: the port of the corpus
+to `z2ui5_cl_ui5_view_builder` (`#752`) left a trailing blank on seven lines in
+seven app classes, all four CI workflows stayed green, and a maintainer had to
+find and push them by hand — `b7edbc6` "fix abaplint diffs". The rule is
+enabled there now, so that specific hole is closed.
+
+So, before you finish in **any** repository: if its abaplint config does not
+list `whitespace_end`, the check is yours.
+
+```
+grep -rnP '[ \t]+$' --include='*.abap' --include='*.xml' src/ && echo "trailing whitespace"
+```
+
+(`grep -E '[ \t]+$'` does **not** work — in a POSIX bracket expression `\t` is
+a backslash and a `t`, so it matches every line ending in `t`, which is why a
+scan can come back full of hits and still have found nothing. Use `-P`.) Strip
+what it finds with `sed -i 's/[[:space:]]\+$//'` — that is all
+`npm run strip_trailing_ws` does — and add `whitespace_end` to that
+repository's abaplint config in the same pull request once the tree is clean.
+That is what turns one fix into the last one.
 
 ## 2. Activation — compiles here, syntax error there
 

--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -34,6 +34,21 @@ Quick orientation while it loads:
   `a( )`s, not between consecutive `tag`s, not after a bare `ele` that only
   descends into another `ele`. Full rules and a worked example:
   "Formatting the chain" in §3 of the guide.
+- **The indent has to state the depth: 4 spaces per level, never 2, and one
+  descent per line.** A line may open the next element at its end
+  (`` )->tag( `Label` ``); it may not open two, and
+  `` )->end( )->end( )->ele( … )->ele( … `` at the end of an attribute line is
+  the shape that makes a chain unreadable. When you need a node again, hold it
+  in a variable (`` DATA(page) = view->ele( `Shell` )->ele( `Page` … ) ``) and
+  start a new statement per subtree — never unwind with a run of `end( )`s.
+- **Do not expect a gate to catch a mangled chain.** abaplint's formatting
+  rules are off for app code on purpose; the abap2UI5-linter's
+  `chain-indentation` / `chain-element-per-line` do judge it but ship as
+  `hint`, which a `failOn: warning` config never prints — and in `samples` 339
+  of them sit in the baseline. Read the repository's `abap2ui5lint.jsonc`
+  before you trust a green run, and re-read the chain you wrote against §3's
+  example. `samples` `z2ui5_cl_smp_app_052` came out of a port unreadable and
+  every gate stayed green.
 - Bind with `client->_bind( var )` (also for display-only;
   `_bind_edit` is obsolete). Row-template fields bind as `` `{UPPERCASE}` ``.
   Never write a model path as a text literal.

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -190,6 +190,32 @@ does not undo them.
 - **Indent after every `ele`.** Each `ele( )` shifts its children's `)->`
   one level (4 spaces) to the right, `end( )` shifts back left, and the `)->`
   of an `end` sits in the same column as the `ele` it closes.
+- **The indent *states* the depth — 4 spaces, never 2.** The column a line
+  starts in is the only place the reader can see where in the tree they are,
+  so it has to be true: same depth, same column; one level deeper, exactly
+  four more. A step of two, or a line that changes depth and leaves the next
+  line in the old column, and the layout is no longer describing the XML — it
+  is decorating it.
+- **One descent per line, and never a descent behind an `end( )`.** Two things
+  may share a line with the call that opens them, because neither hides
+  anything: a control and its own attributes
+  (`` )->tag( `Label` )->a( n = `text` … ``), and a bare container handing
+  straight over to the next (`` view->ele( `Shell` )->ele( `Page` ``,
+  `` popover->ele( `footer` )->ele( `OverflowToolbar` ``). A *subtree* may
+  not. `` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar` `` at the
+  end of an attribute line — up two, down two — is the shape that destroys a
+  chain: four level changes nobody can follow, and every line after them
+  starts in a column that means nothing.
+- **Come back to a node through a variable, not through a run of `end( )`s.**
+  `end( )` is for closing what you are finished with, one level, at the start
+  of its own line. When you need a node *again* — a page you hang three
+  sections off, a `footer` beside a form — keep it: `` DATA(page) =
+  view->ele( `Shell` )->ele( `Page` … ) ``, then `page->ele( … )` per subtree,
+  each its own statement, each starting at the method's indent. Every app in
+  the framework and in `abap2UI5/samples` is built this way, and it is what
+  keeps the rule above satisfiable: a statement that never unwinds can indent
+  monotonically. A subtree deep enough that its lines drift past the
+  right-hand side of the screen is telling you the same thing — split it.
 - **A control's `a( )` lines sit one level (4 spaces) in from the control's
   own `)->` line** — one attribute per line, `v =` column aligned across the
   block.
@@ -239,6 +265,69 @@ The blank above `Title` is what makes the three fields read as the form's
 content rather than as a continuation of the `content` aggregation; the
 missing blanks between them are what keep the three together. Blanks in both
 places, or in neither, and the same view reads as a pile of fragments.
+
+**Do not expect a gate to catch this for you.** abaplint's formatting rules
+are deliberately kept off the app chains (`align_parameters` and
+`line_break_multiple_parameters` are excluded in
+`.github/abaplint/auto_abaplint_fix.jsonc`, `indentation` is off — they would
+flatten exactly the layout this section builds). The abap2UI5-linter does
+judge it, with two rules — `chain-indentation` (a sibling in a different
+column than its siblings, a call written left of the element it belongs to;
+the step *size* is not judged, only that a chain keeps its own rhythm) and
+`chain-element-per-line` (several controls on one line; attributes may share
+their control's line, and so may the container it opens) — **but both ship as
+`hint`, and a config with `failOn: warning` does not even print them.** In
+`abap2UI5/samples` they are muted twice over: 339 `chain-element-per-line`
+findings went into `abap2ui5lint-baseline.json` when the linter was adopted,
+one of them the `` view->ele( `Shell` )->ele( `Page` `` idiom that repository
+documents. So check the config of the repository you are in before you trust
+a green run — and either way, re-read the chain you just wrote against the
+example above.
+
+#### What a broken chain looks like
+
+From `abap2UI5/samples` `z2ui5_cl_smp_app_052`, after the port to this builder
+— lint-green, and unreadable:
+
+```abap
+    lo_popover->ele( `Popover`
+        )->a( n = `title`        v = |abap2UI5 - Popover - { mv_product }|
+        )->a( n = `contentWidth` v = `20rem` )->ele( n = `SimpleForm` ns = `form`
+          )->a( n = `layout`   v = `ColumnLayout`
+          )->a( n = `editable` b = abap_false )->ele( n = `content` ns = `form` )->tag( `Label`
+              )->a( n = `text` v = `Product` )->tag( `Text`
+              )->a( n = `text` v = mv_product )->tag( `Text`
+              )->a( n = `text` v = `this is a text` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar`
+              )->tag( `ToolbarSpacer` )->tag( `Button`
+                )->a( n = `press` v = client->_event( `BUTTON_DETAILS` ) ).
+```
+
+Three defects, and they compound: the indent steps by 2 and then by 4 and then
+stops moving at all; one line opens `content` *and* a `Label`; and the
+`` )->end( )->end( )->ele( `footer` )->ele( `OverflowToolbar` `` at the end of
+an attribute line leaves the `ToolbarSpacer` two levels away from where its
+column claims it is. Nothing here says `footer` is a sibling of `SimpleForm`.
+The same tree, with the subtree held in a variable:
+
+```abap
+    DATA(popover) = lo_popover->ele( `Popover`
+        )->a( n = `title`        v = |abap2UI5 - Popover - { mv_product }|
+        )->a( n = `contentWidth` v = `20rem` ).
+
+    popover->ele( n = `SimpleForm` ns = `form`
+        )->a( n = `layout`   v = `ColumnLayout`
+        )->a( n = `editable` b = abap_false
+        )->ele( n = `content` ns = `form`
+            )->tag( `Label` )->a( n = `text` v = `Product`
+            )->tag( `Text`  )->a( n = `text` v = mv_product
+            )->tag( `Text`  )->a( n = `text` v = `this is a text` ).
+
+    popover->ele( `footer` )->ele( `OverflowToolbar`
+        )->tag( `ToolbarSpacer`
+        )->tag( `Button`
+            )->a( n = `press` v = client->_event( `BUTTON_DETAILS` )
+            )->a( n = `text`  v = `details` ).
+```
 
 ## 4. Data binding
 


### PR DESCRIPTION
# Description

This PR expands the documentation for building apps with the UI5 view builder, focusing on two critical areas:

1. **Chain formatting rules** — Adds comprehensive guidance on how to format method chains for readability and maintainability:
   - Indent must state depth (4 spaces per level, never 2)
   - One descent per line; never descend behind `end()`
   - Use variables to return to nodes instead of unwinding with multiple `end()`s
   - Includes a worked example showing a broken chain and its corrected form

2. **Trailing whitespace detection** — Documents that trailing whitespace is not caught by the abapGit gate and must be checked per-repository:
   - Explains why it matters (ABAP editor strips trailing blanks on save)
   - Notes that `whitespace_end` is not in every repository's abaplint config
   - Provides a grep command to detect trailing whitespace
   - Includes sed command to strip it and guidance on adding the rule to abaplint config

Also updates the ABAP check skill description to mention trailing whitespace as a known gap in CI checks.

## How to test

N/A — Documentation only. Review the added sections in `docs/agents/building-apps.md` and `.claude/skills/` for clarity and accuracy against the examples provided.

## Checklist

- [x] No code changes under `src/`
- [x] Documentation updates only
- [x] Changes made via abapGit: N/A

https://claude.ai/code/session_01947Lexmmz1RTWAWrERCnpp