### PR TITLE
Say "you skipped the transpile" instead of MODULE_NOT_FOUND, and put playground on the list

### DIFF
--- a/.github/scripts/scripts-gate.mjs
+++ b/.github/scripts/scripts-gate.mjs
@@ -52,6 +52,12 @@ const REPOS = [
   'linter',
   'docs',
   'web-abap2UI5',
+  /* Added 2026-08-28. It was missing, and the omission is what the rule is
+   * about: `playground` is a source repository with an AGENTS.md, a test
+   * suite, its own `check.yml` and a contributor - and it had no `check`
+   * script at all, which is precisely the state this gate exists to refuse.
+   * Nothing found that, because nothing was looking. */
+  'playground',
 
   /* The addons, which sit in a second organisation and were outside every
    * ecosystem gate until 2026-08-20 - which is how eleven repositories came to

--- a/.github/shared/CONVENTIONS.md
+++ b/.github/shared/CONVENTIONS.md
@@ -79,9 +79,12 @@ Rules that follow from the role:
 
 - **Every repository has `check` and `test`.** They are the two names an
   outside developer types without reading anything first, and "Missing script"
-  is a bad first answer. `check` exists in all twenty-one repositories as of
-  2026-08-20; it reached the ten `abap2UI5` ones on 2026-08-18, and the eleven
-  `abap2UI5-addons` ones when they were brought into these rules.
+  is a bad first answer. `check` exists in all twenty-two repositories as of
+  2026-08-28; it reached the ten `abap2UI5` ones on 2026-08-18, and the eleven
+  `abap2UI5-addons` ones when they were brought into these rules. `playground`
+  was the twenty-second, added on 2026-08-28: it had never been on the gate's
+  list, and it had no `check` at all — the rule holds only over the repositories
+  somebody remembered to enumerate.
 - `check` runs what CI runs on a pull request. A step that exists only in
   `package.json` is a step no pull request has to pass; a step that exists only
   in a workflow is one no contributor can run before pushing.
@@ -92,12 +95,14 @@ Rules that follow from the role:
   the failure this rule exists to prevent. Today: `vscode-extension` omits
   `test:web` (downloads VS Code web + chromium), `samples-controls` omits
   `gates:full` and the two downport lint configs, `web-abap2UI5` omits the
-  Playwright e2e run.
+  Playwright e2e run, `playground` and `linter` omit the Chromium download their
+  own tests then ask for by name, and `linter` also omits `codeql`, the
+  composite-action job and the publish-shaped `package` job.
 - `test` runs the repository's own tests. Where there is no separate test suite
   — the corpora are checked, not unit-tested — `test` is `npm run check`, so
   that the universal command still answers.
 - The first two rules are gated: `npm run check:scripts` in this repository
-  reads all twenty-one `package.json` files (sibling checkout, else raw main,
+  reads all twenty-two `package.json` files (sibling checkout, else raw main,
   else say so and pass) and fails naming any repository that has lost either
   script.
   Prose is not a thing that fails a pull request, which is why five of them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,12 +526,12 @@ in untouched code as a possible upstream move only in that fallback case.
 | `npm run check:app2abap` | Regenerate `src/01/03/` from `app/webapp/` and fail on drift (mirrors `check_app2abap.yaml`; regenerates in place; installs `app/node_modules` when missing; part of `verify`) |
 | `npm run downport` | Downport `src/` into `node/downport/` for 7.02 compatibility (non-destructive; the step `verify` runs) |
 | `npm run auto_transpile` | Transpile the downported ABAP to JS into `node/output/` |
-| `npm run unit` | Run the transpiled unit tests |
+| `npm run unit` | Run the transpiled unit tests. **Needs the transpiled tree** (`npm run downport && npm run auto_transpile`) — it is generated, not committed, and `node/setup/require-transpiled.mjs` says so instead of letting node answer `MODULE_NOT_FOUND` on a file nobody wrote by hand. `test.yaml` never hits that: its `transpile` job builds the tree once and every downstream job unpacks it |
 | `npx abaplint .github/abaplint/auto_abaplint_fix.jsonc --fix` | Auto-fix formatting |
 | `npm run frontend:cloud` / `frontend:cloud_v2` / `frontend:standard` / `frontend:standard_v2` | Build ONE of the four delivery trees into `tools/out/` instead of all four (`npm run frontend:build` is all four) |
 | `npm run frontend:verify` | Compare a local build in `tools/out/` against what is published in `abap2UI5/frontend` **today** — file for file, byte for byte, stamped the way the deploy stamps them. Not the same question as `check:frontend`, which asks whether the sources still produce a valid build |
 | `npm run frontend:lint` | abaplint over `frontend/abap/cloud/` — the ICF/BSP handler sources this repository ships into the delivery branches (gated in `frontend_check.yaml`) |
-| `npm test` | Alias of `npm run unit` — CONVENTIONS §3 asks every repository in the ecosystem to answer to it (`npm run check:scripts` is the gate) |
+| `npm test` | Alias of `npm run unit` — CONVENTIONS §3 asks every repository in the ecosystem to answer to it (`npm run check:scripts` is the gate). It carries the same transpiled-tree prerequisite, which is the whole reason the guard exists: §3 calls these the two names an outside developer types without reading anything first, so what they answer on a fresh clone is the repository's first impression |
 | `npm run express` | Start dev server on port 3000 |
 | `npm run app2abap` | **Canonical** full regeneration pipeline: Prettier (`app` format) → generate → abaplint normalize. Use this after editing `app/webapp/` so only truly-changed `src/01/03/` files differ |
 | `npm run auto_app2abap` | Generate ABAP string constants from `app/webapp/` (raw, **un-normalized** — prefer `npm run app2abap` instead) |

--- a/node/setup/require-transpiled.mjs
+++ b/node/setup/require-transpiled.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/*
+ * require-transpiled — the unit suite runs against TRANSPILED ABAP, and the
+ * transpiled tree is not in the repository.
+ *
+ * `npm test` is, by CONVENTIONS section 3, one of the two commands an outside
+ * developer types before reading anything. On a fresh clone it aliased
+ * `npm run unit`, which is `node node/output/index.mjs`, and node answered:
+ *
+ *   Error: Cannot find module '/…/abap2UI5/node/output/index.mjs'
+ *   code: 'MODULE_NOT_FOUND'
+ *
+ * That names the file nobody wrote by hand and not the two commands that write
+ * it, so the honest reading is "the repository is broken" rather than "you
+ * skipped a build step". `test.yaml` never hits it because the `transpile` job
+ * produces `node/output` and every downstream job unpacks it.
+ *
+ * A guard rather than making `unit` run the transpile itself: the transpile is
+ * minutes, `npm run unit` is seconds, and a developer iterating on the ABAP
+ * runs it many times per transpile. Doing it implicitly would make the fast
+ * command slow to save one error message.
+ *
+ *   node node/setup/require-transpiled.mjs      (first half of `npm run unit`)
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ENTRY = path.join(ROOT, 'node', 'output', 'index.mjs');
+
+if (!fs.existsSync(ENTRY)) {
+  console.error(
+    'node/output is not there — the unit suite runs against transpiled ABAP,\n'
+    + 'and the transpiled tree is generated, not committed. Build it first:\n'
+    + '\n'
+    + '    npm run downport         # copy src/, abaplint --fix the copy, strip whitespace\n'
+    + '    npm run auto_transpile   # ABAP -> mjs into node/output\n'
+    + '\n'
+    + 'Both together take a few minutes; after that `npm run unit` is seconds,\n'
+    + 'and only a change under src/ makes it stale (AGENTS.md, "Build & verify").',
+  );
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "auto_transpile": "rm -rf node/output && cp node/srv/*.abap node/srv/*.clas.xml node/downport && abap_transpile ./node/setup/abap_transpile.json",
     "rename": "abaplint .github/abaplint/rename.jsonc --rename",
     "express": "node node/srv/express.mjs",
-    "unit": "node node/output/index.mjs",
+    "unit": "node node/setup/require-transpiled.mjs && node node/output/index.mjs",
     "test": "npm run unit",
     "check:guide": "node .github/scripts/check-guide-api.mjs"
   },


### PR DESCRIPTION
## What this changes

Two halves of the same rule — CONVENTIONS section 3, the two commands an outside
developer types before reading anything.

1. `npm test` on a fresh clone explains itself instead of failing as
   `MODULE_NOT_FOUND`, and `AGENTS.md` states the prerequisite on the rows that
   need it.
2. `playground` joins the list `scripts-gate.mjs` enumerates. It was missing.

## Why

**The first.** `npm test` aliases `npm run unit`, which is
`node node/output/index.mjs` — and `node/output` is generated, not committed. So
a fresh clone got:

```
Error: Cannot find module '/…/abap2UI5/node/output/index.mjs'
code: 'MODULE_NOT_FOUND'
```

That names a file nobody wrote by hand and not the two commands that produce it,
so the honest reading is "this repository is broken" rather than "you skipped a
build step". `test.yaml` never hits it: its `transpile` job builds the tree once
and every downstream job unpacks it, which is exactly why it could stay this way.

`node/setup/require-transpiled.mjs` now says which two commands to run. It is a
**guard, not an implicit transpile**: the transpile is minutes and `npm run unit`
is seconds, and someone iterating on ABAP runs the fast one many times per slow
one. Building implicitly would make the fast command slow to save one error
message.

`AGENTS.md` documented the prerequisite only on the `coverage` row. It now says
it on `unit` and on `npm test` — the rows where somebody meets it first.

**The second.** `scripts-gate.mjs` enumerates the ecosystem by hand, and its
comment explains the omissions it makes on purpose: generated channel
repositories with no `package.json` and no contributor to type a command.
`playground` is not one of those. It is a source repository with an `AGENTS.md`,
a Playwright suite, its own `check.yml` and a contributor — and it had **no
`check` script at all**, which is precisely the state this gate exists to refuse.
Nothing found it because nothing was looking.

`CONVENTIONS.md` moves to twenty-two repositories, and its "what each repository
omits" list gains `playground` and `linter`.

## Ordering

**abap2UI5/playground#21 must merge first.** With no sibling checkout beside it —
which is the case in CI — `check:scripts` reads each repository's `package.json`
from raw `main`, so this gate stays red until that PR lands.

## Checks

- `npm run gates` — 28 checked, all OK (including `check:scripts`, `check:shared`
  and `check:commands`)
- `npm run check` — abaplint, 0 issues over 260 files
- `npm run unit` — green with the transpiled tree present, and the guard verified
  in both directions: with `node/output` moved aside it exits 1 with the message,
  with it restored the suite runs

---
_Generated by [Claude Code](https://claude.ai/code/session_0146Q9UP9JavNhdDd8bqdQik)_