### PR TITLE
Pin the last action left on a moving tag

### DIFF
--- a/.github/workflows/test_browser.yaml
+++ b/.github/workflows/test_browser.yaml
@@ -37,7 +37,7 @@ jobs:
       run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}


### PR DESCRIPTION
26 of this repository's 27 third-party action references were already pinned to a commit; `test_browser.yaml`'s `actions/cache@v6` was not.

One unpinned reference in a set of 27 is the harder kind to notice, because the repository looks pinned — which is how it was found: by counting, across all nine repositories, rather than by reading a file.

Same commit the other repositories now pin (`55cc834`, v6.1.0), so `actions/cache` means one commit organisation-wide. The remaining unpinned `uses:` lines here are this repository's own composite actions under `./.github/actions/`, which move with the commit that uses them and are correctly left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_