### PR TITLE
A table deleted out from under its own loop, filed where it is looked for

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -494,6 +494,38 @@ precisely because no gate will catch it.
   `DELETE`, the response structures) do have it, which is why only the
   `EXECUTE` statements were flagged and the `READ ENTITIES` in the same class
   was not. `cebe6bd`.
+- **`DELETE itab INDEX sy-tabix` inside a `LOOP AT` over the SAME table is a
+  silent wrong answer on a system and a 500 on the Node backend.** Deleting the
+  current row shifts every row after it while the loop's own cursor walks on,
+  so the row *after* each deletion is skipped:
+
+      LOOP AT tab INTO DATA(row).          " filters 10 rows, judges 5 of them
+        IF <drop it>.
+          DELETE tab INDEX sy-tabix.
+        ENDIF.
+      ENDLOOP.
+
+  On a real system this does not dump. It returns a plausible-looking, WRONG
+  result — a filter that keeps rows it was told to drop. The transpiled Node
+  backend is stricter and raises `TABLE_INVALID_INDEX`, which is how the case
+  was found at all (an e2e interaction driving samples-controls' app 352 got an
+  HTTP 500 out of its `listClose` round-trip, 2026-08-17).
+
+  A pattern search then found it **eight times** across the ecosystem: four
+  ports in `abap2UI5/samples-controls` (352 twice, 354, 298, 377), three in
+  `abap2UI5/samples` (`z2ui5_cl_smp_context`'s `filter_itab` and
+  `itab_filter_by_val`, app 070), and one in the vendored ajson
+  (`z2ui5_cl_ajson_filter_lib`, upstream — not patched here). Two of them were
+  wrong twice over: in `filter_itab` the `sy-tabix` belonged to an INNER loop,
+  so the index deleted was another table's, and elsewhere a `DO` loop between
+  the `LOOP` and the `DELETE` clobbers it again.
+
+  Build the result instead — collect what is kept and assign it back. It reads
+  as what it does and has neither failure mode. `DELETE itab WHERE …` is fine
+  too where the condition can be expressed there; `DELETE itab INDEX sy-tabix`
+  right after a `READ TABLE` is correct and common (`z2ui5_cl_ajson`), which is
+  why the shape cannot simply be banned.
+
 - **Three environments, one source.** Code must work on NW 7.02, standard ABAP
   and ABAP Cloud (`check:standard`, `check:cloud`, `downport`). A statement
   that only exists in a newer release passes the default target and fails the

--- a/.github/scripts/prose-name-gate.mjs
+++ b/.github/scripts/prose-name-gate.mjs
@@ -46,6 +46,7 @@ const RELEASED_HEADING = /^\d{4}-\d{2}-\d{2}\s+v\d/;
 const EXTERNAL = new Map([
   ["Z2UI5_CL_APP_ICF_CONFIG", "ships in abap2UI5/abap2UI5-icf-config"],
   ["Z2UI5_CL_CC_DEMO_OUT", "sample custom control of the samples repository"],
+  ["Z2UI5_CL_SMP_CONTEXT", "the samples repository's shared table/context helper"],
   ["Z2UI5_CL_SMP_APP_000", "the samples repository's overview app"],
   ["Z2UI5_CL_SMPC_APP_OVERVIEW", "the samples-controls overview app"],
   ["Z2UI5_CL_SMPS_APP_00", "the samples-stack overview app"],

--- a/.github/scripts/skill-rule-gate.mjs
+++ b/.github/scripts/skill-rule-gate.mjs
@@ -50,6 +50,7 @@ const NOT_A_RULE = new Map([
   ['non-binary', 'prose — a non-binary MIME type'],
   ['steampunk-2305-api', 'an ABAP Cloud release name'],
   ['sy-subrc', 'an ABAP system field'],
+  ['sy-tabix', 'an ABAP system field'],
   ['sy-sysid', 'an ABAP system field'],
   ['unit-tests', 'the abapGit round-trip rule name in this skill\'s own table'],
 ]);


### PR DESCRIPTION
`abap-check` §5 is where a defect goes when it is *green here and wrong there*, and this is the clearest instance the file has had.

```abap
LOOP AT tab INTO DATA(row).
  IF <drop it>.
    DELETE tab INDEX sy-tabix.
  ENDIF.
ENDLOOP.
```

**On a system it does not dump.** It returns a plausible-looking **wrong result** — the row after each deletion is skipped, so a filter keeps rows it was told to drop. The transpiled Node backend is stricter and raises `TABLE_INVALID_INDEX`, which is the only reason it was found at all: an e2e interaction driving `samples-controls`' app 352 got an HTTP 500 out of its `listClose` round-trip.

### Eight sites, found by pattern search after the first one

| | |
|---|---|
| `samples-controls` | apps 352 (×2), 354, 298, 377 |
| `samples` | `z2ui5_cl_smp_context`'s `filter_itab` and `itab_filter_by_val`, app 070 |
| here | the vendored `z2ui5_cl_ajson_filter_lib` — **upstream, not patched** |

**Two were wrong twice over**: in `filter_itab` the `sy-tabix` belonged to an *inner* loop, so the index deleted was another table's; elsewhere a `DO` loop between the `LOOP` and the `DELETE` clobbers it again.

### Why the shape cannot simply be banned

`DELETE itab INDEX sy-tabix` **right after a `READ TABLE`** is correct and common — `z2ui5_cl_ajson` does exactly that, in this repository. The entry says what to write instead (collect the kept rows, or `DELETE … WHERE` where the condition allows) and where the line between the two runs.

`sy-tabix` joins `sy-subrc` in the skill-rule gate's `NOT_A_RULE` list — a system field, not a linter rule.

`skill-rule-gate` green, `npm test` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_