### PR TITLE
Point agents at what exists, and hand the reader a prompt

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -41,8 +41,10 @@ Four separate holes, worth knowing precisely:
 
 - **abaplint parses ABAP, it does not model abapGit's file format.** The
   sidecar is only read for the few facts its rules name. Verified against
-  abaplint 2.120: a `.clas.xml` with the BOM stripped, the terminating newline
-  removed **and** CRLF line endings throughout produces **zero** findings.
+  abaplint 2.120.24 with 73 rules active and `check_syntax` live: a `.clas.xml`
+  with the BOM stripped, the terminating newline removed, CRLF line endings
+  throughout **and** a raw apostrophe in `<DESCRIPT>` — four defects at once —
+  produces **zero** findings.
 - **abaplint's `global.files` is not all of `src/`.** It covers `src/00`
   (with `noIssues`), `src/01` and `src/02` — `src/99` is never read at all.
 - **The transpiler ignores visibility.** Every ABAP member becomes a plain JS
@@ -52,6 +54,46 @@ Four separate holes, worth knowing precisely:
   v750 and the transpiler is a JS runtime. Neither is 7.02, neither is a 7.40
   or low-SP 7.50 system, and neither is ABAP Cloud — and a good half of this
   catalogue is code that is valid on one of those and rejected by another.
+
+### Measuring one of these against abaplint — read this first
+
+Every "abaplint does not catch X" claim in this file was measured, and the
+measurement has one trap that makes every result meaningless:
+
+> **An abaplint config with no `rules` block runs NO rules.** Not the defaults —
+> none. A run over a deliberately broken file then prints
+> `0 issue(s) found, 3 file(s) analyzed`, which looks exactly like a confirmed
+> gap and is nothing of the kind.
+
+Three of four claims measured this way in one sitting came back "gap", and one
+of them was wrong: `local_testclass_consistency` covers `<WITH_UNIT_TESTS>` in
+**both** directions and says so in plain words. It had simply not been switched
+on.
+
+So: **enable the rules explicitly, and run a control probe first.** Break
+something abaplint certainly catches — an undefined variable is the cheapest —
+and only trust a zero once you have seen a one:
+
+```jsonc
+{ "global": { "files": "/src/**/*.*" },
+  "syntax": { "version": "v750", "errorNamespace": "^(Z|Y)" },
+  "rules": { "check_syntax": true, /* …and the rule you are testing… */ } }
+```
+
+Two more things that silently void a result: an `errorNamespace` that does not
+match your test class's name, and a `syntax.version` too old for the syntax you
+wrote (`DATA(x) = …` on `v702` is a parser error that masks everything after
+it).
+
+**Verified gaps as of abaplint 2.120.24** — measured this way, control probe
+passed, nothing abap2UI5-specific about any of them, and therefore candidates
+to push upstream rather than to reimplement here:
+
+| Case | Why it matters |
+|---|---|
+| `CLASS-METHODS class_constructor.` in a PRIVATE SECTION | ABAP requires the static constructor in the public section; the class pool does not activate. `constructor_visibility_public` sees only the instance constructor |
+| a test class calling a PRIVATE member without `CLASS <global> DEFINITION LOCAL FRIENDS <ltcl>.` | same activation failure; it has reached users twice (`cadfb7ae`, #2146) |
+| the `.clas.xml` byte format — BOM, line endings, terminating newline, `&apos;` | abapGit re-serializes it differently on every pull, for everyone |
 
 ---
 
@@ -76,7 +118,7 @@ everyone.
 | `package` | every folder under `src/` has a `package.devc.xml` — it *is* the package | — |
 | `clsname` | `<CLSNAME>` equals the file name, upper-cased | — |
 | `langu` | `<LANGU>` equals `<MASTER_LANGUAGE>` from `.abapgit.xml` (`E`). An object created while logged on in another language serializes with that language and diffs against every other developer | — |
-| `unit-tests` | `<WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>` exactly when a `.testclasses.abap` exists | `d5eaaa79` "fix unit test metadata" — `z2ui5_cl_util_range` had the test include and not the flag |
+| `unit-tests` | `<WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>` exactly when a `.testclasses.abap` exists. **Also owned by abaplint's `local_testclass_consistency`, in both directions** — so in a repository that enables that rule this one is belt and braces, not the only gate | `d5eaaa79` "fix unit test metadata" — `z2ui5_cl_util_range` had the test include and not the flag |
 
 ### The size limits — where the *import* fails, not the diff
 

--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -10,6 +10,20 @@ self-contained guide** (template, lifecycle, builder verbs, binding rules,
 events, popups, navigation, portability rules, validation tooling). This
 skill is the trigger and the checklist; the guide is the content.
 
+**Before writing one from scratch, ask whether it exists.** `abap2UI5/samples`
+holds 152 working apps, each linted, rendered and downported to three
+releases — a value help, a tree, navigation between two apps, a dynamic table
+typed at runtime. Reading one beats reproducing it, and beats any snippet: the
+sample is gated, a snippet is a copy somebody has to keep in step.
+
+- With the [MCP server](https://github.com/abap2UI5/ai-mcp): the `examples`
+  tool queries that catalogue (`examples { query: "value help f4" }`) and
+  hands back the class to read. Its neighbour `capabilities` answers the other
+  question — whether a UI5 *control* can be expressed at all — out of
+  samples-controls' 416 ports.
+- Without it: [SAMPLES.md](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md)
+  is the same catalogue as a page.
+
 Quick orientation while it loads:
 
 - One ABAP class implements `z2ui5_if_app`; `main( client )` runs once per

--- a/README.md
+++ b/README.md
@@ -141,10 +141,45 @@ This project thrives thanks to its [contributors](https://github.com/abap2UI5/ab
 * Documentation created with [VitePress](https://vitepress.dev/) [(contributors)](https://github.com/vuejs/vitepress/graphs/contributors)
 
 #### AI Assistants
-* [app-template](https://github.com/abap2UI5/app-template) - Starter repo for **new app projects**: gates, CI and agent setup preconfigured
-* [docs/agents/building-apps.md](docs/agents/building-apps.md) - Self-contained agent guide for **building apps** with abap2UI5
-* [AGENTS.md](AGENTS.md) - The briefing for AI assistants working **on the framework** itself
-* [llms.txt](llms.txt) - Index of both entry points and the surrounding tooling (linter, MCP server, samples)
+
+Almost everything ever published about abap2UI5 shows `z2ui5_cl_xml_view`, the
+view builder that has since been frozen. A model asked cold will write that —
+it compiles and it renders, so nothing complains. **Give it the current
+sources first.** Paste this ahead of your task:
+
+```text
+Before writing any abap2UI5 code, read https://abap2ui5.github.io/docs/llms.txt
+and follow it to the pages you need.
+
+Four things that override whatever you remember about abap2UI5:
+1. An app is ONE ABAP class implementing z2ui5_if_app. Everything enters main( ),
+   which dispatches on client->check_on_init( ), client->check_on_event( `X` ) and
+   client->check_on_navigated( ).
+2. Build the view with z2ui5_cl_ui5_view_builder and its verbs ele / tag / a / end /
+   stringify. z2ui5_cl_xml_view is the FROZEN predecessor - it is what most examples
+   online show, and it is not what to write.
+3. Bind with client->_bind( ). It is bidirectional; only what the user edited comes back.
+4. Every roundtrip is a fresh ABAP session. Nothing survives on the server except
+   the app class itself, which is serialized.
+
+Before building something from scratch, check whether it exists: 152 complete apps
+are listed with search terms at
+https://github.com/abap2UI5/samples/blob/main/SAMPLES.md
+
+When you are done, check the result with the abap2UI5-linter
+(npx abap2ui5lint) - it reads the view your ABAP builds and needs no SAP system.
+```
+
+Then, depending on how much setup you want:
+
+| | |
+|---|---|
+| [llms.txt](https://abap2ui5.github.io/docs/llms.txt) | the documentation as a map, one fetch. [llms-full.txt](https://abap2ui5.github.io/docs/llms-full.txt) is all of it in one document, and every page is served as raw markdown next to its `.html` |
+| [ai-mcp](https://github.com/abap2UI5/ai-mcp) | MCP server: query the sample catalogue, validate a view, deploy, build, boot the app headless and **look at a screenshot**. No SAP system. This is the setup that closes the loop |
+| [app-template](https://github.com/abap2UI5/app-template) | start a project here — both gates, CI and an `AGENTS.md` for your own repo, already wired up |
+| [linter](https://github.com/abap2UI5/linter) | the check to run on generated code. It reports a class written on the frozen builder, which is the most common thing a model gets wrong |
+| [docs/agents/building-apps.md](docs/agents/building-apps.md) | self-contained offline guide for **building apps**, when fetching is not an option |
+| [AGENTS.md](AGENTS.md) · [llms.txt](llms.txt) | for work **on the framework itself** — architecture, layering, coding rules, and a map of the code |
 
 #### Get Involved
 We welcome all contributions! Here's how you can help:

--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,12 @@
 > views, binds ABAP data and dispatches events over stateless HTTP
 > roundtrips. Supports NW 7.02 to ABAP Cloud, on-premise and cloud.
 
+If you arrived here from a web search rather than from this repository, the
+documentation site publishes its own, and it is the better map of the prose:
+https://abap2ui5.github.io/docs/llms.txt — every chapter with a one-line
+summary, plus https://abap2ui5.github.io/docs/llms-full.txt for all of it in
+one fetch. This file is the map of the CODE.
+
 Two audiences, two entry points:
 
 ## Building apps with abap2UI5
@@ -20,8 +26,10 @@ Two audiences, two entry points:
 - [View builder](src/02/z2ui5_cl_ui5_view_builder.clas.abap): generic 1:1 UI5 XML builder
 - [Hello world](src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap): smallest complete app
 - [Rendered documentation](https://abap2ui5.github.io/docs/): the human docs site
-- [samples](https://github.com/abap2UI5/samples): curated example apps —
-  the framework basics
+- [samples](https://github.com/abap2UI5/samples): 152 curated example apps, one
+  class each. [SAMPLES.md](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md)
+  lists every one of them with the words to search it by — ask it whether a
+  sample already exists before writing an app from scratch
 - [samples-controls](https://github.com/abap2UI5/samples-controls) (formerly
   ai-demokit): ~400 gate-verified ports of the official UI5 demo kit samples,
   plus CAPABILITIES.md (what abap2UI5 can express)


### PR DESCRIPTION
Three documentation changes, all one problem: an AI asked about abap2UI5 answers from what it read on the internet, and that is `z2ui5_cl_xml_view`.

It was the API from 2023 until the generic builder replaced it, so it is in every blog post, forum answer and tutorial a model was trained on. It also still compiles and still renders, because it was frozen rather than deleted — **the wrong answer arrives looking exactly like a right one**, and nothing complains.

## 1. The skill looks for the app before writing one

`build-an-app` already holds no app code and points at the guide. The same applies one step earlier: 152 working apps exist, each linted, rendered and downported to three releases, and an agent that cannot find them writes a value help from scratch.

Two ways in, because not every agent has the MCP server: the `examples` tool ([ai-mcp](https://github.com/abap2UI5/ai-mcp)) queries the catalogue and hands back a class to read, and `SAMPLES.md` is the same catalogue as a page. Both point at the sample rather than reproducing it — a snippet in a skill is a copy nobody compiles.

Also names the boundary that keeps coming up: `examples` answers *"has somebody built this app"*, `capabilities` answers *"can abap2UI5 express this control"*. Neither answers the other.

## 2. `llms.txt` says which map it is

The documentation site now publishes its own `llms.txt` and an `llms-full.txt` (abap2UI5/docs#138). That is the better map of the prose, and it sits at the address the convention says to look — this file is reachable only by somebody already inside the repository, who is past needing it. So it says which is which: this one maps the **code**, that one maps the **documentation**.

The samples entry also said "curated example apps" without mentioning that `SAMPLES.md` exists.

## 3. The README hands over a prompt

The *AI Assistants* section was four links and no instruction. Anyone arriving with *"I want an AI to write me an abap2UI5 app"* had to rank the four alone — and most will not; they will just ask the model.

It now opens with the `z2ui5_cl_xml_view` problem and gives a prompt to paste before the task:

- read `llms.txt`, follow it to the pages you need
- four things that override what the model remembers: one class and the `main( )` dispatch, the current builder and its five verbs, `_bind( )`, stateless roundtrips
- check `SAMPLES.md` before building anything from scratch
- check the result with `npx abap2ui5lint`

Four points, because a prompt nobody reads to the end corrects nothing.

The links stay, as a table saying what each is *for* — no setup, MCP server, starting a project, checking generated code, working offline, working on the framework itself.

## Verification

`check:prose`, `check:guide` and `check:frozen` all pass. Documentation only — no ABAP changes.