### PR TITLE
Hold the addons to the conventions too

### DIFF
--- a/.github/scripts/scripts-gate.mjs
+++ b/.github/scripts/scripts-gate.mjs
@@ -52,17 +52,36 @@ const REPOS = [
   'linter',
   'docs',
   'web-abap2UI5',
-];
+
+  /* The addons, which sit in a second organisation and were outside every
+   * ecosystem gate until 2026-08-20 - which is how eleven repositories came to
+   * disagree with CONVENTIONS on workflow naming, toolchain pins and these two
+   * scripts at once, and how one of them shipped for ten days against a class
+   * that exists nowhere. They are source repositories with contributors, so
+   * the rule is theirs too. */
+  { org: 'abap2UI5-addons', repo: 'popups' },
+  { org: 'abap2UI5-addons', repo: 'se16n' },
+  { org: 'abap2UI5-addons', repo: 'sql-console' },
+  { org: 'abap2UI5-addons', repo: 'table-content-loader' },
+  { org: 'abap2UI5-addons', repo: 'table-maintenance' },
+  { org: 'abap2UI5-addons', repo: 'layout-management' },
+  { org: 'abap2UI5-addons', repo: 'selection-screen' },
+  { org: 'abap2UI5-addons', repo: 'lock-manager' },
+  { org: 'abap2UI5-addons', repo: 'custom-controls' },
+  { org: 'abap2UI5-addons', repo: 'rap-ext' },
+  { org: 'abap2UI5-addons', repo: 'fork-abapToC' },
+].map((e) => (typeof e === 'string' ? { org: 'abap2UI5', repo: e } : e));
 
 const REQUIRED = ['check', 'test'];
 
-const raw = (repo) => `https://raw.githubusercontent.com/abap2UI5/${repo}/main/package.json`;
+const raw = ({ org, repo }) => `https://raw.githubusercontent.com/${org}/${repo}/main/package.json`;
 
 const problems = [];
 const notes = [];
 let checked = 0;
 
-for (const repo of REPOS) {
+for (const entry of REPOS) {
+  const { repo } = entry;
   /* This repository is the checkout the gate runs in, not a sibling of it. */
   const local = repo === 'abap2UI5'
     ? path.join(ROOT, 'package.json')
@@ -75,7 +94,7 @@ for (const repo of REPOS) {
     from = 'checkout';
   } else {
     try {
-      const res = await fetch(raw(repo), { signal: AbortSignal.timeout(15000) });
+      const res = await fetch(raw(entry), { signal: AbortSignal.timeout(15000) });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       text = await res.text();
       from = 'github';

--- a/.github/shared/CONVENTIONS.md
+++ b/.github/shared/CONVENTIONS.md
@@ -22,6 +22,13 @@ first paragraph.
 | **Product** | Ships on its own release cycle to npm, Marketplace or an action. | `linter`, `vscode-extension`, `mcp-server` |
 | **Corpus** | A body of installable example code, installed on its own. | `samples`, `samples-controls`, `samples-stack` |
 
+These rules bind the `abap2UI5-addons` organisation as well as `abap2UI5`. They
+did not until 2026-08-20, and the drift that bought is the reason the sentence
+is here: eleven repositories with their own workflow naming, three different
+abaplint pins, no `check` script between them, not one scheduled run — and one
+that shipped for ten days against a class that exists in no repository, behind
+a green badge, because nothing re-ran its CI.
+
 Rules that follow from the role:
 
 - A channel repository carries a README whose first line says it is generated,
@@ -66,8 +73,9 @@ Rules that follow from the role:
 
 - **Every repository has `check` and `test`.** They are the two names an
   outside developer types without reading anything first, and "Missing script"
-  is a bad first answer. `check` exists in all ten repositories as of
-  2026-08-18; before that it existed in five.
+  is a bad first answer. `check` exists in all twenty-one repositories as of
+  2026-08-20; it reached the ten `abap2UI5` ones on 2026-08-18, and the eleven
+  `abap2UI5-addons` ones when they were brought into these rules.
 - `check` runs what CI runs on a pull request. A step that exists only in
   `package.json` is a step no pull request has to pass; a step that exists only
   in a workflow is one no contributor can run before pushing.
@@ -83,8 +91,9 @@ Rules that follow from the role:
   — the corpora are checked, not unit-tested — `test` is `npm run check`, so
   that the universal command still answers.
 - The first two rules are gated: `npm run check:scripts` in this repository
-  reads all ten `package.json` files (sibling checkout, else raw main, else say
-  so and pass) and fails naming any repository that has lost either script.
+  reads all twenty-one `package.json` files (sibling checkout, else raw main,
+  else say so and pass) and fails naming any repository that has lost either
+  script.
   Prose is not a thing that fails a pull request, which is why five of them
   drifted out of the rule before anyone noticed.
 - Namespaces use a colon: `check:chains`, `fmt:chains`, `bump:linter`. No


### PR DESCRIPTION
# Description

`scripts-gate` read ten repositories, all of them in the `abap2UI5` organisation. The eleven in `abap2UI5-addons` were outside it — and outside `shared-file-gate`, and outside every other ecosystem check. That is not *why* they drifted, but it is why nothing ever said so.

What that bought, measured this week across those eleven repositories:

| | |
| --- | --- |
| Workflow naming | eleven repositories, their own scheme — `ABAP_CLOUD.yaml`, `rename_test.yaml` |
| abaplint pins | three different ones, including a bare `@latest` |
| `npm run check` | not one repository had it |
| Scheduled runs | zero, in any workflow, anywhere |
| Dead README badges | 11, pointing at workflows that do not exist |
| Repositories that did not compile | 3 |

The last row is the one that matters. **`rap-ext` shipped for ten days against `z2ui5_cl_ai_xml`, a class that exists in no repository** — 55 abaplint errors behind a green badge, because its last CI run predated the break and, with no pull request open and no schedule, nothing re-ran it. `sql-console` named `z2ui5_cl_cc_spreadsheet` after custom-controls renamed it. `lock-manager` had never compiled at all: every lock call named `z2ui5_cl_util` where the members live in `z2ui5_cl_util_ext`, and with no CI in the repository, nothing had ever looked.

## What this changes

`REPOS` carries an **org per entry** rather than assuming `abap2UI5`, so the gate reads all twenty-one `package.json` files. The resolution order is unchanged — sibling checkout, then `raw.githubusercontent`, then say so and pass.

`CONVENTIONS.md` says the rules bind both organisations, and says why the sentence is there. The two stale counts ("all ten repositories") are corrected to twenty-one.

## ⚠️ Merge last

This gate reads the addons' `main` branches. Their pull requests add the `check` and `test` scripts it now requires, so **merging this before they land turns `check:scripts` red**:

| Merge order | |
| --- | --- |
| 1 | [layout-management#49](https://github.com/abap2UI5-addons/layout-management/pull/49) — the others resolve its helper from `main` |
| 2 | [selection-screen#5](https://github.com/abap2UI5-addons/selection-screen/pull/5) · [popups#19](https://github.com/abap2UI5-addons/popups/pull/19) |
| 3 | [se16n#13](https://github.com/abap2UI5-addons/se16n/pull/13) · [sql-console#24](https://github.com/abap2UI5-addons/sql-console/pull/24) · [table-content-loader#9](https://github.com/abap2UI5-addons/table-content-loader/pull/9) · [table-maintenance#11](https://github.com/abap2UI5-addons/table-maintenance/pull/11) |
| 4 | [lock-manager#6](https://github.com/abap2UI5-addons/lock-manager/pull/6) · [fork-abapToC#1](https://github.com/abap2UI5-addons/fork-abapToC/pull/1) · [rap-ext#7](https://github.com/abap2UI5-addons/rap-ext/pull/7) · [custom-controls#19](https://github.com/abap2UI5-addons/custom-controls/pull/19) |
| 5 | this one |

## How to test

```sh
node .github/scripts/scripts-gate.mjs
```

With the eleven addon checkouts beside this one it reports `21 of 21`. Without them it falls back to `raw.githubusercontent` and — until the pull requests above merge — names the addons as missing `check` and `test`, which is the gate working.

`node .github/scripts/shared-file-gate.mjs` is unaffected: 9 shared files, 20 of 20 copies match.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — no `app/webapp/` change here
- [ ] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — no new behaviour; the gate's own output is the check
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [x] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUhL1rra5QZbr4hV14YZXM)_