### PR TITLE
Extend the shared prose checker to CAPABILITIES.md and E2E.md

### DIFF
--- a/.github/shared/check-prose-names.mjs
+++ b/.github/shared/check-prose-names.mjs
@@ -61,7 +61,7 @@ const OWNER = [
 
 /* Prose only. src/ is ABAP and belongs to abaplint; the generated catalogue is
  * written FROM the classes, so checking it would only ever confirm itself. */
-const PROSE = ['README.md', 'CONTRIBUTING.md', 'AGENTS.md', 'CLAUDE.md', 'TRAINING.md', 'STATUS.md'];
+const PROSE = ['README.md', 'CONTRIBUTING.md', 'AGENTS.md', 'CLAUDE.md', 'TRAINING.md', 'STATUS.md', 'CAPABILITIES.md', 'E2E.md'];
 
 /* A journal records what a class was called when the entry was written; that
  * is history, not drift. Same reasoning as abap2UI5's changelog cut-off. */


### PR DESCRIPTION
# Description

The source side of samples-controls#124. **Merge that one, samples#782 and samples-stack#44 first** — `check:shared` compares this file against their `main`.

`samples-controls/CAPABILITIES.md` is what an agent reads before deciding a feature is inexpressible, and it had been carrying nine class names no repository ships any more: five renamed with their corpus (`z2ui5_cl_demo_app_*` → `z2ui5_cl_smp_app_*` / `z2ui5_cl_smps_app_*`), three gone entirely, and one framework class retired in the `ui5f` rename (`z2ui5_cl_app_frontendaction_js` → `z2ui5_cl_ui5f_frontact_js`).

Nothing could notice, because the checker's `PROSE` list stopped at `STATUS.md` — so the file most likely to cite another repository's classes was the one file not checked for exactly that.

Two entries added. The other two consumers pay nothing for them: the script already skips a file a repository does not have, so `samples` and `samples-stack` check the same 25 and 14 names as before, and the file stays byte-identical in all three — which is what `check:shared` holds it to.

## How to test

```
npm run gates          # 20 checks
npm run check:shared   # 9 sources, 20 of 20 copies
```

With all three consumer branches merged. Run in each consumer, `npm run check:prose` reports 36 / 25 / 14 names, all resolving.

## Checklist

- [x] `npm run verify` passes — `npm run gates` reports 20 checks OK
- [ ] Unit tests added/updated where it makes sense — not applicable; two entries in a list, and the behaviour they add is proved by the consumer pull request finding nine real names
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API in `src/02/` only changed additively — unchanged
- [x] Changes were made via abapGit: no — no ABAP source touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_