### PR TITLE
Take the linter from npm, and restore the chain layout the gate signed off on

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -49,7 +49,7 @@ Quick orientation while it loads:
   frontend). UI5 1.71 is the compatibility floor — check "available since".
 - The app checks its own authorizations at the top of `main`.
 - Validate with the abap2UI5-linter
-  (`npx --yes github:abap2UI5/linter <file>`); iterate without a SAP
+  (`npx --yes @abap2ui5/linter <file>`); iterate without a SAP
   system via the ai-mcp server (`deploy_app` → `build_backend` → `run_app`).
 - Before you finish, run the `abap-check` skill over what you wrote — it is the
   companion to this one and catches what a green lint does not: abapGit

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -549,7 +549,7 @@ The same tree, with the subtree held in a variable:
 - **[abap2UI5-linter](https://github.com/abap2UI5/linter)** checks
   app classes statically (unknown/deprecated/too-new controls and members,
   binding mistakes, builder-tree defects) and can render the view headless:
-  `npx --yes github:abap2UI5/linter my_app.clas.abap` — also
+  `npx --yes @abap2ui5/linter my_app.clas.abap` — also
   available as a GitHub Action and inside the VS Code extension.
 - **[ai-mcp](https://github.com/abap2UI5/ai-mcp)** gives MCP-capable agents
   the full loop without a SAP system: `capabilities` → `deploy_app` →

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.142.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "github:abap2UI5/linter#a39ee2a",
+        "@abap2ui5/linter": "^0.1.0",
         "@abaplint/cli": "^2.119.66",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
@@ -25,7 +25,8 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#a39ee2a11e540bf1d6780c53d9fe09df61e513be",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.1.0.tgz",
+      "integrity": "sha512-/bz0tZgmNNWLMFYNtu6/hTdMYZbo5195tHWObYKaFHetz4fLmW7ftW2IsMzOGVcLcqByxIiGAJEY6hAhLLkpfA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abap2ui5/linter": "github:abap2UI5/linter#a39ee2a",
+    "@abap2ui5/linter": "^0.1.0",
     "@abaplint/cli": "^2.119.66",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -748,7 +748,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
             )->a( n = `level`  v = `H3`
             )->a( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
 
-    )->end( ).
+      )->end( ).
 
   ENDMETHOD.
 

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -748,7 +748,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
             )->a( n = `level`  v = `H3`
             )->a( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
 
-      )->end( ).
+    )->end( ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

Two changes, both about `check:abap2ui5`.

**The linter now comes from npm.** `@abap2ui5/linter` 0.1.0 is on the registry, and the pinned `a39ee2a` is an ancestor of the commit it was published from — the diff between the two over `lib/`, `data/`, `cli.mjs` and `types.d.ts` is *empty*, so no rule behaviour moves. What changes is that `npm ci` resolves a tarball with an integrity hash instead of cloning a branch commit that nothing stops from being force-pushed away. The two places that told a reader to `npx` the git URL now name the package.

No `@abap2ui5/render-runtime` here: `abap2ui5lint.jsonc` has `"render": false`, and this repository already renders these apps in a real browser through its own Playwright suite.

**`main` is currently failing that gate, and this fixes it.** In #2597 a line in `z2ui5_cl_ui5_app_start` was re-indented by two spaces *after* `check_chain_format` had run on the PR:

```diff
-    )->end( ).
+      )->end( ).
```

The gate never ran again — it fires on `pull_request`, so the merged state is never checked on its own, and [that one run](https://github.com/abap2UI5/abap2UI5/actions/runs/31880429640) is still the only one that exists. `npm run check:abap2ui5` has been red on `main` ever since. This puts the closing call back in the column of the element it closes, which is the blob the passing run actually approved.

Worth noting for later: the same hole is still open. A path-filtered `pull_request` workflow cannot vouch for `main`, so a change slipped in after the last run stays invisible until the next PR touches ABAP.

## How to test

```sh
npm ci
npm run check:abap2ui5     # 7 files, 0 failing
npm run check              # abaplint: 0 issues, 249 files
```

Before the ABAP fix, `check:abap2ui5` reports `751:7 warning … chain-house-layout` and exits 1. `npm run fmt:chains` produces exactly the one-line change in this PR.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively
- [x] Changes were made via abapGit: no

On the first box: I ran `npm run check` (abaplint, 0 issues) and `npm run check:abap2ui5` (0 findings) rather than the full `verify`, which drives the downport, the transpiler and the Playwright suite. Nothing here touches those paths — the ABAP change is whitespace inside a builder chain and the rest is a devDependency swap — but the box is unticked because I did not actually run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATRwcRZvAxCfRUmxXsqpAu)_