### PR TITLE
The user-exit tests own the statics they measure, and abap-check names the bundle it cannot see

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -450,6 +450,32 @@ pitfalls".
 - **ABAP Doc is parsed as HTML.** A literal `<`, `>` or `&` must be escaped as
   `&lt;`, `&gt;`, `&amp;`.
 
+**Not gated: the BUNDLE.** `check:atc` walks this repository's `src/` — that is
+its stated scope, and over `src/` it holds: every `FIND`/`REPLACE … REGEX` here
+carries `##REGEX_POSIX`, including the five in the vendored AJSON where the
+pragma sits on the statement's CONTINUATION line (a line-based grep reports
+those as missing; the gate flattens statements first, so it does not).
+
+`abap2UI5-local` is a different artefact. `trigger_local.yaml` copies these
+sources into that repository, where a script folds them into ONE class whose
+"Local Implementations" hold everything. A user's system run on
+`z2ui5_cl_abap2ui5_local` (2026-08-23) reported eight SLIN warnings against
+that folded include — POSIX regex twice, ABAP Doc position, `<CLASS>` not
+supported / not closed three times, a redundant `CONV string( )` — at character
+OFFSETS (`@16232`, `@38704`), not at lines in any file here. All four kinds are
+the families above, and all four are silenced in `src/` by a pragma, a
+`##REGEX_POSIX`, or an escape. **They come back after the fold**, so what the
+fold does to those annotations is the thing to establish; the sources on this
+side are clean and no change here would move them. The `<CLASS>` pair is worth
+looking at first: `<p class="shorttext synchronized">` is the standard ADT
+shorttext form, and a tag scanner that splits on whitespace reads the attribute
+name as a second tag — which would make it an artefact of the fold rather than
+of the doc comment.
+
+Not verified from here: `abap2UI5-local` was not attached to the session that
+wrote this, so the bundler itself was not read. What IS measured is that
+`src/` carries the annotations and that `check:atc` is green over it.
+
 ## 4. Downport and transpile — one source, three targets plus a JS runtime
 
 **Gate: this repo** — `npm run verify` builds all three targets and runs the

--- a/.github/scripts/prose-name-gate.mjs
+++ b/.github/scripts/prose-name-gate.mjs
@@ -53,6 +53,10 @@ const EXTERNAL = new Map([
   ["Z2UI5_CL_SMPS_EVT_TCK", "the samples-stack ticket event handler - an abap-check case"],
   ["Z2UI5_CL_MY_CLASS", "placeholder in an AGENTS.md example"],
   ["Z2UI5_CL_MY_APP", "placeholder in an example"],
+  // the single class abap2UI5-local folds this repository's sources into -
+  // its "Local Implementations" are where SLIN reports findings that are
+  // annotated away on this side, which is the abap-check entry naming it
+  ["Z2UI5_CL_ABAP2UI5_LOCAL", "the bundled class abap2UI5/abap2UI5-local builds"],
 ]);
 
 // Whole families that live in the sample repositories. The removal plan counts

--- a/src/01/04/z2ui5_cl_ui5_user_exit.clas.testclasses.abap
+++ b/src/01/04/z2ui5_cl_ui5_user_exit.clas.testclasses.abap
@@ -34,6 +34,13 @@ CLASS ltcl_test_user_exit DEFINITION FINAL
   FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
 
   PRIVATE SECTION.
+    " whatever exit class the SYSTEM has installed, parked for the test's
+    " duration - see setup
+    DATA installed_exit TYPE REF TO z2ui5_if_ui5_exit.
+
+    METHODS setup.
+    METHODS teardown.
+
     METHODS test_defaults_http_get   FOR TESTING RAISING cx_static_check.
     METHODS test_defaults_http_post  FOR TESTING RAISING cx_static_check.
     METHODS test_expiry_clamped      FOR TESTING RAISING cx_static_check.
@@ -42,6 +49,33 @@ ENDCLASS.
 
 
 CLASS ltcl_test_user_exit IMPLEMENTATION.
+
+  METHOD setup.
+
+    " get_instance( ) binds gi_user_exit to the exit class it FINDS on the
+    " system, and the dispatch prefers it: IF gi_user_exit ... ELSEIF
+    " gi_user_exit_dep. Every test here asserts either the shipped defaults or
+    " the superseded-interface fallback, so an installed customer exit changes
+    " what they measure - test_superseded_intf failed on a system with one
+    " while passing in CI, because its double sat in the branch the installed
+    " exit had already won. The statics are owned here and put back in
+    " teardown; they are class-wide, so leaving them changed would leak into
+    " whatever runs next.
+    z2ui5_cl_ui5_user_exit=>get_instance( ).
+    installed_exit = z2ui5_cl_ui5_user_exit=>gi_user_exit.
+    CLEAR z2ui5_cl_ui5_user_exit=>gi_user_exit.
+    CLEAR z2ui5_cl_ui5_user_exit=>gi_user_exit_dep.
+
+  ENDMETHOD.
+
+
+  METHOD teardown.
+
+    z2ui5_cl_ui5_user_exit=>gi_user_exit = installed_exit.
+    CLEAR z2ui5_cl_ui5_user_exit=>gi_user_exit_dep.
+
+  ENDMETHOD.
+
 
   METHOD test_defaults_http_get.
 
@@ -110,8 +144,6 @@ CLASS ltcl_test_user_exit IMPLEMENTATION.
 
     li_exit->set_config_http_get( CHANGING cs_config = ls_config ).
     li_exit->set_config_http_post( CHANGING cs_config = ls_post ).
-
-    CLEAR z2ui5_cl_ui5_user_exit=>gi_user_exit_dep.
 
     " both seeded by the shipped exit first, then overwritten by the exit it
     " found - `sap_horizon` or 4 here would mean the old interface was skipped


### PR DESCRIPTION
# Description

Both halves come from the same system run a user reported: 1084 methods, 1083 passed, one failed — plus eight SLIN warnings on `z2ui5_cl_abap2ui5_local`.

## `test_superseded_intf` failed on a system and passed in CI

```
Critical Assertion Error: 'Test_Superseded_Intf: ASSERT_EQUALS'
  Expected [sap_belize] Actual [sap_horizon]
  LTCL_TEST_USER_EXIT->TEST_SUPERSEDED_INTF, line 118
```

The asymmetry is the test's own, not the framework's. The dispatch under test is

```abap
IF gi_user_exit IS BOUND.          " the current interface
ELSEIF gi_user_exit_dep IS BOUND.  " the superseded one
```

and `get_instance( )` binds `gi_user_exit` to whatever exit class it **finds on the system**. The test placed its double in `gi_user_exit_dep` but never cleared `gi_user_exit`, so on a system carrying a customer exit the `IF` branch wins, the double is never reached, and the theme stays at the `sap_horizon` the shipped exit seeds — which the test then reads as *"the old interface was skipped"*. In CI no such class exists, so the `ELSEIF` runs and it is green.

The other three tests have the same exposure: they assert the **shipped defaults**, and an installed exit that touches the theme or the expiry would move them too. It happens that the one on the reporting system does not.

So `setup` parks the installed exit and clears both statics, and `teardown` puts it back — they are class-wide, so leaving them changed would leak into whatever runs next.

**Nothing in the production dispatch changes.** Preferring the current interface is the documented behaviour, and the superseded one is still the fallback.

## `abap-check` gains the artefact it does not cover

The same run reported eight SLIN warnings against `z2ui5_cl_abap2ui5_local` — POSIX regex twice, ABAP Doc position, `<CLASS>` not supported / not closed three times, a redundant `CONV string( )`. All four kinds are already in the catalogue, three of them under **Gated**, which is the right question to ask: why did `check:atc` not catch them?

Because it never sees that code in that shape, and the entry now says so.

- Over `src/` the gate holds. Every `FIND`/`REPLACE … REGEX` here carries `##REGEX_POSIX`, including the five in the vendored AJSON where the pragma sits on the statement's **continuation** line. A line-based grep reports those five as unannotated and is wrong — the gate flattens statements first. Measured before writing it down, because *"the mirror is missing pragmas"* was the obvious wrong answer.
- `abap2UI5-local` is a different artefact. `trigger_local.yaml` copies these sources there, and a script folds them into **one** class whose Local Implementations hold everything. The warnings carry character **offsets** into that folded include (`@16232`, `@38704`), not lines in any file here. The annotations that silence these in `src/` therefore do not survive or do not apply after the fold, and that is where the fix belongs.
- The `<CLASS>` pair is the one worth opening first: `<p class="shorttext synchronized">` is the standard ADT shorttext form, and a tag scanner splitting on whitespace reads the attribute name as a second tag — which would make it an artefact of the fold rather than of the doc comment.

The entry also records what was **not** verified: `abap2UI5-local` was not attached to the session, so the bundler itself was not read.

## How to test

- `npx abaplint abaplint.jsonc` — 0 issues over 258 files.
- `npm run check:atc` — 102 files, OK.
- `npm run check:skills` — every rule id the skills name exists.
- On a system with a customer exit installed: all four `ltcl_test_user_exit` methods pass, where `test_superseded_intf` failed before.

**`npm run unit` has not been run for this branch.** It reads `node/output`, and that directory was being rewritten by a corpus build throughout — running `auto_transpile` alongside it would have collided. The change is confined to a test class's setup/teardown and a skill document; it is still a gap in the evidence and is called out rather than glossed over.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — `app/webapp/` untouched; see the note on `npm run unit` above
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — this change *is* the test fix
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [ ] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRPQ84UVzuc2HqRLPt1T1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRPQ84UVzuc2HqRLPt1T1V)_