### PR TITLE
Let the test-server apps ask the lifecycle like every other app, and write the rule down

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -11,7 +11,7 @@ events, popups, navigation, portability rules, validation tooling). This
 skill is the trigger and the checklist; the guide is the content.
 
 **Before writing one from scratch, ask whether it exists.** `abap2UI5/samples`
-holds 150 working apps, each linted, rendered and downported to three
+holds 149 working apps, each linted, rendered and downported to three
 releases — a value help, a tree, navigation between two apps, a dynamic table
 typed at runtime. Reading one beats reproducing it, and beats any snippet: the
 sample is gated, a snippet is a copy somebody has to keep in step.
@@ -41,8 +41,8 @@ Quick orientation while it loads:
   covers the branch that exists but never displays.
 - **Ask the lifecycle with the call itself, never with `IS INITIAL`.** The
   three `check_on_*( )` methods return `abap_bool`, so the branch is
-  `IF client->check_on_init( ).` — a predicative call, the way all 610 sample
-  apps and the documentation on `z2ui5_if_client` write it. Compounds keep the
+  `IF client->check_on_init( ).` — a predicative call, the way the sample corpus
+  and the documentation on `z2ui5_if_client` write it. Compounds keep the
   shape (`IF client->check_on_init( ) OR client->check_on_navigated( ).`,
   `` ELSEIF client->check_on_event( `LOCK` ). ``). `IS NOT INITIAL` asks a
   boolean whether it is EMPTY, which is what that question means for a string,

--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -39,6 +39,17 @@ Quick orientation while it loads:
   anywhere. Apps built without it work perfectly until the day someone calls
   them from a navigation — the linter's `missing-view-display-on-navigated`
   covers the branch that exists but never displays.
+- **Ask the lifecycle with the call itself, never with `IS INITIAL`.** The
+  three `check_on_*( )` methods return `abap_bool`, so the branch is
+  `IF client->check_on_init( ).` — a predicative call, the way all 610 sample
+  apps and the documentation on `z2ui5_if_client` write it. Compounds keep the
+  shape (`IF client->check_on_init( ) OR client->check_on_navigated( ).`,
+  `` ELSEIF client->check_on_event( `LOCK` ). ``). `IS NOT INITIAL` asks a
+  boolean whether it is EMPTY, which is what that question means for a string,
+  and it is one more dialect an app author has to read. Only a NEGATIVE branch
+  is spelled out, as `= abap_false`: the corpus has no negated predicative
+  form. Every other `abap_bool` follows the same rule: `IF mv_flag = abap_false.`
+  and `DELETE lt_x WHERE flag = abap_false.`, never `IS INITIAL` on either.
 - PUBLIC attributes = serialized, browser-visible state. Bound data only;
   everything else PROTECTED.
 - Build views with `z2ui5_cl_ui5_view_builder`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,7 @@ This project follows the [SAP Clean ABAP styleguide](https://github.com/SAP/styl
 - No aliases, no STATICS, no BREAK-POINT, no DEFINE macros
 - `NEW #()` instead of `CREATE OBJECT`; `xsdbool()` for booleans (NEVER use `boolc()` — the downport pipeline converts `xsdbool` to `boolc` automatically); `line_exists()` instead of READ TABLE
 - Backtick string literals (`` ` ``) preferred over single quotes
+- An `abap_bool` is compared to `abap_true` / `abap_false` — never asked with `IS INITIAL` / `IS NOT INITIAL`, which is the question for a string. The app corpus goes one step further for the three `check_on_*( )` lifecycle methods and writes the predicative call itself (`IF client->check_on_init( ).`), a negative branch only as `= abap_false`; that rule and its reasons live in the `build-an-app` skill, and the apps under `node/srv` follow it like any other
 - `IS NOT` over `NOT ... IS`; `RETURNING` over `EXPORTING` for single outputs
 - No `EXPORT TO MEMORY`/`DATABASE`; no test seams; `lines()` instead of `DESCRIBE LINES`
 - No DB operations in loops; SQL uses `@` host variable escaping

--- a/llms.txt
+++ b/llms.txt
@@ -26,7 +26,7 @@ Two audiences, two entry points:
 - [View builder](src/02/z2ui5_cl_ui5_view_builder.clas.abap): generic 1:1 UI5 XML builder
 - [Hello world](src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap): smallest complete app
 - [Rendered documentation](https://abap2ui5.github.io/docs/): the human docs site
-- [samples](https://github.com/abap2UI5/samples): 150 curated example apps, one
+- [samples](https://github.com/abap2UI5/samples): 149 curated example apps, one
   class each. [SAMPLES.md](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md)
   lists every one of them with the words to search it by — ask it whether a
   sample already exists before writing an app from scratch

--- a/node/srv/zcl_tst_focus.clas.abap
+++ b/node/srv/zcl_tst_focus.clas.abap
@@ -25,18 +25,18 @@ CLASS zcl_tst_focus IMPLEMENTATION.
     " asynchronously - the browser silently ignores focus() on a disabled
     " element, so the frontend has to re-apply the focus after the re-render
     " (see evSetFocus in app/webapp/core/FrontendAction.js).
-    IF client->check_on_init( ) IS NOT INITIAL.
+    IF client->check_on_init( ).
       enabled = abap_true.
       value   = `86801398`.
       view_display( ).
 
-    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+    ELSEIF client->check_on_navigated( ).
       view_display( ).
 
-    ELSEIF client->check_on_event( `LOCK` ) IS NOT INITIAL.
+    ELSEIF client->check_on_event( `LOCK` ).
       enabled = abap_false.
 
-    ELSEIF client->check_on_event( `UNLOCK_AND_FOCUS` ) IS NOT INITIAL.
+    ELSEIF client->check_on_event( `UNLOCK_AND_FOCUS` ).
       enabled = abap_true.
       client->follow_up_action( val   = client->cs_event-set_focus
                                 t_arg = VALUE #( ( `inpDocNum` ) ( `0` ) ( `4` ) ) ).

--- a/node/srv/zcl_tst_nav_detail.clas.abap
+++ b/node/srv/zcl_tst_nav_detail.clas.abap
@@ -20,8 +20,8 @@ CLASS zcl_tst_nav_detail IMPLEMENTATION.
     " check_on_navigated also fires when browser Forward / reload restores
     " this app from its KEEP-route draft - the view must be rendered again
     " there (the app contract; see docs life_cycle.md)
-    IF client->check_on_init( ) IS NOT INITIAL
-        OR client->check_on_navigated( ) IS NOT INITIAL.
+    IF client->check_on_init( )
+        OR client->check_on_navigated( ).
       view = z2ui5_cl_ui5_view_builder=>factory( ).
       page = view->ele( n = `View` ns = `mvc`
           )->a( n = `xmlns`        v = `sap.m`

--- a/node/srv/zcl_tst_nav_hub.clas.abap
+++ b/node/srv/zcl_tst_nav_hub.clas.abap
@@ -19,13 +19,13 @@ CLASS zcl_tst_nav_hub IMPLEMENTATION.
 
     me->client = client.
 
-    IF client->check_on_init( ) IS NOT INITIAL.
+    IF client->check_on_init( ).
       view_display( ).
 
-    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+    ELSEIF client->check_on_navigated( ).
       view_display( ).
 
-    ELSEIF client->check_on_event( ) IS NOT INITIAL.
+    ELSEIF client->check_on_event( ).
       CASE client->get_event( ).
         WHEN `INC`.
           counter = counter + 1.

--- a/node/srv/zcl_tst_nav_hub_keep.clas.abap
+++ b/node/srv/zcl_tst_nav_hub_keep.clas.abap
@@ -19,13 +19,13 @@ CLASS zcl_tst_nav_hub_keep IMPLEMENTATION.
 
     me->client = client.
 
-    IF client->check_on_init( ) IS NOT INITIAL.
+    IF client->check_on_init( ).
       view_display( ).
 
-    ELSEIF client->check_on_navigated( ) IS NOT INITIAL.
+    ELSEIF client->check_on_navigated( ).
       view_display( ).
 
-    ELSEIF client->check_on_event( ) IS NOT INITIAL.
+    ELSEIF client->check_on_event( ).
       CASE client->get_event( ).
         WHEN `INC`.
           counter = counter + 1.


### PR DESCRIPTION
# Description

The five `zcl_tst_*` apps under `node/srv` asked the lifecycle with
`IS NOT INITIAL`:

```abap
IF client->check_on_init( ) IS NOT INITIAL.
ELSEIF client->check_on_event( `LOCK` ) IS NOT INITIAL.
```

The three `check_on_*( )` methods return `abap_bool`, so that asks a boolean
whether it is *empty*. The sample corpus and the documentation on
`z2ui5_if_client` use the predicative call instead. `node/srv` is not a private
corner — `check:abap2ui5` lints it precisely because it is part of the corpus an
app developer copies from — so the same question is now asked the same way.

The second half of this PR is the reason it drifted at all: **nothing said so.**
The idiom lived in the corpus and in no rule, which is how `IS NOT INITIAL` got
into these apps and into the playground's teaching snippets without anybody
noticing. It is written down now, in the place this repository already owns for
it (`samples-stack/AGENTS.md` §5: *"how to write an abap2UI5 app"* lives here,
*"a shared thing needs one owner"*).

## Changes

- `node/srv/zcl_tst_nav_hub.clas.abap`, `zcl_tst_nav_hub_keep.clas.abap`,
  `zcl_tst_nav_detail.clas.abap`, `zcl_tst_focus.clas.abap` — 11 conditions,
  including two parametrised ones (`check_on_event( `LOCK` )`).
- `.claude/skills/build-an-app/SKILL.md` — the rule, as a bullet beside the
  `check_on_navigated( )` one: the predicative call for the positive branch,
  `= abap_false` for the negative (there is no negated predicative form in the
  corpus), and the general case — an `abap_bool` is compared to
  `abap_true` / `abap_false`, never asked whether it is empty.
- `AGENTS.md` → Style Rules — the one-line version, pointing at the skill, and
  saying `node/srv` is not exempt.

**`src/99/01/z2ui5_cl_util_ext.clas.abap:1220` carries the same construct and is
deliberately left alone** — frozen package, `check:frozen` refuses an in-place
edit, and AGENTS.md says not to harden it.

## One fix that is not about booleans

`check:counts` went red on the first push, and not because of this diff:
`samples#796` took the catalogue from 150 to 149, and `llms.txt` and
`build-an-app/SKILL.md` both still said 150. The gate reads `SAMPLES.md` live,
so any PR opened after that merge would have hit it. Both numbers now say what
the catalogue says, and the gate is green — carried here rather than left for
the next PR to trip over, since one of the two files was already open in this
change.

## How to test

The predicative call is 7.50 syntax, and `node/srv` is the one tree that is
**copied verbatim** into `node/downport` by `auto_transpile` rather than
downported, so its floor is worth stating:

- `abap_transpile.json` sets no `syntax.version`, so the transpiler parses at
  abaplint's default, **v816**. (The files already carry `VALUE #( )`, so the
  floor was never 7.02.)
- `abaplint.jsonc` does not cover `node/srv`; `abap_standard`/`abap_cloud` are
  `src`-only, at v750 and Cloud — all above the 7.50 floor.
- Confirmed the floor rather than assuming it: `IF flag( ).` is a parser error
  at v702, clean at v750 and v816.

CI on the first push: `transpile`, `test_unit`, `test_node`, `test_unit_js`,
`abaplint` and all four `browser` matrix jobs (chromium, firefox, webkit,
ui5-1.71) green — the transpiled test apps answer exactly as before.

## Checklist

- [ ] `npm run verify` — **not run**: it needs `npm install` plus the pinned git
      dependencies, which this container does not have. Run individually here:
      `check:frozen`, `check:prose`, `check:naming`, `check:dynamic`,
      `check:scripts`, `check:counts` — all green; the rest is what CI reports.
- [x] Unit tests added/updated where it makes sense — none needed; no behaviour
      changes.
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/`
- [x] Public API in `src/02/` only changed additively — untouched
- [ ] Changes were made via abapGit: no

Companion PRs: `abap2UI5/playground#19` (the same idiom in every shipped
snippet) and `abap2UI5/samples#797` (two `abap_bool` fields, plus the rule in
its own Code Conventions).

*Correction to the first version of this description: it claimed "all 610 sample
apps". 610 counted `check_on_init( )` occurrences across four repositories, not
apps — 133 sample classes use it, out of a catalogue of 149. The same wrong
number was in the skill text and is fixed in the last commit.*