### PR TITLE
Take the shorter dispatcher in the shipped app, and pin the linter that reads it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.143.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.2.0",
+        "@abap2ui5/linter": "^0.2.1",
         "@abaplint/cli": "^2.119.66",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.0.tgz",
-      "integrity": "sha512-wZQ3MkVz+IiHBzuudizx7rQsYNoAMxM8cBsyDz0Oxrc7zaWb+cRKdx3h/+RqRUpPozGIOxnR2AD9SO0PZe4f/g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.1.tgz",
+      "integrity": "sha512-48uMFctR78nogNai1w6kE7Ho4IXLuEnGPq5BJkstpWL69ToL1G+OJ1t4fDOBmOcJ36uFejDn2ofnoBqEkt+9sA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.2.0",
+    "@abap2ui5/linter": "^0.2.1",
     "@abaplint/cli": "^2.119.66",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",

--- a/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap
@@ -13,7 +13,7 @@ CLASS z2ui5_cl_ui5_app_hi_world IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ) OR client->check_on_navigated( ).
+    IF client->check_on_navigated( ).
 
       DATA(view) = z2ui5_cl_ui5_view_builder=>factory(
           )->ele( n = `View` ns = `mvc`


### PR DESCRIPTION
```abap
IF client->check_on_init( ) OR client->check_on_navigated( ).   " before
IF client->check_on_navigated( ).                               " after
```

One condition too many — and **this repository is where that is provable**: `z2ui5_cl_ui5_action=>factory_first_start` raises `check_on_navigated( )` for a fresh `CREATE OBJECT` and for a bookmark-draft restore, which are exactly the roundtrips on which `check_on_init( )` is true. `z2ui5_if_client` has said so in ABAP Doc since #2614; the shipped hello-world app said otherwise.

`@abap2ui5/linter` **0.2.1** is what makes the shorter form safe to write down: 0.2.0 read the `ELSE` of a `COND #( … )` as the end of a lifecycle branch and reported apps whose `view_display( )` came after one.

`npm test` green, `abap2ui5lint` 24 files 0 failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_