### PR TITLE
Drop the rule against the builder- prefix

### DIFF
--- a/.github/shared/CONVENTIONS.md
+++ b/.github/shared/CONVENTIONS.md
@@ -27,8 +27,11 @@ Rules that follow from the role:
 - A channel repository carries a README whose first line says it is generated,
   names the workflow that writes it, and says where to file bugs. Its issues are
   disabled. A `-build` suffix in the repository name means channel, always.
-- No repository name uses a `builder-` prefix. The prefix reads as a synonym of
-  the `-build` suffix while meaning its opposite.
+- The role is what the README states, not what the name suggests. Only the
+  `-build` suffix carries meaning; nothing else in a name is constrained. In
+  particular `builder-cap2UI5`, `builder-cap2UI5-web` and `builder-abap2UI5-js`
+  are sources that BUILD a channel — the opposite of a `-build` repository —
+  and they keep their names.
 - A source repository never carries a hand-maintained copy of content another
   repository owns. Either generate it, or gate it (section 5).
 


### PR DESCRIPTION
# Description

`CONVENTIONS.md` §1 said no repository name may use a `builder-` prefix, because it reads as a synonym of the `-build` suffix while meaning its opposite. Three repositories used it when the rule was written, and three use it today: `builder-cap2UI5`, `builder-cap2UI5-web`, `builder-abap2UI5-js`.

**A convention nobody follows is worse than no convention** — it makes the file unreliable everywhere else in it.

The choice was to rename three repositories or to strike the rule. The rule loses: renaming costs redirects, clone URLs, pipeline references and three `run/input` mirrors — real work, and a real window in which something resolves to the old name — to settle a confusion nobody has reported. The two names never appear side by side.

What replaces it keeps the useful half: **the role is what the README states, not what the name suggests**, and only the `-build` suffix is load-bearing. The three names are written out so the next reader does not rediscover the tension and re-open it as a defect.

This closes the same gap `check:scripts` (#2640) closed from the other side. There, a real rule was made enforceable; here, an unenforced one is withdrawn. Prose that neither binds nor is followed is the thing to avoid — whichever way it gets resolved.

## How to test

```
npm run gates
```

`gates: 21 checked - all OK`. `CONVENTIONS.md` is a source-only shared file with no consumer copies, so `check:shared` has nothing to propagate.

## Checklist

- [x] `npm run gates` passes — 21 checks
- [ ] Unit tests added/updated — not applicable; one prose rule
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API unchanged
- [x] Changes were made via abapGit: no — no ABAP source touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_