### PR TITLE
Unfreeze the linter pin here too, and add the workflow that keeps it moving

### DIFF
--- a/.github/workflows/bump-linter.yaml
+++ b/.github/workflows/bump-linter.yaml
@@ -1,0 +1,98 @@
+# The linter comes from npm as `@abap2ui5/linter`, and package-lock.json is
+# what actually decides which version the gates run: the shared setup action
+# does `npm ci`, which reads the lock. Nothing here moved it. The lock sat at
+# 0.2.2 through 0.3.0 and 0.4.x while the three sample repositories moved on,
+# and `^0.2.2` means `>=0.2.2 <0.3.0` - so 0.3.0 could not arrive even through
+# a fresh install. The gate stayed green the whole time and said less every
+# release without saying so.
+#
+# This repository is a linter CONSUMER like the sample corpora, for a reason
+# spelled out in abap2ui5lint.jsonc: the app classes under src/01/04, src/02
+# and node/srv are what an app developer copies from, so the corpus this
+# repository ships to be imitated is checked with the tool it ships for
+# imitators. A stale pin there means the shipped examples are held to an older
+# standard than the samples that follow them.
+#
+# It tracks `latest` rather than staying inside the declared range, because the
+# range is the thing being maintained here: a linter release that adds rules is
+# additive for the linter and breaking for a corpus, so a range that pins the
+# corpus out of new rules is the failure, not the protection.
+#
+# BOTH gates run before the PR exists, which is what makes tracking `latest`
+# safe - a rule regression fails this workflow instead of landing on main:
+#
+#   check:abap2ui5   the properties half, the one check_gates.yaml runs
+#   check:render     the render half, which needs @abap2ui5/render-runtime
+#
+# The runtime is installed --no-save at the linter's exact version, the way
+# render-gate.yaml does it: the two packages are cut from one tag, and it is
+# deliberately NOT a dependency here (~123 MB of UI5 that every other job
+# would pay for through the shared `npm ci`). --no-save leaves package.json
+# AND package-lock.json untouched - verified, because this workflow commits
+# the lock and a runtime entry leaking into it would be committed with it.
+name: bump-linter
+
+on:
+  schedule:
+    - cron: '11 6 * * 1'   # Mondays 06:11 UTC - before the three sample corpora
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-linter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: '22'
+
+    - name: Move @abap2ui5/linter to the latest published version
+      id: pin
+      run: |
+        set -euo pipefail
+        # Resolved first and checked, because `npm view` prints nothing and
+        # still exits 0 when a package has no `latest` dist-tag - installing
+        # `@abap2ui5/linter@` would then resolve to whatever npm felt like.
+        VERSION=$(npm view @abap2ui5/linter version)
+        test -n "$VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        # Writes the range in package.json AND the exact version in the lock.
+        # Both matter: the range is what a fresh install reads, the lock is
+        # what `npm ci` reads, and the gates below run on the lock.
+        npm install --save-dev "@abap2ui5/linter@$VERSION"
+        # package.json alone is not the signal: a release inside the declared
+        # range moves only package-lock.json, and that is exactly the bump this
+        # repository needs to see.
+        if git diff --quiet package.json package-lock.json; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - if: steps.pin.outputs.changed == 'true'
+      run: npm run check:abap2ui5
+
+    # the render half, exactly as render-gate.yaml installs it
+    - if: steps.pin.outputs.changed == 'true'
+      run: npm i --no-save --no-audit --no-fund "@abap2ui5/render-runtime@${{ steps.pin.outputs.version }}"
+    - if: steps.pin.outputs.changed == 'true'
+      run: npx playwright install --with-deps chromium
+    - if: steps.pin.outputs.changed == 'true'
+      run: npm run check:render
+
+    - if: steps.pin.outputs.changed == 'true'
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      with:
+        branch: bump-linter
+        title: 'chore: bump @abap2ui5/linter'
+        commit-message: 'chore: bump @abap2ui5/linter to ${{ steps.pin.outputs.version }}'
+        body: |
+          Weekly move of `@abap2ui5/linter` to the latest version on npm
+          (${{ steps.pin.outputs.version }}). Both gates that consume it ran
+          over the shipped app classes in the workflow that opened this PR -
+          `check:abap2ui5` and `check:render`.

--- a/.github/workflows/render-gate.yaml
+++ b/.github/workflows/render-gate.yaml
@@ -23,6 +23,12 @@ on:
       - 'src/**'
       - 'abap2ui5lint.jsonc'
       - '.github/workflows/render-gate.yaml'
+      # The lock decides WHICH linter renders: the install step below reads the
+      # version out of it, so a bump changes what this gate does more than a
+      # config edit ever could - and it was the one input that did not start
+      # the gate. bump-linter.yaml runs check:render itself, so an automated
+      # bump was covered; a lock moved by hand was not.
+      - 'package-lock.json'
   push:
     branches: [main]
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.143.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.2.2",
+        "@abap2ui5/linter": "^0.4.1",
         "@abaplint/cli": "^2.120.32",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@abap2ui5/linter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.2.2.tgz",
-      "integrity": "sha512-WegxIRN5M5gH13Ye5Mo13fbpjAZ183J0ei1iArCfEiKUPAGqHot20NnckpNnXHX+YPHCkehA+Z0QapXjaLK1Tw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.4.1.tgz",
+      "integrity": "sha512-lhPjNhRv0/rVNgeI37lJ1ceVh81KuUe2Bcfpz2N/WtHcfVcRDJDMzSzE7dS2/r+uvg+J32Ovez/L0dfuijsbmQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -40,7 +40,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@abap2ui5/render-runtime": "^0.1.0 || ^0.2.0"
+        "@abap2ui5/render-runtime": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0"
       },
       "peerDependenciesMeta": {
         "@abap2ui5/render-runtime": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.2.2",
+    "@abap2ui5/linter": "^0.4.1",
     "@abaplint/cli": "^2.120.32",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",


### PR DESCRIPTION
The fourth and last linter consumer. `samples`, `samples-controls` and
`samples-stack` were unfrozen earlier this week; this repository was the one
left.

## The pin was frozen, and the range made it permanent

`npm ci` reads `package-lock.json`, and the lock sat at `@abap2ui5/linter`
**0.2.2** through 0.3.0 and both 0.4.x releases. Not a missed week: `^0.2.2`
means `>=0.2.2 <0.3.0`, so 0.3.0 could not arrive even through a fresh
`npm install`, and nothing here was ever going to move it.

This repository is a linter **consumer**, for the reason `abap2ui5lint.jsonc`
already states: the app classes under `src/01/04`, `src/02` and `node/srv` are
what an app developer copies from, so the corpus this repository ships *to be
imitated* is checked with the tool it ships *for* imitators. A stale pin means
the shipped examples are held to an older standard than the samples that follow
them — the inversion that file exists to prevent.

## What this does

- moves the lock **and** the range to 0.4.1;
- adds `bump-linter.yaml`, which runs **both** gates that consume the linter
  before the PR exists — `check:abap2ui5` and `check:render` — so a rule
  regression fails the bump instead of landing on main.

The render runtime is installed `--no-save` at the linter's exact version, the
way `render-gate.yaml` does it. It is deliberately not a dependency here
(~123 MB of UI5 every other job would pay for through the shared `npm ci`), and
I verified `--no-save` leaves both `package.json` and `package-lock.json`
untouched — which matters, because unlike `render-gate.yaml` this workflow
commits the lock.

Scheduled 06:11 Mondays, ahead of samples-controls (06:23), samples (06:41) and
samples-stack (06:47), so the framework moves first.

## Verified

| gate | result |
|---|---|
| `check:abap2ui5` | 24 files, 6 building a view, 45 controls judged — **0 findings** |
| `check:render` | 5 documents rendered, 19 built in helper methods and skipped — **0 findings** |
| `npm run gates` | 22 gates, all OK |

No config change needed: none of the rules added since 0.2.2 fires here, and
the `frozen-view-builder` exclusion for `src/99/` still applies unchanged.

The lock diff is exactly one line of substance:
`node_modules/@abap2ui5/linter: 0.2.2 → 0.4.1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8iuqE8QFQXpb1LzHQ3Ym5)_