### PR TITLE
One site in three cannot take the obvious fix, and the rule has to say so

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -461,6 +461,18 @@ precisely because no gate will catch it.
   ```
   The transpiler is more forgiving about `sy-subrc` than the release range this
   repository ships to, so no test here can reproduce it.
+
+  **But `IS ASSIGNED` is not a blind replacement.** A FAILED `ASSIGN` leaves the
+  field symbol bound to whatever it pointed at before — verified in
+  `@abaplint/runtime`'s `assign`, where every failure path sets `sy-subrc = 4`
+  and returns without clearing the target. Inside a `LOOP`, or anywhere the
+  same symbol was already assigned, `IS ASSIGNED` therefore reads TRUE for a
+  failure, which is worse than the bug it replaces. `UNASSIGN <fs>.` before the
+  `ASSIGN` where that can happen. Measured across the four repositories
+  (2026-08-17): **42** sites take the drop-in, **17** are inside a loop and
+  **2** re-assign — about one in three needs the `UNASSIGN`. The #1937 fix
+  itself is a simple case: `<attri>` is declared at method start and assigned
+  in two mutually exclusive branches.
 - **An object name inside a string literal is not a reference — a rename sweep
   will get it wrong and nothing will notice.** `#2564` renamed `z2ui5_cl_exit`
   to `z2ui5_cl_ui5_user_exit` and carried the rename into the *interface*

--- a/backlog/items/abaplint-subrc-after-assign.md
+++ b/backlog/items/abaplint-subrc-after-assign.md
@@ -49,12 +49,40 @@ neither. Nothing reports the check that is actually wrong.
 
 Report a `sy-subrc` comparison whose nearest preceding `sy-subrc`-setting
 statement is an `ASSIGN`, and suggest `IS [NOT] ASSIGNED` on the assigned field
-symbol.
+symbol — **but not unconditionally**, see the next section.
 
 Both halves are statically decidable within a statement block: the set of
 statements that set `sy-subrc` is fixed and abaplint already models it for
 `check_subrc`, and the field symbol to name in the message is the `ASSIGN`
 target.
+
+## `IS ASSIGNED` is not a drop-in replacement, and the rule has to say so
+
+A **failed** `ASSIGN` leaves the field symbol bound to whatever it pointed at
+before. Verified in `@abaplint/runtime`'s `assign`: every failure path sets
+`sy-subrc = 4` and returns *without* clearing the target. So wherever the same
+symbol can already be bound, `IS ASSIGNED` reads TRUE for a failure — turning a
+wrong-branch bug into a silently-taken one, which is worse than what it
+replaces.
+
+The detector next to this item classifies every site by which fix applies,
+measured over abap2UI5, samples, samples-controls and samples-stack:
+
+| | | fix |
+|---|--:|---|
+| **simple** | 42 | freshly declared in this method, assigned once — `IS [NOT] ASSIGNED` is a drop-in |
+| **in-loop** | 17 | inside `LOOP`/`DO`/`WHILE` — needs `UNASSIGN <fs>.` before the `ASSIGN` |
+| **reassigned** | 2 | the same symbol was already assigned earlier in the method — same trap, same fix |
+
+So roughly **one site in three cannot take the naive fix**, and a rule that
+offered it as a quick-fix everywhere would introduce bugs in those. Either the
+rule reports all three and describes both fixes, or it fires only on the simple
+shape and stays silent on the other two — the second is smaller and safer, and
+the classification above is decidable from the same single file.
+
+The corpus's own #1937 fix is a *simple* case and is correct:
+`attri_get_val_ref` declares `<attri>` at method start and assigns it in two
+mutually exclusive branches, so nothing can be left over from before.
 
 ## What it must NOT report
 
@@ -83,67 +111,67 @@ Run **2026-08-17** against `abap2UI5`, `samples`, `samples-controls`, `samples-s
 
 | Repository | Where | |
 |---|---|---|
-| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1035 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1039 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1043 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1048 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1180 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1179 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1191 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1513 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1876 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1882 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1970 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2032 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2274 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2321 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:191 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:233 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:457 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:470 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:320 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:336 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:342 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:371 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:376 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:392 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:414 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:827 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:892 | IF sy-subrc = 0. |
-| abap2UI5 | `src/02/z2ui5_cl_ui5_http_handler.clas.abap`:243 | IF sy-subrc = 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:1563 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:2502 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4105 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4111 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4176 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4223 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4628 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4673 | IF sy-subrc <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:1015 | IF sy-subrc  <> 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:1027 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:4586 | ASSERT sy-subrc = 0. |
-| abap2UI5 | `src/99/02/z2ui5_cl_pop_to_select.clas.abap`:205 | ASSERT sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:707 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1642 | IF sy-subrc  <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1654 | ASSERT sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1824 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1867 | IF sy-subrc <> 0. |
-| samples | `src/00/98/z2ui5_cl_smp_app_117.clas.abap`:136 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_131.clas.abap`:139 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_185.clas.abap`:123 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_191.clas.abap`:124 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_193.clas.abap`:43 | IF sy-subrc = 0. |
-| samples | `src/00/98/z2ui5_cl_smp_app_193.clas.abap`:51 | IF sy-subrc = 0. |
-| samples | `src/00/98/z2ui5_cl_smp_app_195.clas.abap`:123 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_211.clas.abap`:150 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/00/98/z2ui5_cl_smp_app_212.clas.abap`:86 | IF sy-subrc <> 0. |
-| samples | `src/00/98/z2ui5_cl_smp_app_338.clas.abap`:138 | IF sy-subrc = 0 AND <view_display> = abap_true. |
-| samples | `src/01/z2ui5_cl_smp_app_104.clas.abap`:49 | IF sy-subrc <> 0. |
-| samples | `src/01/z2ui5_cl_smp_app_104.clas.abap`:68 | IF sy-subrc <> 0. |
-| samples | `src/01/z2ui5_cl_smp_app_461.clas.abap`:85 | IF sy-subrc <> 0. |
-| samples | `src/01/z2ui5_cl_smp_app_461.clas.abap`:89 | IF sy-subrc <> 0. |
-| samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:449 | IF sy-subrc <> 0. |
-| samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:492 | IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1035 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1039 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1043 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1048 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/01/z2ui5_cl_ajson.clas.locals_imp.abap`:1180 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1179 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1191 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1513 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1876 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1882 | [reassigned] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:1970 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2032 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2274 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_context.clas.abap`:2321 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:191 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:233 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:457 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/00/03/z2ui5_cl_ui5_util_http.clas.abap`:470 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:320 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:336 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:342 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:371 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:376 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:392 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:414 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:827 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap`:892 | [simple] IF sy-subrc = 0. |
+| abap2UI5 | `src/02/z2ui5_cl_ui5_http_handler.clas.abap`:243 | [simple] IF sy-subrc = 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:1563 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:2502 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4105 | [simple] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4111 | [reassigned] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4176 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4223 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4628 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util.clas.abap`:4673 | [in-loop] IF sy-subrc <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:1015 | [simple] IF sy-subrc  <> 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:1027 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/99/01/z2ui5_cl_util_ext.clas.abap`:4586 | [simple] ASSERT sy-subrc = 0. |
+| abap2UI5 | `src/99/02/z2ui5_cl_pop_to_select.clas.abap`:205 | [in-loop] ASSERT sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:692 | [in-loop] IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1608 | [simple] IF sy-subrc  <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1620 | [simple] ASSERT sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1790 | [in-loop] IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1833 | [in-loop] IF sy-subrc <> 0. |
+| samples | `src/00/98/z2ui5_cl_smp_app_117.clas.abap`:136 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_131.clas.abap`:139 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_185.clas.abap`:123 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_191.clas.abap`:124 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_193.clas.abap`:43 | [simple] IF sy-subrc = 0. |
+| samples | `src/00/98/z2ui5_cl_smp_app_193.clas.abap`:51 | [simple] IF sy-subrc = 0. |
+| samples | `src/00/98/z2ui5_cl_smp_app_195.clas.abap`:123 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_211.clas.abap`:150 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/00/98/z2ui5_cl_smp_app_212.clas.abap`:86 | [simple] IF sy-subrc <> 0. |
+| samples | `src/00/98/z2ui5_cl_smp_app_338.clas.abap`:138 | [simple] IF sy-subrc = 0 AND <view_display> = abap_true. |
+| samples | `src/01/z2ui5_cl_smp_app_104.clas.abap`:49 | [simple] IF sy-subrc <> 0. |
+| samples | `src/01/z2ui5_cl_smp_app_104.clas.abap`:68 | [simple] IF sy-subrc <> 0. |
+| samples | `src/01/z2ui5_cl_smp_app_461.clas.abap`:85 | [simple] IF sy-subrc <> 0. |
+| samples | `src/01/z2ui5_cl_smp_app_461.clas.abap`:89 | [simple] IF sy-subrc <> 0. |
+| samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:449 | [in-loop] IF sy-subrc <> 0. |
+| samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:492 | [in-loop] IF sy-subrc <> 0. |
 
 **Must NOT fire on 171 site(s)** that match the shape and are correct:
 
@@ -275,25 +303,25 @@ Run **2026-08-17** against `abap2UI5`, `samples`, `samples-controls`, `samples-s
 | abap2UI5 | `src/99/02/z2ui5_cl_pop_to_select.clas.abap`:244 | ASSERT sy-subrc = 0. |
 | abap2UI5 | `src/99/02/z2ui5_cl_pop_to_select.clas.testclasses.abap`:244 | IF sy-subrc <> 0. |
 | abap2UI5 | `src/99/02/z2ui5_cl_pop_to_select.clas.testclasses.abap`:288 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:884 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:893 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:948 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:999 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1659 | IF sy-subrc <> 0 OR <field> <> abap_true. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1663 | ASSERT sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1777 | IF sy-subrc <> 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1920 | CHECK sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1961 | CHECK sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1993 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2008 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2011 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2032 | CHECK sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2047 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2060 | CHECK sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2071 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2080 | IF sy-subrc = 0. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2089 | IF sy-subrc <> 0 OR <tky> IS INITIAL. |
-| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2109 | CHECK sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:850 | IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:859 | IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:914 | IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:965 | IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1625 | IF sy-subrc <> 0 OR <field> <> abap_true. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1629 | ASSERT sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1743 | IF sy-subrc <> 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1886 | CHECK sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1927 | CHECK sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1959 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1974 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1977 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:1998 | CHECK sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2013 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2026 | CHECK sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2037 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2046 | IF sy-subrc = 0. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2055 | IF sy-subrc <> 0 OR <tky> IS INITIAL. |
+| samples | `src/00/01/z2ui5_cl_smp_context.clas.abap`:2075 | CHECK sy-subrc = 0. |
 | samples | `src/00/98/z2ui5_cl_smp_app_194.clas.abap`:55 | IF sy-subrc <> 0. |
 | samples | `src/00/98/z2ui5_cl_smp_app_212.clas.abap`:94 | IF sy-subrc <> 0. |
 | samples | `src/00/98/z2ui5_cl_smp_app_212.clas.abap`:101 | IF sy-subrc <> 0. |
@@ -305,7 +333,7 @@ Run **2026-08-17** against `abap2UI5`, `samples`, `samples-controls`, `samples-s
 | samples | `src/00/98/z2ui5_cl_smp_app_337.clas.abap`:185 | IF sy-subrc <> 0. |
 | samples | `src/00/98/z2ui5_cl_smp_app_348.clas.abap`:175 | IF sy-subrc <> 0. |
 | samples | `src/00/98/z2ui5_cl_smp_app_349.clas.abap`:193 | IF sy-subrc <> 0. |
-| samples | `src/01/z2ui5_cl_smp_app_070.clas.abap`:365 | IF sy-subrc <> 0. |
+| samples | `src/01/z2ui5_cl_smp_app_070.clas.abap`:356 | IF sy-subrc <> 0. |
 | samples-controls | `src/01/01/z2ui5_cl_smpc_app_012.clas.abap`:558 | IF sy-subrc = 0. |
 | samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:414 | CHECK sy-subrc = 0. |
 | samples-stack | `src/00/00/z2ui5_cl_smps_context.clas.abap`:535 | IF sy-subrc <> 0. |
@@ -323,7 +351,8 @@ Run **2026-08-17** against `abap2UI5`, `samples`, `samples-controls`, `samples-s
 
 **Where the detector is an approximation of the rule:**
 
-- The set of sy-subrc-writing statements above is hand-written and short. A statement missing from it lets an ASSIGN keep its claim too long, so the count is an upper bound — abaplint knows the real set (it models it for `check_subrc`) and would report fewer.
+- Which fix applies: 42 simple · 17 in a loop · 2 re-assigned. Only the first is a drop-in; the other two need `UNASSIGN` before the `ASSIGN`, because a failed assign leaves the previous binding in place and `IS ASSIGNED` then reads TRUE for a failure. Verified against `@abaplint/runtime`'s assign, which sets sy-subrc = 4 and returns without clearing the target.
+- The set of sy-subrc-writing statements is hand-written and short. A statement missing from it lets an ASSIGN keep its claim too long, so the count is an upper bound — abaplint knows the real set (it models it for `check_subrc`) and would report fewer.
 - Field-symbol assignment inside a macro or a chained statement is not followed.
 
 <!-- probe:end -->

--- a/backlog/items/abaplint-subrc-after-assign.probe.mjs
+++ b/backlog/items/abaplint-subrc-after-assign.probe.mjs
@@ -5,6 +5,23 @@
  * is a plain dynamic `ASSIGN`. The negatives are the same test after
  * `ASSIGN COMPONENT … OF STRUCTURE`, where `sy-subrc` distinguishes "component
  * not found" and IS the documented check — the scope the rule has to respect.
+ *
+ * Each site also carries WHICH FIX APPLIES, because they are not the same fix
+ * and the difference decides whether the rule can be auto-fixed at all:
+ *
+ *   simple      the field symbol is freshly declared in this method and this
+ *               is its only ASSIGN — `IS [NOT] ASSIGNED` is a drop-in
+ *   in-loop     the ASSIGN sits inside LOOP / DO / WHILE, so a FAILED assign
+ *               leaves the binding from the previous iteration in place and
+ *               `IS ASSIGNED` reads TRUE for a failure. Needs `UNASSIGN`
+ *               first — verified against `@abaplint/runtime`'s assign, which
+ *               sets sy-subrc = 4 and returns WITHOUT clearing the target
+ *   reassigned  the same field symbol was already assigned earlier in the
+ *               method; same trap, same fix
+ *
+ * Getting this wrong is how a "cleanup" turns a wrong-branch bug into a
+ * silently-taken one, so a rule that blanket-suggests `IS ASSIGNED` would be
+ * worse than no rule.
  */
 import { lines, isComment, abapFiles } from '../../.github/scripts/lib/abap-scan.mjs';
 
@@ -23,21 +40,45 @@ const SUBRC = /\bsy-subrc\b/i;
 const SETS_SUBRC =
   /^\s*(read\s+table|select|loop\s+at|find|replace|call\s+function|call\s+method|delete|insert|modify|append|split|open\s+dataset|authority-check|import|export|describe|search|at\s+selection|get\s+parameter|set\s+parameter)\b/i;
 
+const TARGET = /\bTO\s+(?:FIELD-SYMBOL\()?(<[a-z_0-9]+>)/i;
+let lastKind = 'simple';
+
 export function run(roots) {
   const sites = [];
   const negatives = [];
+  const counts = { simple: 0, 'in-loop': 0, reassigned: 0 };
   for (const root of roots) {
     for (const file of abapFiles(root)) {
       const src = lines(file);
-      // 'plain' | 'component' | null — what last laid claim to sy-subrc
       let claim = null;
+      let depth = 0;
+      let assignedHere = new Set();
+      let lastTarget = null;
       src.forEach((line, i) => {
         if (isComment(line) || !line.trim()) return;
-        if (ASSIGN.test(line)) { claim = ASSIGN_COMPONENT.test(line) ? 'component' : 'plain'; return; }
+        if (/^\s*METHOD\s/i.test(line)) { assignedHere = new Set(); depth = 0; }
+        if (/^\s*(loop\s+at|do\b|while\b)/i.test(line)) depth += 1;
+        else if (/^\s*(endloop|enddo|endwhile)\b/i.test(line)) depth = Math.max(0, depth - 1);
+
+        if (ASSIGN.test(line)) {
+          claim = ASSIGN_COMPONENT.test(line) ? 'component' : 'plain';
+          const t = TARGET.exec(line);
+          lastTarget = t ? t[1].toLowerCase() : null;
+          if (claim === 'plain' && lastTarget) {
+            const kind = depth > 0 ? 'in-loop' : (assignedHere.has(lastTarget) ? 'reassigned' : 'simple');
+            assignedHere.add(lastTarget);
+            lastKind = kind;
+          }
+          return;
+        }
         if (SUBRC.test(line)) {
           if (claim) {
             const where = { repo: file.repo, file: file.rel, line: i + 1, text: line.trim() };
-            (claim === 'plain' ? sites : negatives).push(where);
+            if (claim === 'plain') {
+              where.text = `[${lastKind}] ${where.text}`;
+              counts[lastKind] += 1;
+              sites.push(where);
+            } else negatives.push(where);
           }
           claim = null;
           return;
@@ -50,8 +91,14 @@ export function run(roots) {
     sites,
     negatives,
     notes: [
-      'The set of sy-subrc-writing statements above is hand-written and short. '
-      + 'A statement missing from it lets an ASSIGN keep its claim too long, so '
+      `Which fix applies: ${counts.simple} simple · ${counts['in-loop']} in a loop `
+      + `· ${counts.reassigned} re-assigned. Only the first is a drop-in; the other `
+      + 'two need `UNASSIGN` before the `ASSIGN`, because a failed assign leaves '
+      + 'the previous binding in place and `IS ASSIGNED` then reads TRUE for a '
+      + 'failure. Verified against `@abaplint/runtime`\'s assign, which sets '
+      + 'sy-subrc = 4 and returns without clearing the target.',
+      'The set of sy-subrc-writing statements is hand-written and short. A '
+      + 'statement missing from it lets an ASSIGN keep its claim too long, so '
       + 'the count is an upper bound — abaplint knows the real set (it models it '
       + 'for `check_subrc`) and would report fewer.',
       'Field-symbol assignment inside a macro or a chained statement is not '


### PR DESCRIPTION
Follow-up to #2619. Documentation and detector only — no ABAP changes.

## What happened

`backlog/items/abaplint-subrc-after-assign.md` proposed reporting a `sy-subrc` test after `ASSIGN` and suggesting `IS [NOT] ASSIGNED`. The detector measured **61 sites**, 23 of them in this repository's own non-frozen code, so the obvious next step was to convert them.

Checking first showed the proposal was two-thirds right.

## A failed `ASSIGN` does not unassign

Verified in `@abaplint/runtime`'s `assign`: every failure path sets `sy-subrc = 4` and returns **without clearing the target**. The field symbol keeps whatever it pointed at before.

So inside a `LOOP`, or anywhere the same symbol was already assigned, `IS ASSIGNED` reads TRUE for a failure — turning a wrong-branch bug into a silently-taken one. That is worse than what it replaces, and it is exactly the shape a well-meaning cleanup produces.

## Measured split

The detector classifies every site now:

| | | fix |
|---|--:|---|
| **simple** | 42 | freshly declared in this method, assigned once — `IS [NOT] ASSIGNED` is a drop-in |
| **in-loop** | 17 | inside `LOOP`/`DO`/`WHILE` — needs `UNASSIGN <fs>.` first |
| **reassigned** | 2 | same symbol already assigned earlier in the method — same trap, same fix |

So the rule either reports all three and describes both fixes, or fires only on the simple shape and stays silent on the other two. The second is smaller and safer, and the classification is decidable from the same single file.

## Why no ABAP changed here

Of this repository's 23 non-frozen sites, **7 are inside loops**. A per-site judgement on released framework code deserves its own pull request rather than riding along with a documentation fix.

For the record, the #1937 fix itself is a *simple* case and is correct: `attri_get_val_ref` declares `<attri>` at method start and assigns it in two mutually exclusive branches, so nothing can be left over.

## Files

- `backlog/items/abaplint-subrc-after-assign.probe.mjs` — classifies each site
- `backlog/items/abaplint-subrc-after-assign.md` — the caveat, the table, and the narrowed proposal (regenerated `Measured` block)
- `.claude/skills/abap-check/SKILL.md` §5 — the same caveat where the entry lives
- `backlog/ABAPLINT.md`, `backlog/probes.json` — generated

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_