### PR TITLE
Make check_on_navigated part of the documented dispatcher

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -13,7 +13,18 @@ skill is the trigger and the checklist; the guide is the content.
 Quick orientation while it loads:
 
 - One ABAP class implements `z2ui5_if_app`; `main( client )` runs once per
-  roundtrip — dispatch with `check_on_init( )` / `check_on_event( )`.
+  roundtrip — dispatch with `check_on_init( )` / `check_on_event( )` /
+  `check_on_navigated( )`.
+- **The `check_on_navigated( )` branch is part of the dispatcher, not an
+  option.** `check_on_init( )` is "this app instance never ran", not "the app
+  starts": it stays false when a called app hands control back
+  (`nav_app_leave`, any `z2ui5_cl_pop_*` value help — those run over
+  `nav_app_call` too) and when a bookmarked state is restored. Those roundtrips
+  fire `check_on_navigated( )` alone, and a branch that does not re-run
+  `view_display( )` there leaves the previous screen standing with no error
+  anywhere. Apps built without it work perfectly until the day someone calls
+  them from a navigation — the linter's `missing-view-display-on-navigated`
+  covers the branch that exists but never displays.
 - PUBLIC attributes = serialized, browser-visible state. Bound data only;
   everything else PROTECTED.
 - Build views with `z2ui5_cl_ui5_view_builder`

--- a/README.md
+++ b/README.md
@@ -60,9 +60,18 @@ METHOD z2ui5_if_app~main.
     view_display( ).   " app start – build a UI5 XML view, bind ABAP variables into it
   ELSEIF client->check_on_event( ).
     on_event( ).       " user interaction – bound data already contains the user's input
+  ELSEIF client->check_on_navigated( ).
+    view_display( ).   " back from a called app or a popup – put this app's view back
   ENDIF.
 ENDMETHOD.
 ```
+
+All three branches belong to the dispatcher. `check_on_init( )` fires once per
+app instance, so it is *not* reached again when another app hands control back
+(`nav_app_leave`, a `z2ui5_cl_pop_*` value help) or when a bookmarked state is
+restored – those roundtrips fire `check_on_navigated( )`. Without that branch
+the browser keeps showing whatever was on screen before, with no error
+anywhere.
 
 Under the hood, abap2UI5 is a **single-page app**: the browser loads a generic UI5 shell once, then every user interaction becomes one HTTP/JSON roundtrip to ABAP:
 


### PR DESCRIPTION
# Description

The README's "How It Works" snippet and the `build-an-app` skill both showed a
two-branch dispatcher — `check_on_init( )` / `check_on_event( )`. That reads as
the complete contract, and apps written from it work fine, until the day
something navigates into them.

`check_on_init( )` means "this app **instance** never ran", not "the app
starts": `mv_check_initialized` flips in `db_save( )`
(`z2ui5_cl_ui5_app_cont.clas.abap:216`) after the very first roundtrip. So it is
false on three roundtrips that put the app back on screen — all three set
`check_on_navigated` in `z2ui5_cl_ui5_action.clas.abap`:

| Situation | `check_on_init` | `check_on_navigated` | set at |
|---|---|---|---|
| First start | true | true | `:112` |
| Normal event | false | false | — |
| `nav_app_call` into a new instance | true | true | `:250` |
| **`nav_app_leave` back to the caller** | **false** | **true** | `:250` |
| **Bookmark / draft restore** | **false** | **true** | `:85` |

The last two rows are the defect. Why it fails *silently* is in `main_end`
(`z2ui5_cl_ui5_handler.clas.abap:790ff`): with no `display` action in the
response, only the model is pushed — into a MAIN slot still holding the other
app's view. No error anywhere, just the wrong screen.

It does not take a "real" sub-app either: the built-in popups
(`z2ui5_cl_pop_*`) run over `nav_app_call` themselves
(`z2ui5_cl_pop_data.clas.abap:35`), so a value help is enough to trigger it.

Both templates now carry the branch, with the reason next to it.

## How to test

Nothing to run — the change is documentation only (`README.md` and
`.claude/skills/build-an-app/SKILL.md`), no `src/` and no `app/webapp/`.

To see the behaviour the docs now describe, the existing e2e app pair is
already written correctly: `node/srv/zcl_tst_nav_hub.clas.abap` re-displays in
its `check_on_navigated( )` branch and returns from
`zcl_tst_nav_detail`. Deleting that branch reproduces the blank screen.

Verified here:

```
npm run check:guide   # every client method and cs_* constant the guide names exists - OK
```

The corpus effect of the same rule, measured with the linter change that
accompanies this one (abap2UI5/linter): 85 classes in `samples`, 425 in
`samples-controls`, 27 in `samples-stack`, **0** in `app-template` — whose
template already had the branch and is unchanged here.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — **not run**: no `src/`, `app/webapp/`, `build/` or frontend file is touched, so nothing it gates is in this diff. `npm run check:guide` was run and passes.
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — n/a, documentation only
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — no API change at all
- [ ] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLUaucd6qehSTUWSB7cWRn)_