### PR TITLE
Follow the MCP server's rename to mcp-server

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -16,7 +16,7 @@ releases — a value help, a tree, navigation between two apps, a dynamic table
 typed at runtime. Reading one beats reproducing it, and beats any snippet: the
 sample is gated, a snippet is a copy somebody has to keep in step.
 
-- With the [MCP server](https://github.com/abap2UI5/ai-mcp): the `examples`
+- With the [MCP server](https://github.com/abap2UI5/mcp-server): the `examples`
   tool queries that catalogue (`examples { query: "value help f4" }`) and
   hands back the class to read. Its neighbour `capabilities` answers the other
   question — whether a UI5 *control* can be expressed at all — out of
@@ -75,7 +75,7 @@ Quick orientation while it loads:
 - The app checks its own authorizations at the top of `main`.
 - Validate with the abap2UI5-linter
   (`npx --yes @abap2ui5/linter <file>`); iterate without a SAP
-  system via the ai-mcp server (`deploy_app` → `build_backend` → `run_app`).
+  system via the mcp-server (`deploy_app` → `build_backend` → `run_app`).
 - Before you finish, run the `abap-check` skill over what you wrote — it is the
   companion to this one and catches what a green lint does not: abapGit
   round-trip diffs, activation errors (`class_constructor` visibility,

--- a/.github/scripts/samples-md-gate.mjs
+++ b/.github/scripts/samples-md-gate.mjs
@@ -13,9 +13,9 @@
  * What is NOT defensible is that the LINE FORMAT they all emit is read by two
  * programs in two further repositories:
  *
- *   abap2UI5/ai-mcp   lib/examples.mjs      — the `examples` tool an agent
+ *   abap2UI5/mcp-server   lib/examples.mjs  — the `examples` tool an agent
  *                                             searches all three catalogues with
- *   abap2UI5/docs     scripts/lib/catalogue.mjs
+ *   abap2UI5/docs         scripts/lib/catalogue.mjs
  *                                           — the "Working Samples" block on
  *                                             every cookbook page, and the app
  *                                             counts the site quotes
@@ -42,7 +42,7 @@
  * is "can be read", not "is written the way samples writes it".
  *
  * The one known asymmetry between the readers is left alone on purpose:
- * ai-mcp's pattern makes the dash after a bold header optional and docs' does
+ * mcp-server's pattern makes the dash after a bold header optional and docs' does
  * not, so a bold-header-no-dash row loses its title over in docs and falls back
  * to `**Header**` inside the label. That renders as bold text in the generated
  * block — cosmetic, and it is docs' pattern to widen if anybody minds. What
@@ -75,7 +75,7 @@ const raw = (repo) => `https://raw.githubusercontent.com/abap2UI5/${repo}/main/$
  * line in their own repository; keeping them one line here makes a future diff
  * against the original a diff of one line.
  *
- * abap2UI5/ai-mcp, lib/examples.mjs */
+ * abap2UI5/mcp-server, lib/examples.mjs */
 const MCP_ROW = /^\|\s*(?:\*\*(?<title>[^*]+)\*\*\s*(?:(?:—|--)\s*)?)?(?<sub>[^|<]*?)\s*(?<blocks>(?:<br>(?:<[a-z]+>[^<]*<\/[a-z]+>|[^<]*))*)\s*\|\s*\[`(?<cls>[A-Z0-9_]+)`\]\((?<path>[^)]+)\)\s*\|/;
 
 /* abap2UI5/docs, scripts/lib/catalogue.mjs */
@@ -86,7 +86,7 @@ const DOCS_ROW = /^\|\s*(?:\*\*(?<title>[^*]+)\*\*\s*(?:—|--)\s*)?(?<sub>[^|<]
  * row that sits under no heading has no name at all in either reader. */
 const HEADING = /^#{2,3}\s+(.+?)\s*$/;
 
-/* The `<br>`-separated blocks after the title, as ai-mcp splits them. A block
+/* The `<br>`-separated blocks after the title, as mcp-server splits them. A block
  * this gate does not recognise costs nothing — that tolerance is the readers'
  * deliberate design and copying it is the point. */
 const blocksOf = (blocks) =>
@@ -147,7 +147,7 @@ function checkCatalogue(repo, text) {
     const mcp = MCP_ROW.exec(line);
     const docs = DOCS_ROW.exec(line);
     if (!mcp || !docs) {
-      const who = !mcp && !docs ? 'neither reader' : (!mcp ? "abap2UI5/ai-mcp's reader" : "abap2UI5/docs' reader");
+      const who = !mcp && !docs ? 'neither reader' : (!mcp ? "abap2UI5/mcp-server's reader" : "abap2UI5/docs' reader");
       problems.push(
         `${at}: ${who} can parse this row\n`
         + `      ${JSON.stringify(line.slice(0, 120))}\n`
@@ -162,8 +162,8 @@ function checkCatalogue(repo, text) {
     if (g.cls !== docs.groups.cls || g.path !== docs.groups.path) {
       problems.push(
         `${at}: the two readers disagree about the pointer\n`
-        + `      ai-mcp: ${g.cls} -> ${g.path}\n`
-        + `      docs:   ${docs.groups.cls} -> ${docs.groups.path}`,
+        + `      mcp-server: ${g.cls} -> ${g.path}\n`
+        + `      docs:       ${docs.groups.cls} -> ${docs.groups.path}`,
       );
     }
 
@@ -172,7 +172,7 @@ function checkCatalogue(repo, text) {
     }
 
     /* The link target is the class file. Both readers hand the path straight to
-     * a reader or a URL builder without checking it, and ai-mcp additionally
+     * a reader or a URL builder without checking it, and mcp-server additionally
      * decides `src/01` vs experimental from its first segment. */
     if (!/^src\/[^)\s]*\.clas\.abap$/.test(g.path)) {
       problems.push(`${at}: \`${g.path}\` is not a \`src/…/<class>.clas.abap\` path`);
@@ -199,7 +199,7 @@ function checkCatalogue(repo, text) {
       }
     }
 
-    /* The `docs:` block: ai-mcp returns its links as the answer to "which
+    /* The `docs:` block: mcp-server returns its links as the answer to "which
      * chapter explains this", and finds the KEYWORDS by taking the first `<sub>`
      * that is not it. Two of them and the second is unreachable. */
     const docBlocks = blocksOf(g.blocks).filter((b) => b.tag === 'sub' && b.text.startsWith('docs:'));
@@ -258,7 +258,7 @@ if (problems.length) {
   console.error(`\n${problems.length} problem(s):`);
   for (const p of problems) console.error(`  ${p}`);
   console.error(
-    '\n  The row format is read by abap2UI5/ai-mcp (lib/examples.mjs) and'
+    '\n  The row format is read by abap2UI5/mcp-server (lib/examples.mjs) and'
     + '\n  abap2UI5/docs (scripts/lib/catalogue.mjs). A row neither can parse is'
     + '\n  a sample that answers "no such sample" instead of failing anything.'
     + '\n  Fix the generator in the repository the row came from.',

--- a/.github/scripts/shared-file-gate.mjs
+++ b/.github/scripts/shared-file-gate.mjs
@@ -308,13 +308,13 @@ const METADATA_EXTENSIONS = {
 /* samples-controls' chain formatter skips one directory the other consumer's
  * does not, and the difference is real rather than drift.
  *
- * `src/zz_dev` is where abap2UI5/ai-mcp's `deploy_app` writes the class an
+ * `src/zz_dev` is where abap2UI5/mcp-server's `deploy_app` writes the class an
  * agent is working on. It is gitignored scratch, but every script here walks
  * `src/` on the filesystem and the filesystem does not read `.gitignore`, so
  * the loop this ecosystem recommends to agents left four classes where the
  * gates look. samples-controls is the ONLY repository that happens to:
  * `deploy_app` resolves the samples-controls checkout and writes nowhere else
- * (ai-mcp `lib/runtime.mjs`). Carrying the skip into `samples` would be a
+ * (mcp-server `lib/runtime.mjs`). Carrying the skip into `samples` would be a
  * branch that can never be taken, plus a `lib/src-tree.mjs` beside it that
  * exists to list nothing.
  *

--- a/.github/shared/CONVENTIONS.md
+++ b/.github/shared/CONVENTIONS.md
@@ -19,7 +19,7 @@ first paragraph.
 | --- | --- | --- |
 | **Source** | Humans and agents edit here. CI gates every change. | `abap2UI5`, `linter`, `web-abap2UI5` |
 | **Channel** | Generated and pushed by a workflow. Never edit. | `frontend`, `web-abap2UI5-build`, `app-template` |
-| **Product** | Ships on its own release cycle to npm, Marketplace or an action. | `linter`, `vscode-extension`, `ai-mcp` |
+| **Product** | Ships on its own release cycle to npm, Marketplace or an action. | `linter`, `vscode-extension`, `mcp-server` |
 | **Corpus** | A body of installable example code, installed on its own. | `samples`, `samples-controls`, `samples-stack` |
 
 Rules that follow from the role:

--- a/.github/shared/check-prose-names.mjs
+++ b/.github/shared/check-prose-names.mjs
@@ -104,7 +104,7 @@ const here = (() => {
 })();
 
 /* Where a sibling repository is, if it is here at all. The environment wins,
- * the way it does for abap2UI5/ai-mcp's resolvers - and it has to: a CI runner
+ * the way it does for abap2UI5/mcp-server's resolvers - and it has to: a CI runner
  * cannot check a repository out ABOVE the workspace, so `../<repo>` is a local
  * convenience and the variable is what CI uses. */
 const HOMES = {

--- a/.github/workflows/check_gates.yaml
+++ b/.github/workflows/check_gates.yaml
@@ -100,7 +100,7 @@ jobs:
         run: npm run check:counts
 
       # the row format of the three generated SAMPLES.md catalogues is parsed by
-      # abap2UI5/ai-mcp and abap2UI5/docs - three generators, two readers, none
+      # abap2UI5/mcp-server and abap2UI5/docs - three generators, two readers, none
       # of them in the same repository, and a reader that stops matching answers
       # "there are no samples for that" instead of failing
       - name: every catalogue row can be read by both of its readers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [samples-stack](https://github.com/abap2UI5/samples-stack) (formerly samples-ext) | Step 3: everything that needs more than an abap2UI5 installation — OData, RAP, WebSockets, the Fiori Launchpad. The dividing line against `samples` is that requirement, not the topic |
 | [docs](https://github.com/abap2UI5/docs) | Project documentation — the prose for **people**; it generates its own `llms.txt` for agents. `llms.txt` here is the map of the CODE, and the two are deliberately different things |
 | [linter](https://github.com/abap2UI5/linter) | `@abap2ui5/linter` — static + headless-render checks over an app class and the view its builder produces. A devDependency **here** (`abap2ui5lint.jsonc`, rule 21) and the destination of the `ui5-check` skill's `Linter:` lines |
-| [ai-mcp](https://github.com/abap2UI5/ai-mcp) | MCP server giving an agent the loop without an SAP system: search the catalogues, validate a view, deploy, build, run headless, screenshot |
+| [mcp-server](https://github.com/abap2UI5/mcp-server) | MCP server giving an agent the loop without an SAP system: search the catalogues, validate a view, deploy, build, run headless, screenshot |
 | [vscode-extension](https://github.com/abap2UI5/vscode-extension) | IDE support — lints while you type, `F9` runs a class against a real system, and registers the MCP servers into the editor |
 | [abap-util](https://github.com/abap-util/abap-util) | Master catalog of the platform utilities — upstream of `src/00/03/` (see "Utilities") |
 | [app-template](https://github.com/abap2UI5/app-template) | Starter repo for app projects — gates, CI and agent setup preconfigured |

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Then, depending on how much setup you want:
 | | |
 |---|---|
 | [llms.txt](https://abap2ui5.github.io/docs/llms.txt) | the documentation as a map, one fetch. [llms-full.txt](https://abap2ui5.github.io/docs/llms-full.txt) is all of it in one document, and every page is served as raw markdown next to its `.html` |
-| [ai-mcp](https://github.com/abap2UI5/ai-mcp) | MCP server: query the sample catalogues, validate a view, deploy, build, boot the app headless and **look at a screenshot**. No SAP system. This is the setup that closes the loop |
+| [mcp-server](https://github.com/abap2UI5/mcp-server) | MCP server: query the sample catalogues, validate a view, deploy, build, boot the app headless and **look at a screenshot**. No SAP system. This is the setup that closes the loop |
 | [app-template](https://github.com/abap2UI5/app-template) | start a project here — both gates, CI and an `AGENTS.md` for your own repo, already wired up |
 | [linter](https://github.com/abap2UI5/linter) | the check to run on generated code. It reports a class written on the frozen builder, which is the most common thing a model gets wrong |
 | [vscode-extension](https://github.com/abap2UI5/vscode-extension) | registers the MCP servers into the editor, lints while you type, and runs an app against a real system with `F9` |

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -560,7 +560,7 @@ The same tree, with the subtree held in a variable:
   binding mistakes, builder-tree defects) and can render the view headless:
   `npx --yes @abap2ui5/linter my_app.clas.abap` — also
   available as a GitHub Action and inside the VS Code extension.
-- **[ai-mcp](https://github.com/abap2UI5/ai-mcp)** gives MCP-capable agents
+- **[mcp-server](https://github.com/abap2UI5/mcp-server)** gives MCP-capable agents
   the full loop without a SAP system: `capabilities` → `deploy_app` →
   `build_backend` → `run_app` (headless screenshot + errors).
 - **[vscode-extension](https://github.com/abap2UI5/vscode-extension)**:

--- a/llms.txt
+++ b/llms.txt
@@ -38,7 +38,7 @@ Two audiences, two entry points:
   Launchpad and more
 - [abap2UI5-linter](https://github.com/abap2UI5/linter): static +
   headless-render checks for app view code (CLI, GitHub Action, VS Code)
-- [ai-mcp](https://github.com/abap2UI5/ai-mcp): MCP server with the
+- [mcp-server](https://github.com/abap2UI5/mcp-server): MCP server with the
   deploy -> build -> run -> screenshot loop, no SAP system needed
 
 ## Developing the framework itself


### PR DESCRIPTION
# Description

`abap2UI5/ai-mcp` is now `abap2UI5/mcp-server`. **Merge the consumer pull requests first** — samples#783, samples-controls#125, samples-stack#45 and app-template#13 — because two of the files here are shared sources that `check:shared` compares against their `main`.

Ten files: `README.md`, `AGENTS.md`, `llms.txt`, the `build-an-app` skill, `.github/shared/CONVENTIONS.md`, `.github/scripts/samples-md-gate.mjs`, `.github/scripts/shared-file-gate.mjs`, `.github/workflows/check_gates.yaml`, and the two shared sources:

- **`.github/shared/check-prose-names.mjs`** — changed here and in all three consumer copies in the same batch.
- **`docs/agents/building-apps.md`** — changed here; app-template's mirror is regenerated from it in that repository's pull request, not hand-edited.

A comment table in `samples-md-gate.mjs` was re-padded so its columns still line up — the new name is four characters longer — and a few sentences were reworded rather than substituted, because a blind replace turns "the ai-mcp server" into "the mcp-server server".

## How to test

```
npm ci && npm run gates      # 20 checks
npm run check:shared         # 9 sources, 20 of 20 copies
```

With the four consumer branches merged. `gates: 20 checked - all OK` here.

## Checklist

- [x] `npm run verify` passes — `npm run gates` reports 20 checks OK
- [ ] Unit tests added/updated where it makes sense — not applicable; prose and comments, no behaviour
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API in `src/02/` only changed additively — unchanged
- [x] Changes were made via abapGit: no — no ABAP source touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_