### PR TITLE
Show the dispatcher as init, navigated, event

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Your entire app is **one ABAP class** implementing `z2ui5_if_app`. The framework
 METHOD z2ui5_if_app~main.
   IF client->check_on_init( ).
     view_display( ).   " app start – build a UI5 XML view, bind ABAP variables into it
-  ELSEIF client->check_on_event( ).
-    on_event( ).       " user interaction – bound data already contains the user's input
   ELSEIF client->check_on_navigated( ).
     view_display( ).   " back from a called app or a popup – put this app's view back
+  ELSEIF client->check_on_event( ).
+    on_event( ).       " user interaction – bound data already contains the user's input
   ENDIF.
 ENDMETHOD.
 ```

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -59,10 +59,10 @@ CLASS zcl_my_app IMPLEMENTATION.
     IF client->check_on_init( ).
       model_init( ).
       view_display( ).
-    ELSEIF client->check_on_event( ).
-      on_event( ).
     ELSEIF client->check_on_navigated( ).
       view_display( ).
+    ELSEIF client->check_on_event( ).
+      on_event( ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
The canonical dispatcher appears in three places here and in the three sample
repositories. The two here — `README.md` and `docs/agents/building-apps.md` —
put `check_on_navigated` **last**, after `check_on_event`:

```abap
IF client->check_on_init( ).
  view_display( ).
ELSEIF client->check_on_event( ).
  on_event( ).
ELSEIF client->check_on_navigated( ).   " <- last
  view_display( ).
ENDIF.
```

`samples`' AGENTS.md §11, `samples-controls`' `scaffold.mjs` and generation
prompt, and the `port-a-sample` recipe all put it **second**. Same semantics
either way — the branches are exclusive in an `ELSEIF` chain — but the order a
reader copies should be one order.

Second is also the better teaching order: `navigated` belongs next to `init`
because both hand a view over, so the chain reads "first call, back on screen,
user did something" instead of splitting the two display branches around the
event one.

The three corpora were converted to this order in the same session (576
classes: `samples` 113, `samples-controls` 427, `samples-stack` 30), so the
guide now matches what a reader finds in every sample they open.

Docs only — no ABAP changes. `check-guide-api` passes.

Companion PRs: abap2UI5/samples#768, abap2UI5/samples-controls#105,
abap2UI5/samples-stack#35, abap2UI5/linter#46.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgqpUJXaehPpuWg5nWnQ7a)_