### PR TITLE
The NavContainer item asks only for the half the shipped rule cannot see

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,7 +458,7 @@ fail on.)
 
 ```bash
 npm run check        # Fast inner loop: abaplint only (seconds) — run this while iterating
-npm run gates        # The 17 sub-second static gates in one process (~4s). Reports
+npm run gates        # The 24 sub-second static gates in one process (~4s). Reports
                      # EVERY failure, not just the first, and names the npm script
                      # that reruns each one - the local half of what
                      # check_gates.yaml's per-step `!cancelled()` does in CI

--- a/backlog/ABAP2UI5-LINTER.md
+++ b/backlog/ABAP2UI5-LINTER.md
@@ -21,7 +21,7 @@ _nothing exists upstream yet — this is the stock_
 
 | Item | What | Priority | In stock since | Upstream |
 |---|---|---|---|---|
-| [`navcontainer-position-not-reissued`](items/navcontainer-position-not-reissued.md) | a NavContainer / FlexibleColumnLayout / ToolPage position is live control state a rebuilt view resets, while the bound `selectedKey`-family field that describes it is class state that survives; the discriminator is mechanical and a rule can carry it | medium | 2026-08-26 | abap2UI5/linter |
+| [`navcontainer-position-not-reissued`](items/navcontainer-position-not-reissued.md) | `control-state-lost-on-rebuild` judges only `set…( )` wires, so the containers whose position is moved by a NAVIGATION call (`to`, `backToPage`, `toDetail`, `toMaster`) are structurally outside it - and there the discriminator is not "the value is non-literal" but "a surviving bound field names a page id of that container" | medium | 2026-08-26 | abap2UI5/linter |
 
 ---
 

--- a/backlog/items/navcontainer-position-not-reissued.md
+++ b/backlog/items/navcontainer-position-not-reissued.md
@@ -1,33 +1,58 @@
 ---
 target: abap2ui5-linter
-title: 'A bound field names a page, but the position is never re-issued after view_display - so the app contradicts itself'
-summary: a NavContainer / FlexibleColumnLayout / ToolPage position is live control state a rebuilt view resets, while the bound `selectedKey`-family field that describes it is class state that survives; the discriminator is mechanical and a rule can carry it
+title: 'The rebuild-survival check cannot see the `to( )` family - a NavContainer/FCL position `view_display( )` resets while a bound field still names the page'
+summary: `control-state-lost-on-rebuild` judges only `set…( )` wires, so the containers whose position is moved by a NAVIGATION call (`to`, `backToPage`, `toDetail`, `toMaster`) are structurally outside it - and there the discriminator is not "the value is non-literal" but "a surviving bound field names a page id of that container"
 priority: medium
 state: open
 first_seen: 2026-08-26
 upstream: abap2UI5/linter
 evidence:
-  - samples-controls app 585 - measured through the framework's own app-state restore: `selected_key` (two-way bound to SideNavigation.selectedKey) survived as `root2` while the NavContainer returned to its `initialPage="page2"`, so the side nav highlighted one item and the content pane showed another
-  - apps 302, 303, 167 are structurally identical (bound `selectedkey` + a NavContainer returning to its initialPage); app 301 is the sharpest, because TWO fields contradict the reset - `selectedkey` AND `page_text`, which the item-select handler writes onto the target page
-  - app 558 needs no navigation trick at all - pressing "+" on the tab bar creates the tab, sets selected_tab/save_visible/cancel_visible, and drops the user on the product list, because four of its handlers call view_display( ) from on_event
-  - the same sweep cleared 8 ports as legitimate (096, 097, 242, 263, 407, 012, 101, 565), so the class is discriminating rather than blanket - in each of those nothing survives that names a page
-  - this is the same defect shape as the confirmed 607, 249 and 534 fixes, all of which put the remedy at the tail of view_display( ) guarded by the surviving state
+  - samples-controls app 585 - measured through the framework's own app-state restore - `selected_key` (two-way bound to SideNavigation.selectedKey) survived as `root2` while the NavContainer returned to its `initialPage="page2"`, so the side nav highlighted one item and the content pane showed another
+  - the remedy is now written by hand in SEVEN ports - 167, 301, 302, 303, 558, 578, 585 - each ending `view_display( )` on a `control_by_id` `to( )` guarded by the field that survived. 578 is the `sap.f.FlexibleColumnLayout` one, 558 the one that needed no navigation trick at all (four of its handlers call `view_display( )` from `on_event`). Every one of them is a worked example rather than a live defect today, and nothing stops an eighth from being written without it
+  - "the value is non-literal" does NOT discriminate here, and two ports prove it - app 242 wires `to` with `client->get_event_arg( )` and keeps a two-way bound `animation`; app 096 wires `toDetail` with `client->get_event_arg( )` and keeps a two-way bound `mode`. Both are correct: the surviving field names a TRANSITION and a SplitAppMode, not a page
+  - apps 096/097 (`to`/`toMaster` at literal `detailDetail`/`master2`), 263 and 565 (`to` at literal `page1`/`page2`/`detail`) keep nothing that names a page either, so the class stays discriminating rather than blanket
+  - `control-state-lost-on-rebuild` (linter v0.5.0, still v0.5.1) already covers the `set…( )` half this item used to ask for as well - `setActivePage`, `setSelectedSection`, `setNextStep`, `setCurrentStep` - so what is left is only the navigation family
+  - the remedy this item used to call unwritable now exists for every container in the family: abap2UI5#2669 gave `to` a `pageId` argument kind (`app/webapp/core/actions/ControlCall.js`) and abap2UI5#2670 gave `backToPage` the same, both measured (apps 578 and 101)
+  - this is the same defect shape as the confirmed 607, 249 and 534 fixes, all of which put the remedy at the tail of `view_display( )` guarded by the surviving state
 ---
 
-# A bound field names a page the rebuilt view no longer shows
+# A bound field names a page the rebuilt view no longer shows - the half `control-state-lost-on-rebuild` cannot reach
+
+## What already ships, and what this asks for
+
+`control-state-lost-on-rebuild` (v0.5.0) decides exactly this question for
+`set…( )` wires: a `CONTROL_BY_ID` setter carrying a non-literal value, for a
+member no binding can carry, issued only off the display path. Its docs lead
+with the association cases - `setNextStep`, `setSelectedSection`,
+**`setActivePage`**, `setCurrentStep` - and `setActivePage` is one of the
+methods an earlier version of this item named in its own discriminator. That
+part is **done**; nothing below re-asks for it.
+
+What is left is the other way a container's position moves: a **navigation
+call**. `to`, `backToPage`, `toDetail`, `toMaster` (and `back`, `backDetail`,
+`backMaster`, `navigateBack`) are the whole vocabulary of `sap.m.NavContainer`,
+`sap.m.SplitApp`/`SplitContainer`, `sap.f.FlexibleColumnLayout` and
+`sap.tnt.ToolPage`, and none of them is a setter. The shipped collector matches
+
+    /^set([A-Z]\w*)$/
+
+on the wire's method name, so no navigation call can ever enter it. That is the
+subject of this item.
 
 ## Motivation
 
 abap2UI5 rebuilds the whole view on `view_display( )`. A NavContainer's current
-page, an FCL column position and a Carousel's active page are **live control
-state**: `XMLView.create` puts them back to what the XML declares. A two-way
-bound field is not - it is class state and it survives.
+page and an FCL column position are **live control state**: `view_display( )`
+hands new XML to the `VIEW_SLOTS` action, whose `displayMain` destroys the MAIN
+slot, and `XMLView.create` builds a fresh tree carrying what the XML declares -
+`initialPage`, and nothing else. A two-way bound field is not: it is class state
+and it survives.
 
 When a port stores the position in such a field, the two disagree after every
-rebuild, and the app tells the user something that is not on screen. That is
-exactly the shape of the `binding_call` filter loss (app 607), the badge bounds
-loss (app 249) and the wizard branch loss (app 534) - all three confirmed and
-all three fixed the same way.
+rebuild, and the app tells the user something that is not on screen. That is the
+shape of the `binding_call` filter loss (app 607), the badge bounds loss (app
+249) and the wizard branch loss (app 534) - all three confirmed, all three fixed
+by re-issuing from the display path.
 
 `check_on_navigated( )` reaches `view_display( )` on a draft restore and on
 return from a called app, neither of which has an upstream counterpart: a UI5
@@ -35,21 +60,38 @@ sample re-instantiated from scratch also lands on its first page, but it has no
 bookmark that restores model state and not view state. So "the original does it
 too" is not a defence here.
 
+The seven ports that carry the remedy carry it as prose plus a guarded
+`follow_up_action( )` at the tail of `view_display( )`. Nothing checks that an
+eighth writes it, and nothing would notice if one of the seven lost it in a
+refactor.
+
 ## What a rule would need to decide it
 
-The discriminator found by the corpus sweep is mechanical, which is why this is
-worth a rule rather than a checklist:
+> a `CONTROL_BY_ID` wire whose method is a **navigation** call
+> (`to`, `backToPage`, `toDetail`, `toMaster`) on a container whose position is
+> not bindable, issued from a method that is **not** on the display path,
+> **and** the class has a two-way bound field whose value can name one of that
+> container's page ids, **and** no method on the display path re-issues a
+> navigation call on the same container.
 
-> a control whose position is not bindable (`NavContainer`, `sap.f.FlexibleColumnLayout`,
-> `sap.tnt.ToolPage`, `sap.m.Carousel`) is moved by a `control_by_id`
-> (`to`, `toDetail`, `toMaster`, `setActivePage`, …) issued from an event
-> handler, **and** the class has a two-way bound field whose value names one of
-> that control's page ids, **and** `view_display( )` does not re-issue the
-> position.
+Three notes on writing it against what the linter already has:
 
-The third clause is what separates a defect from a legitimate fresh start, and
-it is the same test the `expandToLevel` ports (601, 602, 248, 365) and the
-shortcut re-registration (232) already pass.
+- **The method list exists.** `frontend-actions.mjs` already exports
+  `CONTROL_METHOD_ID_ARG` - `to`, `backToPage`, `toDetail`, `toMaster`, … -
+  derived from `CONTROL_METHODS` in the framework's `ControlCall.js`, because
+  those first arguments are control ids. The same list is the candidate set
+  here.
+- **The re-issue test has to key on the CONTAINER, not on id+setter.** The
+  shipped rule silences a wire when the same `id|setter` pair is issued from
+  the display path. For navigation that is right by container: app 585's
+  handler navigates to `key`, its `view_display( )` re-issues `to` with
+  `selected_key` - same container, same method, different argument, and that is
+  the correct remedy, not a second finding.
+- **The bindability test does not transfer.** The shipped rule asks whether a
+  property named after the setter is bindable. There is no `to` property and no
+  container exposes its current page as one, so that arm answers trivially and
+  carries no information. The discriminating clause is the third one - a
+  surviving field that names a page.
 
 ## What the rule must NOT do
 
@@ -57,10 +99,32 @@ shortcut re-registration (232) already pass.
   SplitApp *mode*, 242 keeps only the *transition*, 263 keeps only a checkbox -
   a fresh first page is faithful there, and 263's whole subject is that a
   re-entry resets.
+- **It must not reuse "the value is non-literal" as the discriminator.** This is
+  the trap the `set…( )` rule does not have. For a setter, a non-literal value
+  means class state the rebuild will contradict. For a navigation call it means
+  nothing of the sort: apps 096 and 242 both navigate to
+  `client->get_event_arg( )` - non-literal, read at the moment of the press,
+  carried in no field - and both are correct. Conversely a *literal* target can
+  still be a defect if a bound field names that same page. The literal/field
+  distinction is on the wrong argument; the question is what the CLASS keeps.
 - **It must not fire on a transient popup.** A `follow_up_action` on a popup
   control queued in the same round trip as `popup_display` is safe: the display
   actions are awaited before the custom actions, so the control exists by then.
-- **It must not demand a re-issue that cannot be written.** `sap.f.FlexibleColumnLayout.to`
-  is currently a silent no-op through the whitelist (see
-  `fcl-control-id-cast-in-to`), so for FCL ports the remedy does not exist yet
-  and a finding would be unactionable until that is fixed.
+  (The shipped rule already models this; the same exemption applies.)
+- **It must not fire on a stack-relative call.** `back`, `backDetail`,
+  `backMaster` and `navigateBack` move relative to a `_pageStack` the rebuild
+  empties; re-issuing one from `view_display( )` is meaningless. They belong in
+  the family for documentation, not in the candidate set.
+
+## For whoever widens the `^set…( )` matcher
+
+The exclusion this item is about is **structural, not decided**. Nothing in
+`abap-rules.mjs` or `rule-docs.mjs` says "the navigation family is out of
+scope"; it falls out of `/^set([A-Z]\w*)$/` being the collector's entry
+condition. Widening that regex to admit `to`/`backToPage`/`toDetail`/`toMaster`
+would look like a one-line generalisation and would be wrong on both remaining
+tests - it would fire on apps 096 and 242 (non-literal target, surviving bound
+field, correct code) and its `id|setter` re-issue key would report app 585's own
+remedy. The navigation half needs the third clause above, which is a different
+rule, not a wider matcher. Worth a comment at the collector either way, so the
+line is visible before somebody crosses it.


### PR DESCRIPTION
Two small changes from auditing what #2669 and #2670 left behind.

## `navcontainer-position-not-reissued` had come to partly re-specify a rule that shipped

The item asks the linter for a rule reporting a container position that a rebuilt view resets while the bound field describing it survives. Three things had gone wrong with it:

**A dead cross-reference.** It pointed at `` `fcl-control-id-cast-in-to` `` as the reason the FCL remedy "does not exist yet". That item has never existed — `git log --all -S` across all three repos hits exactly one commit, `56ff2a10`, which is the one that *wrote this reference*.

**The claim is false.** `sap.f.FlexibleColumnLayout.to` was fixed by #2669's `pageId` kind, `backToPage` by #2670. The remedy is writable for every container in the family now.

**It overlapped the shipped rule.** `control-state-lost-on-rebuild` (linter v0.5.0) already decides the `set…( )` half — **including `setActivePage`**, which the item named in its own proposed discriminator.

The item now asks only for the navigation family: `to`, `backToPage`, `toDetail`, `toMaster`. It stays `state: open` — the contract reserves deletion for *implemented*, and this remainder is real.

### Why the remainder is a separate rule, not a widened matcher

This is the part worth reading, because the obvious move is wrong. `^set([A-Z]\w*)$` is the entry blocker, but the shipped rule's **other two tests also give wrong answers** on the navigation family — verified against the corpus:

- **The non-literal-value test does not discriminate.** samples-controls 096 navigates `toDetail( get_event_arg( ) )` while keeping a two-way bound `mode`; 242 navigates `to( get_event_arg( ) )` while keeping a bound `animation`. Non-literal, surviving bound field, and both **correct** — those fields name a SplitAppMode and a transition, not a page. A naive widening fires on both.
- **The re-issue key `id|setter` reports the remedy as the defect.** App 585's handler navigates to `key` and its `view_display( )` re-issues `to` with `selected_key` — same container, different argument, so the keys miss.

So the discriminator that family needs is a surviving bound field naming a *page id of that container*, and the bindability arm does not transfer at all — there is no `to` property to bind instead. The wiring is cheap: the linter already carries the family as data in `CONTROL_METHOD_ID_ARG`, re-derived from this repo's own `CONTROL_METHODS`.

The `^set…` fact is also now recorded at the collector itself in the linter (`abap2UI5/linter@5835b4d`), because the person who would cross that line works there, and the item disappears when it ships.

### A second claim the same audit falsified

The item's evidence read as seven live defects. All seven ports (167, 301, 302, 303, 558, 578, 585) now carry the remedy by hand at the tail of `view_display( )`. And the app-558 line — *"drops the user on the product list"* — was **measured wrong**: samples-controls#154 found that dead event was the frontend's `eB` busy guard, and now asserts `navCon` stays on `tabContainerPage`. That line is gone; the rule's value is stated honestly as regression prevention plus the eighth port nobody will check.

## `AGENTS.md` said 17 static gates

`run-gates.mjs` has been **24** since #2670 added `check:mirrors` and `check:conventions`. The `22` that survives in `run-gates.mjs:78` is correct and was left alone — it is past-tense narration of the bug that motivated the drift check (*"`npm run verify` reported 'gates: 22 checked'"*), and 22 + 2 = 24 exactly. The stale number was the one a contributor reads before typing the command.

## Verification

`npm run gates` → **24 checked, all OK**. `npm run backlog` / `check:backlog` clean (12 items, pages current); only `backlog/ABAP2UI5-LINTER.md` moved, which is right — the item's target is the linter page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8iuqE8QFQXpb1LzHQ3Ym5)_