### PR TITLE
The enum trap, proven against the original instead of argued

### DIFF
--- a/.claude/skills/ui5-check/SKILL.md
+++ b/.claude/skills/ui5-check/SKILL.md
@@ -353,6 +353,21 @@ Not about names or layout — these only show up when the app runs.
   interpolating from ABAP — the `$` paths are resolved by UI5 — so the
   template buys nothing anyway.
 
+  **And it happens without a template at all.** A sweep of all 417
+  samples-controls apps (2026-08-17) found two DEAD on their first render from
+  this class — and app **121** is the sharper one, because the ORIGINAL UI5
+  sample does the same thing and works. It binds
+  `visibility="{visibility}"` against data that is `{"type":"Draft"}` — no
+  `visibility` anywhere. In JavaScript that is `undefined` and UI5 leaves the
+  property at its default; in ABAP the unfilled `TYPE string` serialises as
+  `""` and the enum rejects it. So a **1:1 port of a correct sample is fatal**,
+  and nothing at either end looks wrong. Keep the value out of the model
+  (`_bind( … omit_initial_paths = … )`) or give the binding a fallback.
+
+  Both apps had been reporting **green**: the framework catches a fatal error
+  and RENDERS it, so nothing reaches `pageerror`. samples-controls' e2e gate
+  reads the overlay directly now.
+
   The trap is structural rather than particular to that control: ABAP has no
   null, an unfilled `TYPE string` serialises as `""`, and **`""` is a member of
   no UI5 enum**. So it applies to every enum-typed property in an aggregation

--- a/backlog/items/linter-enum-empty-in-template.md
+++ b/backlog/items/linter-enum-empty-in-template.md
@@ -11,6 +11,7 @@ evidence:
   - the control throws `"" is of type string, expected sap.ui.unified.CalendarDayType for property "secondaryType"` and takes the view down
   - the port boots clean, survives the first press of its toggle and dies on the second — the press that empties the table
   - the analysis and the scope this proposal needs are written up in `.claude/skills/ui5-check/SKILL.md` §4
+  - a full e2e sweep of all 417 samples-controls apps (2026-08-17) found **two** apps DEAD on their first render from this class, both reporting green until the gate learned to read the framework's fatal overlay — app 362 (`sap.ui.core.SortOrder`) and app 121 (`sap.m.ObjectMarkerVisibility`)
 ---
 
 # Report an enum-typed property bound with no fallback inside an aggregation template
@@ -37,6 +38,31 @@ UI5 enum**. So it applies to every enum-typed property in an aggregation
 template — `type`, `state`, `design`, `valueState`, `highlight` — whenever the
 bound table can be empty. A first render passes and the emptying fails, which is
 why nothing offline sees it.
+
+## The same trap without a template: a plain member left initial
+
+App **121** is the sharper case, because **the original UI5 sample does the
+same thing and works**. Its view binds
+
+```xml
+<ObjectMarker type="{type}" visibility="{visibility}"/>
+```
+
+and its data is `{"type":"Draft"}` — no `visibility` anywhere. In JavaScript
+that resolves to `undefined`, and UI5 leaves the property at its default. ABAP
+has no `undefined`: the unfilled `TYPE string` serialises as `""`, and `""` is a
+member of no enum. The app terminated on its first render.
+
+So a **1:1 port of a correct sample is fatal**, and nothing about the view or
+the data looks wrong at either end. That is the structural half of this entry,
+proven against the original rather than argued from ABAP's type system.
+
+It also widens the rule's scope beyond the emptied-table case: any enum-typed
+property bound to a path the model may not carry — a template row that omits
+the field, or a plain member never assigned — has the same end state. The fix
+is the same shape in both: keep the value out of the model
+(`_bind( … omit_initial_paths = … )`, which apps 121, 241 and 299 use) or give
+the binding a fallback.
 
 ## Why this one is worth a rule
 


### PR DESCRIPTION
Documentation only. Companion to abap2UI5/samples-controls#117, which carries the two fixes and the gate change.

## What the sweep found

A full e2e run over all **417** samples-controls apps found exactly **two** dead on their first render, both from the empty-string-into-an-enum class filed in #2619 — and both had been reporting **green**, because the framework catches a fatal error and *renders* it, so nothing reaches `pageerror`:

```
362  "" is of type string, expected sap.ui.core.SortOrder
121  "" is of type string, expected sap.m.ObjectMarkerVisibility
```

## Why 121 is the sharper case

**The original UI5 sample does the same thing and works.** Its view binds

```xml
<ObjectMarker type="{type}" visibility="{visibility}"/>
```

and its data is `{"type":"Draft"}` — no `visibility` anywhere. In JavaScript that resolves to `undefined`, and UI5 leaves the property at its default. ABAP has no `undefined`: the unfilled `TYPE string` serialises as `""`, and `""` is a member of no enum.

So a **1:1 port of a correct sample is fatal**, and nothing about the view or the data looks wrong at either end.

That was the entry's structural claim, argued from ABAP's type system. It is measured now.

## What it changes about the proposed rule

The entry was written from the *emptied aggregation template* case. 121 is a **plain member never assigned** — no template, no emptying — and reaches the same end state. So the scope is wider than the entry said: any enum-typed property bound to a path the model may not carry. The fix is the same shape either way — keep the value out of the model (`_bind( … omit_initial_paths = … )`, which apps 121, 241 and 299 now use) or give the binding a fallback.

## Files

- `backlog/items/linter-enum-empty-in-template.md` — the evidence, the new section, wider scope
- `.claude/skills/ui5-check/SKILL.md` §4 — the same, where the entry lives
- `backlog/ABAP2UI5-LINTER.md` — generated

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxfMgtqL8ufmqpMWEnhY8a)_