### PR TITLE
Make "navigated is true on the first start" a contract, not a detail

### DIFF
--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -509,6 +509,17 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE abap_bool.
 
+  "! TRUE on the first roundtrip of THIS app instance, and only that one -
+  "! the framework flips the flag after the first response, so an app that
+  "! runs for an hour sees it once.
+  "!
+  "! It is NOT "the app starts": an app reached again through the app stack,
+  "! a value help handing control back or a restored bookmark are all
+  "! roundtrips of an EXISTING instance, and check_on_init( ) is false on
+  "! every one of them. Gating the view on it alone is the most common way
+  "! to end up with a screen that does not refresh - see
+  "! check_on_navigated( ), which is true on all of those AND on the first
+  "! roundtrip, and is therefore the branch to display in.
   METHODS check_on_init
     RETURNING
       VALUE(result) TYPE abap_bool.
@@ -517,6 +528,24 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE abap_bool.
 
+  "! TRUE whenever this roundtrip has to put the app on screen: the first
+  "! start of a new instance, a called app returning through the app stack,
+  "! one of the built-in value-help popups closing, and a bookmarked draft
+  "! being restored.
+  "!
+  "! The first start is included ON PURPOSE and is part of the contract, not
+  "! an accident of the current factory: z2ui5_cl_ui5_action=>factory_first_start
+  "! sets the flag for a fresh CREATE OBJECT as well as for a draft restore.
+  "! So `check_on_init( )` being true implies this is true, which makes
+  "!
+  "!     IF client->check_on_navigated( ).
+  "!       view_display( ).
+  "!     ENDIF.
+  "!
+  "! the complete display condition on its own - no OR with check_on_init( )
+  "! is needed, and the samples and documentation are written that way.
+  "! Whoever changes the factory keeps this true, or 530 apps stop rendering
+  "! on their first start with nothing raised anywhere.
   METHODS check_on_navigated
     RETURNING
       VALUE(result) TYPE abap_bool.


### PR DESCRIPTION
`check_on_navigated( )` is true on a fresh app start. That is what lets an app write

```abap
IF client->check_on_navigated( ).
  view_display( ).
ENDIF.
```

as its **whole** display condition, with no `OR check_on_init( )` beside it — the shorter form R-6 could have used across 530 apps and the documentation.

### It is true today

`z2ui5_cl_ui5_action=>factory_first_start` sets the flag for a plain `CREATE OBJECT` as well as for a bookmark-draft restore, and the two `nav_app_call` paths set it too. Every path that produces a roundtrip needing a display sets it, so `check_on_init( )` being true implies `check_on_navigated( )` is true.

### And until now the interface said nothing about either method

No ABAP Doc at all on `check_on_init` or `check_on_navigated`. So the property everything downstream would rely on was an implementation fact somebody could reasonably optimise away — and the symptom would be **530 apps not rendering on their first start, with nothing raised anywhere**.

Both methods now carry it:

- **`check_on_init`** says what it is *not*. Not "the app starts", but the first roundtrip of *this instance* — because gating the view on it alone is the most common way to end up with a screen that does not refresh.
- **`check_on_navigated`** states the first-start inclusion as deliberate, shows the idiom, and names the file that has to keep it true.

### Verified

| | |
|---|---|
| abaplint | 0 issues over 257 files |
| API snapshot | 80 public symbols **unchanged** — an ABAP Doc comment is not a symbol |

Documentation only, no behaviour change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_