### PR TITLE
Declare the sandbox skip samples-controls' formatter carries

### DIFF
--- a/.github/scripts/shared-file-gate.mjs
+++ b/.github/scripts/shared-file-gate.mjs
@@ -261,6 +261,10 @@ const SHARED = [
     file: '.github/shared/chain-format.mjs',
     consumers: ['samples', 'samples-controls'],
     consumerFile: 'scripts/chain-format.mjs',
+    /* The source carries no skip, so its side of the comparison is the file
+     * as it stands; only a consumer that declares one has anything cut. */
+    section: (text, side) => dropSandboxSkip(text, side),
+    mine: (text) => text,
     why: 'the builder-chain formatter the two sample corpora are laid out by,'
       + ' until the linter pin can move and the rule replaces it',
   },
@@ -300,6 +304,43 @@ function metadataBlock(text) {
 const METADATA_EXTENSIONS = {
   'samples-controls': ['### In this repository'],
 };
+
+/* samples-controls' chain formatter skips one directory the other consumer's
+ * does not, and the difference is real rather than drift.
+ *
+ * `src/zz_dev` is where abap2UI5/ai-mcp's `deploy_app` writes the class an
+ * agent is working on. It is gitignored scratch, but every script here walks
+ * `src/` on the filesystem and the filesystem does not read `.gitignore`, so
+ * the loop this ecosystem recommends to agents left four classes where the
+ * gates look. samples-controls is the ONLY repository that happens to:
+ * `deploy_app` resolves the samples-controls checkout and writes nowhere else
+ * (ai-mcp `lib/runtime.mjs`). Carrying the skip into `samples` would be a
+ * branch that can never be taken, plus a `lib/src-tree.mjs` beside it that
+ * exists to list nothing.
+ *
+ * So it is declared, the way `scripts/prose-absent.json` is left per
+ * repository for the same reason: the shared thing is the program, and what
+ * each repository excludes from its own tree is not. Removing the skip over
+ * there fails this gate by name rather than passing quietly. */
+const SANDBOX_SKIP = {
+  'samples-controls': [
+    "import { isSkippedDir } from './lib/src-tree.mjs';\n",
+    '    if (isSkippedDir(e.name)) continue;\n',
+  ],
+};
+
+function dropSandboxSkip(text, side) {
+  const lines = SANDBOX_SKIP[side] ?? [];
+  return lines.reduce((s, line) => {
+    if (!s.includes(line)) {
+      throw new Error(
+        `declared sandbox skip is no longer in ${side}'s copy:\n      ${JSON.stringify(line)}\n`
+        + '      it was removed or rewritten — update SANDBOX_SKIP',
+      );
+    }
+    return s.split(line).join('');
+  }, text);
+}
 
 function dropSubsections(block, headings, side) {
   const lines = block.split('\n');


### PR DESCRIPTION
# Description

Follow-up to #2634. The new `check:shared` entry for the chain formatter goes red against `main` today, and this is the fix.

`chain-format.mjs` entered the shared list byte-equal in both consumers. Between that work and the merge, samples-controls#122 landed a change to its copy alone: `src/zz_dev` is skipped when walking `src/`. The gate caught it on its first run against real branches — which is exactly what it was written for — but making the copies equal again would be the wrong answer.

**The skip is real and belongs to one repository.** `src/zz_dev` is where `abap2UI5/ai-mcp`'s `deploy_app` writes the class an agent is working on. It is gitignored, and every script here walks `src/` on the filesystem, which does not read `.gitignore` — so the loop this ecosystem recommends to agents (deploy → build → run) left scratch classes where the gates look. samples-controls is the only repository that happens to: `deploy_app` resolves that checkout and writes nowhere else (`ai-mcp/lib/runtime.mjs`). Carrying the skip into `samples` would add a branch that can never be taken, plus a `lib/src-tree.mjs` beside it that exists to list nothing.

So it is **declared per consumer**, the same way `scripts/prose-absent.json` is deliberately left per repository beside the shared prose checker: the shared thing is the program, and what a repository excludes from its own tree is not. Removing the skip over there now fails this gate by name rather than passing quietly.

Mechanically this reuses what the metadata entry already does — a `section(text, side)` reader plus a source-side `mine` — so no new concept enters the gate.

## How to test

```
npm run check:shared     # 9 sources, 20 of 20 copies
npm run gates            # 20 checks
```

Verified in the CI shape (sibling checkouts moved aside, so the gate reads `raw.githubusercontent`): the chain-format difference is gone. One difference remains at the time of writing — the frontend README — and it is the raw CDN still serving the pre-merge copy of a file that abap2UI5/frontend#84 already corrected on `main`; `git show origin/main:README.md` there has the new text. It clears itself.

## Checklist

- [x] `npm run verify` passes — `npm run gates` reports 20 checks OK
- [ ] Unit tests added/updated where it makes sense — not applicable; the change is a declaration in a gate, and the negative path (removing the declared line over there) is what the new error message covers
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API in `src/02/` only changed additively — unchanged
- [x] Changes were made via abapGit: no — no ABAP source touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_