### PR TITLE
Follow samples-controls' overview app to z2ui5_cl_smpc_app_000

### DIFF
--- a/.github/abaplint/app-rules.json
+++ b/.github/abaplint/app-rules.json
@@ -8,7 +8,7 @@
     "7bit_ascii": {
       "exclude": [
         "z2ui5_cl_smpc_app_(012|040|092|103|104|114|134|185|191|194|215|218|254|290|302|303|350|356|357|358|360)\\.clas\\.",
-        "z2ui5_cl_smpc_app_overview\\.clas\\."
+        "z2ui5_cl_smpc_app_000\\.clas\\."
       ]
     },
     "abapdoc": false,
@@ -233,7 +233,7 @@
       "checkForms": true,
       "checkFunctionModules": true,
       "exclude": [
-        "z2ui5_cl_smpc_app_overview\\.clas\\."
+        "z2ui5_cl_smpc_app_000\\.clas\\."
       ]
     },
     "method_overwrites_builtin": true,

--- a/.github/scripts/prose-name-gate.mjs
+++ b/.github/scripts/prose-name-gate.mjs
@@ -48,7 +48,7 @@ const EXTERNAL = new Map([
   ["Z2UI5_CL_CC_DEMO_OUT", "sample custom control of the samples repository"],
   ["Z2UI5_CL_SMP_CONTEXT", "the samples repository's shared table/context helper"],
   ["Z2UI5_CL_SMP_APP_000", "the samples repository's overview app"],
-  ["Z2UI5_CL_SMPC_APP_OVERVIEW", "the samples-controls overview app"],
+  ["Z2UI5_CL_SMPC_APP_000", "the samples-controls overview app"],
   ["Z2UI5_CL_SMPS_APP_000", "the samples-stack overview app"],
   ["Z2UI5_CL_SMPS_EVT_TCK", "the samples-stack ticket event handler - an abap-check case"],
   ["Z2UI5_CL_MY_CLASS", "placeholder in an AGENTS.md example"],

--- a/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
+++ b/src/01/04/z2ui5_cl_ui5_app_start.clas.abap
@@ -538,12 +538,13 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
     " overview app of that repository on THIS system? Then the name links to
     " it - otherwise to the repository on GitHub, where the installation
     " starts, and the row is marked as not installed. All three of them renamed
-    " their overview app (z2ui5_cl_demo_app_g00 -> z2ui5_cl_smp_app_000,
-    " z2ui5_cl_dmo_app_overview -> z2ui5_cl_smpc_app_overview and
-    " z2ui5_cl_smps_app_00 -> z2ui5_cl_smps_app_000), so they pass the old name
-    " as a fallback: an installation that predates the rename still links to
-    " its app. One old name each - samples-stack's smpe-era name from before
-    " its namespace migration is older still and no longer tried.
+    " their overview app onto the three-digit number scheme
+    " (z2ui5_cl_demo_app_g00 -> z2ui5_cl_smp_app_000,
+    " z2ui5_cl_smpc_app_overview -> z2ui5_cl_smpc_app_000 and
+    " z2ui5_cl_smps_app_00 -> z2ui5_cl_smps_app_000), so they pass the old
+    " name as a fallback: an installation that predates the rename still links
+    " to its app. One old name each - the dmo- and smpe-era names from before
+    " the earlier renames are older still and no longer tried.
     " The descriptions are the GitHub "About" text of each repository word for
     " word, so the page and the repository say the same thing - with the em
     " dash written as a hyphen, because ABAP source here is 7-bit ASCII.
@@ -564,8 +565,8 @@ CLASS z2ui5_cl_ui5_app_start IMPLEMENTATION.
         name      = `samples-controls`
         descr     = `Learn how to use every UI5 control in ABAP - the UI5 Demo Kit rebuilt with abap2UI5`
         href      = `https://github.com/abap2UI5/samples-controls`
-        class     = `z2ui5_cl_smpc_app_overview`
-        class_old = `z2ui5_cl_dmo_app_overview` ).
+        class     = `z2ui5_cl_smpc_app_000`
+        class_old = `z2ui5_cl_smpc_app_overview` ).
 
     render_samples(
         form      = form


### PR DESCRIPTION
# Description

samples-controls renamed its overview app onto the three-digit number scheme (`z2ui5_cl_smpc_app_overview` → `z2ui5_cl_smpc_app_000`); all three overview apps of the family end in `000` now. The start page's *Controls* row links the new name and carries the previous one as the `class_old` fallback an installation from before the rename still answers to — one old name each, the dmo-era name is no longer tried. The shared rule block's excludes follow in the source (`.github/abaplint/app-rules.json`), in lockstep with the copies in the three sample repositories, and the prose-name gate's EXTERNAL entry moves with the class.

## How to test

- `npm run check`, `check:abapgit`, `check:atc`, `check:prose`, `check:dynamic` — all green.
- On a system with samples-controls installed under the old name: the start page's *Controls* row still resolves via the fallback.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — string literals and comments only; the affected gates above are green
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — n/a
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwVuR2wxsG2HnAosWzrjTP)_