### PR TITLE
Ask Dependabot monthly, and keep majors out of the routine bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Weekly dependency updates, opened as pull requests so check_gates decides
+# Monthly dependency updates, opened as pull requests so check_gates decides
 # whether they are safe rather than a human reading a version number.
 #
 # Grouped one pull request per ecosystem: these manifests hold a handful of
@@ -14,16 +14,21 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
-      # Tuesday, clear of the Monday morning bump workflows in
-      # abap2UI5/linter's consumers, so the two do not open pull requests
-      # against each other's lockfile changes on the same day.
+      interval: monthly
+      # Monthly runs land on the 1st, so the weekday is whatever it falls on -
+      # the old Tuesday slot existed to stay clear of the Monday bump
+      # workflows in abap2UI5/linter's consumers, and that separation is no
+      # longer available. Roughly one month in seven the two will open pull
+      # requests against the same lockfile; that costs a rebase, not a build.
       time: "06:30"
     open-pull-requests-limit: 5
     groups:
       toolchain:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      toolchain-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   # app/webapp is the UI5 source the frontend is built from; its own manifest
   # carries the UI5 tooling, and a bump there changes build/ - which the
@@ -31,21 +36,27 @@ updates:
   - package-ecosystem: npm
     directory: /app
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       time: "06:30"
     open-pull-requests-limit: 5
     groups:
       ui5-tooling:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      ui5-tooling-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: tuesday
+      interval: monthly
       time: "06:30"
     open-pull-requests-limit: 5
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]


### PR DESCRIPTION
# Description

Grouping was already at its limit — one group per ecosystem, `patterns: ["*"]` — so the pull-request volume was not coming from ungrouped updates. It was coming from **multiplication**: three ecosystems here and two in each of nine sibling repositories, every Tuesday, is roughly **21 pull requests a week** for a set of build-time tools. Nobody reads the twenty-first.

**Monthly is the blunt part of the fix and the effective one:** the same updates, a quarter as often.

## Majors travel alone now

Each group is split by `update-types`, so a routine month produces one pull request per ecosystem containing only minor and patch bumps, and a major arrives on its own — visible as a major, and reviewable as one.

`actions/download-artifact` 7 → 8 was merged today inside a group. It happened to be clean (all 15 checks green), but it carried an ESM migration and a digest check that now **fails** a run instead of warning — and a digest mismatch is precisely the kind of thing CI here would never produce on demand. That is the case this split is for.

## The comments were rewritten, not dropped

They explained the Tuesday slot as deliberate distance from the Monday bump workflows. Monthly runs land on the **1st**, so the weekday varies and that distance no longer exists. Left alone, the comment would have kept claiming a property the file had lost — so it now says what is actually true, including that a collision costs a rebase rather than a build.

## What this does *not* do

Auto-merge is the obvious next lever, and it is deliberately not here. `gh pr merge --auto` only waits for CI where branch protection defines required checks; without them it merges **immediately**, which would be worse than the status quo. That precondition now holds in this repository, but not in most of the siblings — so it belongs in its own change, after this one has run for a cycle.

## How to test

```
npm run gates
```

All ten repositories' configs were validated as YAML, with every group carrying `update-types` and no `day:` left over from the weekly schedule (`day` is only honoured for `interval: weekly`).

## Checklist

- [x] YAML validated
- [ ] Unit tests added/updated — not applicable; configuration
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API unchanged
- [x] Changes were made via abapGit: no — no ABAP source touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLDFPfAK1MGq6qHeC6KKWH)_