### PR TITLE
Release 1.144.0 — prepared, do not merge until the release is actually cut

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,10 @@ Legend
 
 unreleased
 ----------
+
+
+2026-08-30 v1.144.0
+-------------------
 + client->_event( arg = ... ) is the one-value spelling of t_arg, and
   client->_bind_path( ... ) the named form of _bind( path = abap_true )
 + Frontend actions: expandSelected / collapseSelected on a tree table,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "abap2UI5",
   "private": true,
-  "version": "1.143.0",
+  "version": "1.144.0",
   "description": "Developing UI5 Apps Purely in ABAP.",
   "scripts": {
     "deps": "node node/setup/fetch-deps.mjs",

--- a/src/02/z2ui5_if_app.intf.abap
+++ b/src/02/z2ui5_if_app.intf.abap
@@ -1,7 +1,7 @@
 INTERFACE z2ui5_if_app PUBLIC.
   INTERFACES if_serializable_object.
 
-  CONSTANTS version TYPE string VALUE `1.143.0`.
+  CONSTANTS version TYPE string VALUE `1.144.0`.
   CONSTANTS origin  TYPE string VALUE `https://github.com/abap2UI5/abap2UI5`.
   CONSTANTS authors TYPE string VALUE `https://github.com/abap2UI5/abap2UI5/graphs/contributors`.
   CONSTANTS license TYPE string VALUE `MIT`.


### PR DESCRIPTION
# Description

The mechanical half of cutting **1.144.0**, prepared so the release itself is a tag push. It moves the `unreleased` changelog entries under a `2026-08-30 v1.144.0` heading and bumps both version numbers — `package.json` and the `version` constant in `src/02/z2ui5_if_app.intf.abap`, the one abapGit shows and `frontend_deploy` stamps into the delivered frontend.

**Draft on purpose — this must not merge until the release is being cut.** Per `RELEASING.md` the commit and the tag go together (`git commit -am "Release X.Y.Z"` then `git tag X.Y.Z && git push --follow-tags`). Merged without the tag, `main` claims 1.144.0 while no such release exists, and every entry added in the meantime lands under a heading that has already been published rather than under `unreleased`. If the release is weeks away, this PR waits weeks.

## Why it was prepared now

`main` carries an API no tag does. `_event( arg = )` and `_bind_path( )` merged in #2681, and `abap2UI5/samples-controls` adopted them in its own #167 — so until this tag exists that corpus resolves the framework at 1.143.0 and cannot compile: **613 abaplint errors**, all `Method importing parameter "ARG" does not exist` or `Method "_bind_path" not found`.

That is the gap `RELEASING.md` describes — paid by the other repositories rather than by this one — and it is open right now rather than hypothetically. It does not, however, make the release urgent on its own: see the note at the bottom.

## How to test

```sh
npm run check:release   # tag, both versions and the changelog agree
npm run verify          # what the release job runs, in full
```

Both are green on this tree. To rehearse the publish without publishing, dispatch `release.yaml` by hand from the Actions tab — same gates, same notes, no tag and no release.

## Checklist

- [x] `npm run verify` passes — reported `verify: everything green`
- [x] Unit tests added/updated where it makes sense — none needed; this changes version constants and prose only
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively — the only `src/02` edit is the `version` constant's value
- [x] `changelog.txt` — this PR *is* the changelog move; the section it creates is what the release job publishes as the notes
- [ ] Changes were made via abapGit: no (version constants and changelog, edited in the repository)

## One prerequisite that is easy to miss

`npm run verify` fails on `check:changelog` without a matching entry in **abap2UI5/docs** — the two files are hand-written on purpose, and the gate holds them to the same facts. That side is prepared in abap2UI5/docs#41, which also carries `check:version` (three places name the released version) and the three deprecation rows marked *next release* that 1.144.0 turns into `1.144.0`. **Merge that one first, or this PR's `check_gates` is red.**

Note that abap2UI5/docs' own `check:examples` compiles every documentation example against the release the site names, so it stays red there until this tag is pushed. That is the check working, not a defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk511jLY6GBzgHcBS3ZorJ)_