### PR TITLE
Close the chain the gate fails on, and stop the autofix from reopening it

### DIFF
--- a/.github/abaplint/auto_abaplint_fix.jsonc
+++ b/.github/abaplint/auto_abaplint_fix.jsonc
@@ -23,7 +23,23 @@
   },
   "rules": {
 
-    "in_statement_indentation": true,
+    // Third rule excluded for the same two files, for the same reason as the
+    // pair below. The house layout puts a chain's closing call in the column
+    // of the element it closes (view-chain-layout, enforced by the
+    // chain-house-layout rule of abap2ui5lint), so the `)->end( ).` that
+    // closes the outermost element lands in the column of the `form->ele( )`
+    // that opened it - two columns left of the statement-start + 2 that
+    // in_statement_indentation requires of a continuation line. The two are
+    // irreconcilable for that one shape: the chain gate rejects any column
+    // but the opener's, this rule rejects anything left of start + 2.
+    //
+    // Left unexcluded, the autofix wins - it runs on every pull request and
+    // pushes - and check_gates then fails on the result. That already
+    // happened: #2583 moved this exact line and #2599 was the pull request
+    // that made the failure visible.
+    "in_statement_indentation": {
+      "exclude": ["z2ui5_cl_ui5_app_start\\.clas\\.abap$", "z2ui5_cl_ui5_app_hi_world\\.clas\\.abap$"]
+    },
     "indentation": true,
     "double_space": true,
     // The two shipped apps write the view builder's a( ) as one line per

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -748,7 +748,7 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
             )->a( n = `level`  v = `H3`
             )->a( n = `class`  v = `sapUiSmallMarginBegin sapUiSmallMarginTop sapUiTinyMarginBottom`
 
-      )->end( ).
+    )->end( ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

`main` is currently red on `check_gates`:

```
src/01/04/z2ui5_cl_ui5_app_start.clas.abap
  751:7  warning  this chain is not in the house layout — 1 line(s) differ   chain-house-layout
```

The `)->end( ).` closing the section heading in `render_section` sits two columns right of the `form->ele( )` it closes. Because `check_gates` runs on `pull_request`, every pull request opened against `main` inherits the failure until this lands.

**Two commits, because the obvious fix does not hold on its own.**

**1. `npm run fmt:chains` on that one line** — moves the closing call back into the opener's column. One line, no logic touched.

**2. The autofix has to stop undoing it.** Committing (1) alone is not enough: `npm run app2abap` runs `abaplint --fix` over `src/`, and it moves the line straight back. The two rules are irreconcilable for this shape:

| | wants line 751 at |
| --- | --- |
| `in_statement_indentation` (abaplint) | statement start + 2 → column 7 |
| `chain-house-layout` (abap2ui5lint) | the column of the `ele( )` it closes → column 5 |

For an `end( )` that closes the *outermost* element of a chain, both cannot hold. The autofix is the side that wins unattended — it runs on every pull request and pushes the result — so `check_gates` would just go red again on the next push.

So the rule is excluded in `.github/abaplint/auto_abaplint_fix.jsonc`, for the same two view-building classes that `align_parameters` and `line_break_multiple_parameters` are already excluded for, and for the same underlying reason. `abaplint.jsonc` has `in_statement_indentation` off entirely, so the autofix config was the only one that needed changing.

**How it got here.** #2583 moved this line — as an autofix push, not a hand edit — while the chain gate still had a `paths` filter that kept it from running on that pull request. #2599 removed the filters, which is what made the failure visible; that pull request's own `check_gates` run failed on this and was merged anyway.

## How to test

```
npm run verify
git status --porcelain    # must be empty
```

Full `verify` passes (exit 0), and — the part that matters here — the working tree is **clean afterwards**. On `main` today the same run leaves `z2ui5_cl_ui5_app_start.clas.abap` modified, because the autofix reverts the layout mid-run. That is the regression test for commit 2.

Covered in that run: abaplint (0 issues, 249 files in `src/`, 343 in the downported tree), the ABAP unit tests, the JS unit tests, `check:app2abap`, `check:frontend`, and all ten `check_gates` gates including `check:abap2ui5`, which now reports `7 files, 0 failing`.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — not applicable: one whitespace column and one linter-config exclusion, no behaviour to test. The regression is guarded by `check_gates` itself.
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — `check:api` reports 80 public symbols unchanged
- [x] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf1mvtGYGvxukRnPHAt3kx)_