### PR TITLE
Small fixes: CI_NOWHERE pragma, guide/skill corrections, dependency refresh

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -252,8 +252,11 @@ pitfalls".
 **Not gated — a script cannot decide these:**
 
 - **`SELECT` without a `WHERE` clause** wants `"#EC CI_NOWHERE`
-  (`z2ui5_cl_ui5_srv_draft=>count_entries`, `43515c97`). Whether the missing
-  `WHERE` is correct is a judgement, not a pattern.
+  (`z2ui5_cl_ui5_srv_draft=>count_entries_total`, `43515c97`). Whether the
+  missing `WHERE` is correct is a judgement, not a pattern — here it is
+  deliberate ( the method reports the whole table's size ), so the pragma
+  records the decision instead of hiding it. `count_entries` next to it *is*
+  owner-scoped and needs no pragma.
 - **`CREATE OBJECT … TYPE (name)` into a generic reference, then `CAST`,** is
   flagged as insecure object creation. Declare the typed reference and create
   into it directly (`b25388ff`):

--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -252,7 +252,7 @@ pitfalls".
 **Not gated — a script cannot decide these:**
 
 - **`SELECT` without a `WHERE` clause** wants `"#EC CI_NOWHERE`
-  (`z2ui5_cl_core_srv_draft=>count_entries`, `43515c97`). Whether the missing
+  (`z2ui5_cl_ui5_srv_draft=>count_entries`, `43515c97`). Whether the missing
   `WHERE` is correct is a judgement, not a pattern.
 - **`CREATE OBJECT … TYPE (name)` into a generic reference, then `CAST`,** is
   flagged as insecure object creation. Declare the typed reference and create

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,7 @@ reader. Known traps — avoid them up front, a green abaplint does not prove
 their absence:
 
 - **`SELECT` without a `WHERE` clause** wants `"#EC CI_NOWHERE` (bit us in
-  `z2ui5_cl_core_srv_draft=>count_entries`).
+  `z2ui5_cl_ui5_srv_draft=>count_entries`).
 - **`CREATE OBJECT ... TYPE (name)` into a generic reference followed by a
   `CAST`** is flagged as insecure object creation. Declare the typed reference
   and create into it directly:

--- a/node/tests/e2e/fixtures.js
+++ b/node/tests/e2e/fixtures.js
@@ -5,7 +5,7 @@
 // reviewer lore (see the ui5-1.71 project in ../../playwright.config.js).
 //
 // The backend GET page hardcodes the evergreen CDN bootstrap and the
-// default theme (z2ui5_cl_exit=>set_config_http_get). The `ui5Src` /
+// default theme (z2ui5_cl_ui5_user_exit=>set_config_http_get). The `ui5Src` /
 // `ui5Theme` project options rewrite those attributes in the served HTML
 // before it reaches the browser; UI5 derives its resource root from the
 // script tag's src, so rewriting the bootstrap URL is enough - every later
@@ -23,7 +23,7 @@ const path = require("path");
 const base = require("@playwright/test");
 
 // The exact attributes the default exit writes into the GET page - keep in
-// sync with z2ui5_cl_exit=>set_config_http_get.
+// sync with z2ui5_cl_ui5_user_exit=>set_config_http_get.
 const DEFAULT_BOOTSTRAP =
   'src="https://sdk.openui5.org/resources/sap-ui-cachebuster/sap-ui-core.js"';
 const DEFAULT_THEME = 'data-sap-ui-theme="sap_horizon"';

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,16 +23,16 @@
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.119.66",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.119.66.tgz",
-      "integrity": "sha512-Anjsm5G0jUnWwEAZrk2Ckm0we+VCrwjc/MOMSSk+774VJ6ka1ovkj981Y8BJdbxcKgKzIvn+D/ddap/tdxMFbw==",
+      "version": "2.120.24",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.120.24.tgz",
+      "integrity": "sha512-NOIxEvjhFeUDTxa3UYwiAbGiHaEC9r9u/b8eh3LoqWitt6rG7Z/FGAYnGgD8swGfpZe3vXp5atDyOJFhZ2DbUQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "abaplint": "abaplint"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/larshp"
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.40",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.40.tgz",
-      "integrity": "sha512-Wm8eWtnzNaMiTaQ6CboRJqjHFlJ2S6JEC8QuMd6heAdtLZY5YBJidja6ityVzchAcoL5r+wrmyAyTJ4/m2LfgA==",
+      "version": "2.13.59",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.59.tgz",
+      "integrity": "sha512-A3uXCEJtIclGscAG13S79akAoEndDa4d98U5tks2TPhssj0ASWhbOOZYKGwcA7AFdFpOjy9QUMCKw7AUQXxBWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.13.40",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.40.tgz",
-      "integrity": "sha512-d7dVOIAJR3lVj+aV3Fsvk9drK9/sRYq0YkCyGxbB8xq7Qm1eC9WTXH0w0Rf9KSYiilcoHdE+QMxUr5rS4163MQ==",
+      "version": "2.13.59",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.59.tgz",
+      "integrity": "sha512-7S8vMRhlCXvWC0HJ0R18CHqtj61Zazgllzew7/QvoYUucAPl+qsoAnGOhTOHkRol8fYhS5VtEz+CKMBSJERvfg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -125,19 +125,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ui5/cli": {
@@ -6846,22 +6846,36 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -6926,9 +6940,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7050,9 +7064,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7256,9 +7270,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7290,9 +7304,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7341,13 +7355,17 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -7465,35 +7483,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -7511,13 +7529,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7527,13 +7546,17 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -7631,15 +7654,15 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7651,14 +7674,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7728,9 +7751,9 @@
       }
     },
     "node_modules/sql.js": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
-      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.2.tgz",
+      "integrity": "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7791,18 +7814,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {

--- a/src/01/01/z2ui5_cl_ui5_srv_draft.clas.abap
+++ b/src/01/01/z2ui5_cl_ui5_srv_draft.clas.abap
@@ -174,7 +174,7 @@ CLASS z2ui5_cl_ui5_srv_draft IMPLEMENTATION.
     " page shows next to the own count, and what says whether cleanup( ) is
     " keeping up. Deliberately NOT owner-scoped, and deliberately only a count:
     " everything that reads draft CONTENT stays owner-bound ( see read( ) )
-    SELECT COUNT( * ) FROM z2ui5_t_01
+    SELECT COUNT( * ) FROM z2ui5_t_01                     "#EC CI_NOWHERE
       INTO @result.
 
   ENDMETHOD.

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -450,7 +450,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
 
     render_link( form = form
                  text = `See a complete example: Hello World`
-                 href = `https://github.com/abap2UI5/abap2UI5/blob/main/src/02/z2ui5_cl_ui5_app_hi_world.clas.abap` ).
+                 href = `https://github.com/abap2UI5/abap2UI5/blob/main/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap` ).
 
     form->tag( `Label` )->a( n = `text`  v = `Step 4` ).
 

--- a/tools/app2app_v2/build-legacy-free.mjs
+++ b/tools/app2app_v2/build-legacy-free.mjs
@@ -88,4 +88,4 @@ cpSync(join(dataDir, "abap/standard"), join(outDir, "src"), { recursive: true })
 cpSync(bsp, join(outDir, "src/02"), { recursive: true });
 rmSync(work, { recursive: true, force: true });
 const n = readdirSync(join(outDir, "src/02")).length;
-console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} erzeugt (${n} Dateien) in ${join(outDir, "src/02")} ${renamed && ownBackend ? "[eigener Backend-Handler]" : "[Backend-Handler /sap/bc/z2ui5]"}`);
+console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} generated (${n} files) in ${join(outDir, "src/02")} ${renamed && ownBackend ? "[own backend handler]" : "[backend handler /sap/bc/z2ui5]"}`);

--- a/tools/build-branches.mjs
+++ b/tools/build-branches.mjs
@@ -258,5 +258,5 @@ for (let i = 0; i < branches.length; i++) {
   builds[i]();
   const b = branches[i];
   const n = readdirSync(outDir(b), { recursive: true }).length;
-  console.log(`OK: ${b} (${n} Eintraege) -> ${relative(core, outDir(b))}`);
+  console.log(`OK: ${b} (${n} entries) -> ${relative(core, outDir(b))}`);
 }


### PR DESCRIPTION
# Description

A batch of small, individually-verified fixes found by sweeping the repository for defects a green CI does not catch. Each commit stands on its own.

**`"#EC CI_NOWHERE` on the one deliberate unscoped SELECT.** `count_entries_total( )` reports the size of the whole draft table on purpose. Extended check (SLIN/ATC) flags every `WHERE`-less `SELECT`, so without the pseudo-comment the finding comes back on every run in a customer system and gets re-investigated each time. It is the only `WHERE`-less `SELECT` in `src/01`; `count_entries( )` beside it is owner-scoped and needs nothing.

**Corrected the `abap-check` catalogue entry** that cited `count_entries` as the example — that method gained a `WHERE` clause when draft reads became owner-bound, so the citation no longer showed the case it was describing.

**Framework class names** followed through the docs and skills where the `Z2UI5_CL_CORE_*` → `Z2UI5_CL_UI5_*` rename had left stale references.

**Dependency refresh, in-range only** — `@abaplint/cli` 2.119.66 → 2.120.24, `@abaplint/runtime` and `@abaplint/transpiler-cli` 2.13.40 → 2.13.59, `@playwright/test` 1.61.1 → 1.62.1. Lockfile only; no declared range moved.

## How to test

`npm run verify` covers all of it. Individually:

```
npx abaplint              # 249 files, 0 issues
npm run check:abapgit     # 343 files in 14 packages
npm run check:atc         # 98 files — this is the gate the pragma answers to
npm run check:frozen
npm run check:guide
npm run check:frontend    # rebuilds byte-identical, build/ unchanged
npm run check:js          # 766 playwright unit tests on the new runner
```

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — no behaviour change here, existing suites re-run green
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [ ] Changes were made via abapGit: no

## Note on `npm audit`

The 7 advisories this repo reports all come from `@ui5/cli` and are **not** addressed here: the vulnerable range is `3.0.1 – 4.0.62`, i.e. every 4.x including the newest, npm's proposed "fix" is a downgrade to 3.0.0, and the only thing beyond is `5.0.0-alpha`. They sit in `pacote`/`sigstore`, npm-registry code paths reached when `ui5` resolves framework libraries — build-time only. Worth a deliberate decision rather than a drive-by bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcX8VpcUFd9tjz1bE2HNdx)_