### PR TITLE
One first-app story, and app builders routed out of AGENTS.md early

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md — AI Assistant Guide for abap2UI5
 
+> **Building an app WITH abap2UI5? Stop reading here.** Everything an app
+> needs — template, lifecycle, view builder, client API — is the
+> self-contained guide **`docs/agents/building-apps.md`** (also wired as the
+> `build-an-app` Claude Code skill; `llms.txt` indexes both audiences). The
+> rest of this file is for changing the framework itself.
+
 > This file follows the cross-tool AGENTS.md convention and is the single
 > agent instruction file of this repository. `CLAUDE.md` exists next to it and
 > is a pointer at this file, nothing more — CONVENTIONS §6 asks for one in
@@ -50,7 +56,7 @@ abap2UI5 is a framework for building SAP UI5 applications purely in ABAP — no 
 | [custom-controls](https://github.com/abap2UI5-addons/custom-controls) | Community custom controls in their own BSP — the reserved resourceRoot `z2ui5_cci` in `app/webapp/manifest.json` is what makes it findable |
 | [customer-frontend-extension](https://github.com/abap2UI5/customer-frontend-extension) | Template for a customer's **own** frontend artefacts (reuse library, icon font, CSS) in their own BSP — same mechanism under the reserved resourceRoot `z2ui5_ccc`. Both roots exist so nobody has to patch `index.html` / `manifest.json`, which are generated here and overwritten downstream |
 
-> **Building apps?** This file is the briefing for AI assistants working **on the framework itself**. For everything an AI needs to **build apps with** abap2UI5 — app template, client API, view-building patterns, lifecycle — read the in-repo guide **`docs/agents/building-apps.md`** (also wired as the `build-an-app` Claude Code skill; `llms.txt` indexes both audiences). The rendered docs site is <https://abap2ui5.github.io/docs/> — unreachable from many sandboxes, which is why the guide lives in-repo.
+> **Building apps?** See the routing note at the very top of this file — the guide is `docs/agents/building-apps.md`. The rendered docs site is <https://abap2ui5.github.io/docs/> — unreachable from many sandboxes, which is why the guide lives in-repo.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ inside the templates and APIs those files describe. If something is not
 covered there, say so instead of inventing it.
 ```
 
+Claude Code users can register the [mcp-server](https://github.com/abap2UI5/mcp-server) — the validate/deploy/screenshot loop, no SAP system needed — with one line: `claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server`.
+
 The full setup — offline files, linter gates and the [mcp-server](https://github.com/abap2UI5/mcp-server) screenshot loop — is described in [Building with AI](https://abap2ui5.github.io/docs/get_started/ai.html).
 
 #### Get Involved

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ ENDCLASS.
 
 That's it – your first UI5 app is ready and abap2UI5 handles the rest! 🎉
 
+This snippet is deliberately the smallest possible app – one interface, one method, one message box. The next rung ships with the framework: [`z2ui5_cl_ui5_app_hi_world`](src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap), the hello-world sample that adds a real view, a bound input, and an event roundtrip. When you start an app of your own, begin from the [canonical app template](docs/agents/building-apps.md) in the agent guide – it adds the full lifecycle dispatcher and the structure every sample repository follows.
+
 #### How It Works
 
 Your entire app is **one ABAP class** implementing `z2ui5_if_app`. The framework calls its `main` method on every roundtrip, and the app dispatches on why it was called – put the view on screen, or handle what the user just did:

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,9 @@ Two audiences, two entry points:
   popups, navigation, validation tooling
 - [Client API contract](src/02/z2ui5_if_client.intf.abap): every method an app
   can call, with inline documentation
+- [Client API reference](https://abap2ui5.github.io/docs/resources/api.html):
+  the same contract as a generated, searchable page — also fetchable as
+  [client-api.json](https://abap2ui5.github.io/docs/api/client-api.json)
 - [App interface](src/02/z2ui5_if_app.intf.abap): the one interface an app implements
 - [View builder](src/02/z2ui5_cl_ui5_view_builder.clas.abap): generic 1:1 UI5 XML builder
 - [Hello world](src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap): smallest complete app


### PR DESCRIPTION
# Description

Three README/AGENTS-level improvements so both audiences (AI agents building apps, human beginners) find their path faster:

- **One first-app story** — the README Quick Start now states the ladder explicitly: the minimal snippet → the shipped `z2ui5_cl_ui5_app_hi_world` sample → the canonical template in the agent guide. Previously three near-identical "first apps" coexisted with no stated relationship. The snippet itself was verified against the current API (no drift found).
- **Audience routing at the top of AGENTS.md** — a five-line router now sits first thing after the title: building an app WITH abap2UI5 → stop here, go to `docs/agents/building-apps.md` + the `build-an-app` skill; the rest of the file is for changing the framework. The old mid-file blockquote shrank to a one-line pointer. No other restructuring.
- **AI section** — the copy-paste prompt's URLs were verified against real files, and the MCP server's one-line install (`claude mcp add abap2ui5 -- npx --yes @abap2ui5/mcp-server`) was added, confirmed verbatim against the mcp-server README.

`docs/agents/building-apps.md` was deliberately not touched, keeping the app-template shared-file mirror byte-equal.

This branch is part of an ecosystem-wide pass (matching PRs in docs, playground, samples, samples-controls, samples-stack, vscode-extension, mcp-server); it stands alone and has no cross-repo merge dependency.

## How to test

`npm run gates` — in particular `check:guide`, `check:shared` (23/23 copies compared), `check:conventions`, `check:counts` (6/6), `check:skills`, `check:prose`. Then read README.md top-to-bottom and AGENTS.md's first screen.

## Checklist

- [ ] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — not run as such; `npm run gates` (all 21 gates) and `npm run check` (abaplint, 0 issues / 258 files) were run green before each commit; no `app/webapp/` change
- [ ] Unit tests added/updated where it makes sense — not applicable, documentation-only change
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — unchanged
- [x] Changes were made via abapGit: no (no ABAP objects touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLKJKRzJ6gYAM6i9Bjyt45

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLKJKRzJ6gYAM6i9Bjyt45)_