### PR TITLE
Never close a user's issue, and keep the reply to what the reporter needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,6 +652,24 @@ test: add unit tests for utility class
   renaming, restructuring) must not ride along in a PR titled for an
   unrelated fix — split it into its own PR so the history stays searchable.
 
+### Issues reported by users
+
+- **Never close an issue somebody else reported, and never let a merge close
+  it.** The reporter is the only one who can confirm the fix, because the
+  defect is on *their* system and ours is what shipped it. Merging a PR is
+  not the end of the report — activating the fix on the affected system is,
+  and only they can do that. So do not use a closing keyword (`Fixes #NNNN`,
+  `Closes #NNNN`, `Resolves #NNNN`) in a PR title, body or commit message:
+  GitHub acts on it at merge time and closes the issue without anybody
+  deciding to. Write `Report: #NNNN` or `See #NNNN` instead, which links the
+  two without the side effect. #2664 was closed exactly this way.
+- **A reply on an issue is written for the reporter, not as a record of the
+  analysis.** A few lines: what was actually wrong, what they do now, and
+  whether their own reading of it was right. The evidence, the ruled-out
+  alternatives and the reasoning belong in the PR body and in the code
+  comment at the fix — a reader who wants them follows the link. A long
+  answer buries the one sentence the reporter needs.
+
 ## Important Rules for AI Assistants
 
 These rules apply to AI assistants **modifying the framework** (this repo). For AI assistants **building apps**, read `docs/agents/building-apps.md` instead (rendered docs site: <https://abap2ui5.github.io/docs/>).


### PR DESCRIPTION
# Description

Two conventions in `AGENTS.md`, next to "Pull request titles". Both were violated on #2664 within one change.

**An issue somebody else reported is closed by the reporter, not by us.** The defect is on their system and ours is what shipped it, so merging a PR is not the end of the report — activating the fix there is, and only they can do that. The mechanism that got it wrong is worth naming explicitly, because it needs no intent: a closing keyword in the PR body (`Fixes #NNNN`) is acted on by GitHub at merge time, so the issue closes without anybody deciding to. `Report: #NNNN` links the two without the side effect.

**A reply on an issue is written for the reporter, not as a record of the analysis.** A few lines: what was wrong, what they do now, whether their own reading was right. The evidence and the ruled-out alternatives belong in the PR body and in the code comment at the fix, where a reader who wants them follows the link; in the reply they bury the one sentence that is actually needed.

Placed as a subsection rather than in the numbered rule list, whose numbers the enforcement blockquote below it refers to.

Context: #2664 (deliberately not a closing keyword — that is the point).

## How to test

Documentation only. `npm run gates` — 22 checked, all OK.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — `gates` (22) green; no code touched, so the ABAP/transpile legs are unaffected
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — n/a, prose
- [x] No manual edits under `src/00/01/`, `src/00/02/`, `src/01/03/` or `build/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — untouched
- [ ] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoRfTySbCzNTr7CdQXSTu8)_