### PR TITLE
Give the shipped apps the check_on_navigated branch

### DIFF
--- a/node/srv/zcl_tst_focus.clas.abap
+++ b/node/srv/zcl_tst_focus.clas.abap
@@ -30,6 +30,9 @@ CLASS zcl_tst_focus IMPLEMENTATION.
       value   = `86801398`.
       view_display( ).
 
+    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+      view_display( ).
+
     ELSEIF client->check_on_event( `LOCK` ) IS NOT INITIAL.
       enabled = abap_false.
 

--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -13,7 +13,7 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -210,6 +210,15 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
       render_start( ).
       set_focus_input( ).
       RETURN.
+
+    ELSEIF client->check_on_navigated( ).
+      " coming back from the config app this app called: the browser still
+      " shows THAT app's view, and the navigated roundtrip carries no event -
+      " on_event( ) would fall through its CASE and render nothing. No
+      " on_init( ) here, the state survived the serialization; no
+      " set_focus_input( ) either, the user did not just arrive.
+      render_start( ).
+      RETURN.
     ENDIF.
 
     on_event( ).


### PR DESCRIPTION
The three sample repositories were converted to the canonical dispatcher this
week — 576 classes across `samples`, `samples-controls` and `samples-stack`.
The framework's own apps had not been, and two of them have exactly the defect
the branch exists to prevent.

`check_on_init( )` means "this app instance never ran", not "the app starts":
`mv_check_initialized` flips in `db_save( )` after the first roundtrip, so it is
**false** when a called app leaves, when a `z2ui5_cl_pop_*` value help returns,
and when a bookmarked draft is restored. Those roundtrips raise
`check_on_navigated( )` alone.

## The two real cases

**`z2ui5_cl_ui5_app_start`** calls the ICF config app through
`nav_app_call( )`. When that app leaves, the start app runs a navigated
roundtrip — which carries **no event**, so `on_event( )` falls through its
`CASE` and renders nothing. The browser keeps showing the config app, with no
error anywhere.

It re-renders now, and deliberately does only that: no `on_init( )` (the state
survived the serialization), no `set_focus_input( )` (the user did not just
arrive).

**`z2ui5_cl_ui5_app_hi_world`** builds and displays its view inline in the init
branch, so nothing came back after a navigation either. It seeds nothing there,
so the condition simply widens:

```abap
IF client->check_on_init( ) OR client->check_on_navigated( ).
```

That is the shape a two-branch inline app takes, and the one the sample corpora
use for it. It matters more than usual here: `app_start` registers this class as
the home app and links to its source as *the* reference example, so the shape it
shows is the shape readers copy.

**`node/srv/zcl_tst_focus`**, the e2e fixture for `SET_FOCUS`, gets the branch
too — the linter reported it and it is an app like any other.

## One that looked like a third and is not

`z2ui5_cl_ui5_app_cont` appears in a text search for `check_on_init` without a
navigated branch. It is **not an app**: it does not implement `z2ui5_if_app`, it
is the framework's app container, and every `check_on_init` in it is prose
describing the lifecycle it implements. Left alone.

`src/99` is untouched. Its 17 apps carry the same shape, and the package is
frozen (AGENTS.md rule 1) — the frozen-path gate refuses an edit there either
way, which I confirmed rather than assumed.

## Verification

`npm run verify` and `npm run unit` pass. The abap2UI5 linter now reports
**no findings at all** on this repository (24 files) — the one hint it carried
was `zcl_tst_focus`, fixed here.

Follow-up to #2612, which aligned the guide to `init → navigated → event`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgqpUJXaehPpuWg5nWnQ7a)_