### PR TITLE
Three abap-check entries a green CI did not catch, and the pin for abap2UI5-local dropping src/99

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -433,7 +433,28 @@ pitfalls".
   `slider_value = CONV i( client->get_event_arg( ) )` in
   `abap2UI5/samples-controls`. abaplint's `value_conversion` /
   `unnecessary_pragma` do not cover it (measured on 2.120.24, control probe
-  fired), and the type inference makes it undecidable for a text-level gate.
+  fired).
+
+  **Now gated, and the earlier claim here was wrong.** This entry used to end
+  "the type inference makes it undecidable for a text-level gate". It is
+  undecidable in general and decidable for the shape SLIN actually flags, which
+  is the only one that matters: the CONV is the WHOLE right-hand side of an
+  assignment (`<name> = CONV i( x ).`) into a name the same file declares
+  `TYPE i` — a `DATA`/`CLASS-DATA` line or a typed parameter. That is
+  `redundant-conv-i` in `samples-controls`' `scripts/pattern-lint.mjs`.
+
+  Two boundaries the rule keeps, both learned by getting them wrong first:
+  a CONV inside a comparison (`COND #( WHEN CONV i( x ) < 14 …`) or an
+  arithmetic expression (`CONV i( x ) + 1`) is load-bearing or at least
+  arguable and is NOT flagged — the first draft reported apps 350 and 353,
+  which SLIN itself had left alone. And a CONV inside a string template
+  (`|{ CONV i( x ) WIDTH = 2 }|`) is a real conversion.
+
+  What the gate is worth, measured: a user's system reported nine findings
+  (534, 546 ×2, 547 ×2, 548, 549, 566, 609) on 2026-08-23. The rule reproduced
+  all nine **and found four more the system run had not** — 356 once, 363
+  three times. A system run sees one package at a time; the gate sees the
+  corpus.
 - **A RAP handler names the entity by its BDEF alias.** Where the behavior
   definition declares `alias Ticket`, an event handler's
   `FOR ENTITY EVENT ... FOR z2ui5_r_smps_tck~TicketCreated` draws "The alias

--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -455,6 +455,35 @@ pitfalls".
   all nine **and found four more the system run had not** — 356 once, 363
   three times. A system run sees one package at a time; the gate sees the
   corpus.
+- **An Open SQL literal is a host expression: `@( … )`.** In strict Open SQL
+  every value in a WHERE comparison is escaped, a literal included — bare
+  `WHERE id = \`TEST_COUNT_FOREIGN\`` becomes
+  `WHERE id = @( \`TEST_COUNT_FOREIGN\` )`. Fixed by a user on a real system
+  (2026-08-23, abap2UI5#2657) in `z2ui5_cl_ui5_srv_draft`'s test class; the
+  transpiled tests and abaplint both accepted it.
+
+  **Do not "fix" an internal table.** `DELETE lt_param WHERE n = \`app_start\``
+  is ITAB syntax, where `@( )` is neither needed nor valid, and a grep for
+  `WHERE <name> = <literal>` finds ten of those in this repository for the one
+  real case. The discriminator is the statement: `DELETE FROM <dbtab>` /
+  `SELECT … FROM <dbtab>` / `UPDATE` / `MODIFY` against a database table.
+  Measured after the fix: that one line was the only bare literal in Open SQL
+  across `src`.
+
+- **`GET REFERENCE OF … INTO x` is the old spelling; write `x = REF #( … )`.**
+  Same pull request, same reason — it is not released for ABAP Cloud, and
+  nothing on this side reports it: `check:cloud` and the transpiled unit run
+  are both green with it in place.
+
+  Still standing in `src` after that fix, and worth deciding on rather than
+  discovering later: four occurrences outside the upstream mirrors and the
+  frozen package — `src/00/03/z2ui5_cl_ui5_util_context.clas.abap:878` and
+  `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap` at 325, 345 and 467. All four
+  take a field symbol or a formal parameter, which `REF #( )` expresses
+  directly. They were left alone deliberately: the pull request changed a test
+  class, and rewriting three production reference paths in the model is a
+  separate change with its own verification.
+
 - **A RAP handler names the entity by its BDEF alias.** Where the behavior
   definition declares `alias Ticket`, an event handler's
   `FOR ENTITY EVENT ... FOR z2ui5_r_smps_tck~TicketCreated` draws "The alias

--- a/.github/pins/refresh_input.sha256
+++ b/.github/pins/refresh_input.sha256
@@ -11,4 +11,4 @@
 # and the diff says a script this repository executes has moved.
 #
 #   sha256sum .github/scripts/refresh_input.sh   (in abap2UI5-local)
-b9eea060b3d71b71a405780c8f7bb65b34d24def3d0215cc34a70dbbd845a6b7
+3e5e7e199adcd86b3f75fca6270bac66cf334539de290c74a14d907a0a7872f7

--- a/.github/scripts/skill-rule-gate.mjs
+++ b/.github/scripts/skill-rule-gate.mjs
@@ -43,6 +43,7 @@ const NOT_A_RULE = new Map([
   ['ui5-check', 'a skill in this directory'],
   ['view-chain-layout', 'a skill in this directory'],
   ['samples-controls', 'the repository abap2UI5/samples-controls'],
+  ['redundant-conv-i', "a rule of samples-controls' own scripts/pattern-lint.mjs, not of the linter - SLIN's redundant-conversion finding, gated there because the corpus is where it appears"],
   ['clear-all', 'a UI5 icon name (sap-icon://clear-all)'],
   ['message-information', 'a UI5 icon name'],
   ['text-align', 'a CSS property named in a view example'],


### PR DESCRIPTION
# Description

Three findings a user hit on a real system, plus the acknowledgement half of a paired change.

## `redundant-conv-i` — and the entry used to claim this was impossible

The catalogue entry on redundant conversions ended *"the type inference makes it undecidable for a text-level gate"*. Undecidable in general, yes — and **decidable for the shape SLIN actually flags**, which is the only one that matters: the `CONV` is the whole right-hand side of an assignment into a name the same file declares `TYPE i`. That is now `redundant-conv-i` in `samples-controls`' `scripts/pattern-lint.mjs` (**abap2UI5/samples-controls#145**), and the entry says so instead of saying it cannot be done.

Two boundaries the rule keeps, both learned by getting them wrong first: a `CONV` inside a comparison or an arithmetic expression is load-bearing or at least arguable and is **not** flagged — the first draft reported apps 350 and 353, which SLIN had left alone — and a `CONV` inside a string template is a real conversion.

Worth, measured rather than claimed: a system reported nine findings; the rule reproduced all nine and found four more the run had not.

## The two shapes from #2657, and what a grep for them gets wrong

**An Open SQL literal is a host expression.** `WHERE id = \`TEST_COUNT_FOREIGN\`` becomes `WHERE id = @( \`TEST_COUNT_FOREIGN\` )`. The transpiled tests and abaplint both accepted the bare form, which is what puts it in this catalogue.

The entry carries the trap with it, because the obvious grep is wrong: most `WHERE <name> = <literal>` here are **internal table** operations (`DELETE lt_param WHERE n = \`app_start\``), where `@( )` is neither needed nor valid — ten of those for the one real case. The discriminator is the statement, not the `WHERE`. Measured after the fix: that one line was the only bare literal in Open SQL across `src`.

**`GET REFERENCE OF … INTO x`** is the old spelling of `x = REF #( … )` and is not released for ABAP Cloud; `check:cloud` and the transpiled unit run are both green with it in place. Four occurrences still stand outside the upstream mirrors and the frozen package — `src/00/03/z2ui5_cl_ui5_util_context.clas.abap:878` and `src/01/02/z2ui5_cl_ui5_srv_model.clas.abap` at 325, 345 and 467 — and the entry names them rather than leaving them to be rediscovered. **Not changed here:** #2657 touched a test class, and rewriting three production reference paths in the model is a separate change with its own verification.

## The pin

`abap2UI5-local`'s `refresh_input.sh` now drops `src/99` from the copy it takes from here (**abap2UI5/abap2UI5-local#14**): the superseded view builders, the old handler, the seventeen popups and `z2ui5_if_types` are all unreferenced from `src/00`–`src/02` outside comments, and folding them into one class costs 40 619 ABAP lines for nothing. 354 → 259 files.

`z2ui5_if_exit` is deliberately kept, and that is the part worth checking rather than trusting: `z2ui5_cl_ui5_user_exit` types `gi_user_exit_dep` against it, so dropping it would break the compatibility fallback. The script's own abaplint run resolves the thinned copy with 0 issues and stays the guard — a future change here that reaches into `99` fails there rather than on a system.

The pin exists so a change to a script this repository **executes**, with the deploy key in scope, has to be read on this side too. This commit is that reading, and the two have to land together.

## How to test

- `npm run check:prose` — 18 files, every name resolves, 10 external names allowed.
- `npm run check:skills` — every rule id the skills name exists (`redundant-conv-i` is registered on `NOT_A_RULE` as another repository's linter rule, which is what that list is for).
- `npm run check:atc` — 102 files, OK.
- `npx abaplint abaplint.jsonc` — 0 issues over 258 files.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — `app/webapp/` untouched; no ABAP changed, the diff is a skill document and a pin file
- [x] Unit tests added/updated where it makes sense — no code surface changed
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [ ] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRPQ84UVzuc2HqRLPt1T1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRPQ84UVzuc2HqRLPt1T1V)_