### PR TITLE
Restore the two cross-repository checks #2685 left broken on main

### DIFF
--- a/.github/scripts/check-guide-api.mjs
+++ b/.github/scripts/check-guide-api.mjs
@@ -74,6 +74,18 @@ const UNDOCUMENTED = new Map([
   ["view_destroy", "as nest_view_display - the slot form of popup_destroy( )"],
   ["popover_destroy", "as nest_view_display"],
   ["set_push_state", "browser-history detail of the routing block in section 7"],
+  // These four SHOULD be in the guide, and the text for them is written. It is
+  // not here yet because this file is mirrored into abap2UI5/app-template's
+  // AGENTS.md, which generates its copy with `npm run agents` - so editing it
+  // fails `npm run check:shared` until that regeneration lands, which is what
+  // it did on main between #2685 and this change. The guide edit and the
+  // app-template regeneration are one change, made when both repositories can
+  // be touched. Drop these four entries then; the check below asks for them
+  // again the moment somebody does.
+  ["_bind_path", "PENDING the app-template mirror sync - named form of _bind( path = abap_true )"],
+  ["get", "PENDING the app-template mirror sync - the request context, incl. t_model_skipped"],
+  ["set_app_state_active", "PENDING the app-template mirror sync - the bookmarkable app-state hash"],
+  ["set_session_stateful", "PENDING the app-template mirror sync - the sticky-session switch"],
   ["get_app", "reaches another app instance on the stack - get_app_prev( ) is the documented case"],
   ["check_app_prev_stack", "a stack predicate for get_app_prev( ), documented through it"],
 ]);

--- a/app/webapp/core/actions/ControlCall.js
+++ b/app/webapp/core/actions/ControlCall.js
@@ -145,19 +145,19 @@ sap.ui.define(
     // control method -> kinds of its positional args. Args beyond the
     // declared kinds are dropped; trailing args the caller did not send are
     // not passed at all (so `open()` stays a true no-arg call).
-    // Object.create(null), not a plain literal, and the same for the two
-    // whitelists below and for the handler map in FrontendAction.js.
-    // These tables are indexed with a name that comes off the wire, and a
-    // plain object answers for every key Object.prototype has: with a method
-    // named "constructor" the CONTROL_METHODS lookup below returned a truthy
-    // value, skipped isSafeControlMethod( ) entirely and then invoked
+    // This table and the two whitelists below are prototype-less - see the
+    // Object.setPrototypeOf right after each one. They are indexed with a name
+    // that comes off the wire, and a plain object answers for every key
+    // Object.prototype has: with a method named "constructor" the
+    // CONTROL_METHODS lookup below returned a truthy value, skipped
+    // isSafeControlMethod( ) entirely and then invoked
     // control["constructor"](...); BINDING_METHODS["toString"] silently ran
     // Object.prototype.toString instead of logging "method not allowed".
     // Not a security boundary by this module's own model - the backend is
     // trusted - but it defeated the deny-list and turned a malformed payload
     // into a silent wrong call rather than the log line that says what
-    // happened. A prototype-less table has no keys but its own.
-    const CONTROL_METHODS = Object.assign(Object.create(null), {
+    // happened.
+    const CONTROL_METHODS = {
       // `pageId`, NOT `controlId`: the three containers that own a `to( )`
       // disagree about what the first argument may be. sap.m.NavContainer
       // normalises a Control to its id on its own first line, but
@@ -231,7 +231,15 @@ sap.ui.define(
       removeStyleClass: ["string"], // sap.ui.core.Control: remove a CSS style class
       toggleStyleClass: ["string"], // sap.ui.core.Control: toggle a CSS style class
       setAsyncURLHandler: ["string"], // sap.m.MessagePopover: name of a URL_POLICY below
-    });
+    };
+    // Prototype-less, but written as a plain literal on purpose: the
+    // abap2UI5 linter mirrors this set and finds it by the exact source text
+    // `const CONTROL_METHODS = {` in the embedded carrier (its
+    // scripts/check-upstream.mjs). Wrapping the literal in a call made that
+    // lookup miss, and the mirror check degraded to "SKIPPED, not verified" -
+    // a cross-repository check that stops checking without failing. Same
+    // effect, marker intact.
+    Object.setPrototypeOf(CONTROL_METHODS, null);
 
     // sap.m.MessagePopover.setAsyncURLHandler expects a live JS callback that
     // resolves a promise per message link - a shape no backend payload can
@@ -361,7 +369,7 @@ sap.ui.define(
     }
 
     // global object -> lazy getter + its allowed methods (with arg kinds).
-    const GLOBAL_TARGETS = Object.assign(Object.create(null), {
+    const GLOBAL_TARGETS = {
       // The two message targets carry a `display` hook: the call is routed
       // through the local showToast/showBox instead of straight at the
       // global, so the option
@@ -505,7 +513,15 @@ sap.ui.define(
           addCustomCurrencies: ["object"], // MERGES: same shape, keeps the rest
         },
       },
-    });
+    };
+    // Prototype-less, but written as a plain literal on purpose: the
+    // abap2UI5 linter mirrors this set and finds it by the exact source text
+    // `const GLOBAL_TARGETS = {` in the embedded carrier (its
+    // scripts/check-upstream.mjs). Wrapping the literal in a call made that
+    // lookup miss, and the mirror check degraded to "SKIPPED, not verified" -
+    // a cross-repository check that stops checking without failing. Same
+    // effect, marker intact.
+    Object.setPrototypeOf(GLOBAL_TARGETS, null);
 
     // Cast one raw string argument to the kind the whitelist declared.
     // `view` (optional) is the slot the owning control was resolved in, so a
@@ -1081,7 +1097,7 @@ sap.ui.define(
       binding.filter([new Filter(outer, true)]); // AND across the groups
     }
 
-    const BINDING_METHODS = Object.assign(Object.create(null), {
+    const BINDING_METHODS = {
       filter(binding, params) {
         const [path, operator, value1, value2] = params;
         // A single param that starts with '[' is the compound groups JSON -
@@ -1118,7 +1134,15 @@ sap.ui.define(
           new Sorter(path, castArg("bool", descending), castArg("bool", group)),
         ]);
       },
-    });
+    };
+    // Prototype-less, but written as a plain literal on purpose: the
+    // abap2UI5 linter mirrors this set and finds it by the exact source text
+    // `const BINDING_METHODS = {` in the embedded carrier (its
+    // scripts/check-upstream.mjs). Wrapping the literal in a call made that
+    // lookup miss, and the mirror check degraded to "SKIPPED, not verified" -
+    // a cross-repository check that stops checking without failing. Same
+    // effect, marker intact.
+    Object.setPrototypeOf(BINDING_METHODS, null);
 
     // args: [_, id, aggregation, method, ...params]
     function evBindingCall(oController, args) {

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -439,9 +439,6 @@ The same tree, with the subtree held in a variable:
   (typed bindings, sorters) get the bare path via
   `client->_bind( val = t_items path = abap_true )`, e.g.
   `` v = |\{ path: '{ client->_bind( val = t_items path = abap_true ) }', sorter: \{ path: 'PRODUCT' \} \}| ``.
-  `client->_bind_path( t_items )` is the named spelling of exactly that call —
-  same result, and it reads as what it is where a binding-info string is being
-  assembled. Use whichever is clearer; there is no behavioural difference.
 - Typed/complex bindings pass through verbatim (braces escaped):
   `` v = |\{ path: 'PRICE', type: 'sap.ui.model.type.Float' \}| `` — note the
   `path:` uses the upper-cased ABAP field name.
@@ -486,12 +483,7 @@ The same tree, with the subtree held in a variable:
 - Wire: `)->a( n = `press` v = client->_event( `SAVE` ) )`.
 - Read in `on_event` via `CASE client->get_event( ).`.
 - **Pass values into an event** with `t_arg`; read them back with
-  `client->get_event_arg( )` (index only for position 2+). For the common case
-  of exactly one value, `arg` is the shorthand:
-  `client->_event( val = `ITEM_SELECT` arg = `${PRODUCT}` )` produces the same
-  wire as `t_arg = VALUE #( ( `${PRODUCT}` ) )` and is asserted byte-identical
-  to it in the framework's own tests. Pass one or the other, never both.
-  A value resolved
+  `client->get_event_arg( )` (index only for position 2+). A value resolved
   on the client must be `$`-prefixed — `` `${PRODUCT}` `` (row field),
   `` `$event.oSource.sId` `` (the pressed control's id),
   `` `${$parameters>/selected}` `` (an event parameter). A bare `{…}` arg is
@@ -558,34 +550,6 @@ The same tree, with the subtree held in a variable:
   Back/Forward buttons — the mode rides in `t_arg`: `cs_nav_mode-keep` (the
   default when `t_arg` is empty) restores the exact draft state,
   `cs_nav_mode-fresh` restarts clean. Works inside the Fiori Launchpad.
-- **Bookmarkable app state**: `client->set_app_state_active( abap_true )` puts
-  the current draft id into the URL hash, so a copied link reopens the app
-  where it was. The framework re-asserts it on every response of that app once
-  set, so `check_on_init` is the place to call it.
-- **Sticky session**: `client->set_session_stateful( abap_true )` keeps the
-  ABAP work process attached across roundtrips. Only for state that genuinely
-  cannot be serialized into the draft (an open cursor, a lock) — the default
-  stateless mode is what makes the framework scale, and a sticky app holds a
-  work process for as long as the user has it open.
-
-### What the request is telling you — `client->get( )`
-
-`client->get( )` returns the request context of the roundtrip being handled,
-which is where the answers to "what just happened" live rather than on
-individual methods:
-
-```abap
-DATA(ls_req) = client->get( ).
-" ls_req-event               the event name (get_event( ) is the shorthand)
-" ls_req-check_on_navigated  this roundtrip arrived by navigation
-" ls_req-s_device            what the browser said about itself
-" ls_req-t_model_skipped     model cells the delta refused to write back
-```
-
-`t_model_skipped` is the one worth knowing about: a value the client sent that
-could not be written into its ABAP field (a non-numeric string into an `i`,
-say) is reported there instead of silently vanishing, so an app that validates
-input can tell "the user typed nonsense" from "the user typed nothing".
 
 ## 8. Rules that keep apps portable
 

--- a/src/01/03/z2ui5_cl_ui5f_ctrlcall_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_ctrlcall_js.clas.abap
@@ -111,7 +111,7 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `      else showFn(sText);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    const CONTROL_METHODS = Object.assign(Object.create(null), {` && |\n| &&
+             `    const CONTROL_METHODS = {` && |\n| &&
              `      to: ["pageId", "string"],` && |\n| &&
              `      back: [],` && |\n| &&
              `` && |\n| &&
@@ -153,7 +153,9 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `      removeStyleClass: ["string"],` && |\n| &&
              `      toggleStyleClass: ["string"],` && |\n| &&
              `      setAsyncURLHandler: ["string"],` && |\n| &&
-             `    });` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
+             `    Object.setPrototypeOf(CONTROL_METHODS, null);` && |\n| &&
              `` && |\n| &&
              `    const URL_POLICIES = {` && |\n| &&
              `      ALLOW_ALL: () => true,` && |\n| &&
@@ -229,7 +231,7 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `      );` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    const GLOBAL_TARGETS = Object.assign(Object.create(null), {` && |\n| &&
+             `    const GLOBAL_TARGETS = {` && |\n| &&
              `      MESSAGE_TOAST: {` && |\n| &&
              `        get: () => MessageToast,` && |\n| &&
              `        methods: { show: ["string"] },` && |\n| &&
@@ -310,7 +312,9 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `          addCustomCurrencies: ["object"],` && |\n| &&
              `        },` && |\n| &&
              `      },` && |\n| &&
-             `    });` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
+             `    Object.setPrototypeOf(GLOBAL_TARGETS, null);` && |\n| &&
              `` && |\n| &&
              `    const AGG_ITEM = /^([^/]+)\/([A-Za-z_][\w]*)\/(\d+)$/;` && |\n| &&
              `` && |\n| &&
@@ -420,12 +424,12 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `    function registerIconFont(fontFamily, fontURI) {` && |\n| &&
              `      const IconPool = sap.ui.require("sap/ui/core/IconPool");` && |\n| &&
              `      if (!IconPool) {` && |\n| &&
-             `        Lib.logError("ICON_POOL: sap/ui/core/IconPool is not loaded");` && |\n| &&
+             `        Lib.logError("ICON_POOL: sap/ui/core/IconPool is not loaded");` && |\n|.
+    result = result &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
              `      if (!fontFamily || !fontURI) {` && |\n| &&
-             `        Lib.logError(` && |\n|.
-    result = result &&
+             `        Lib.logError(` && |\n| &&
              `          "ICON_POOL: registerFont needs a fontFamily AND a fontURI",` && |\n| &&
              `        );` && |\n| &&
              `        return;` && |\n| &&
@@ -697,7 +701,7 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `      binding.filter([new Filter(outer, true)]);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    const BINDING_METHODS = Object.assign(Object.create(null), {` && |\n| &&
+             `    const BINDING_METHODS = {` && |\n| &&
              `      filter(binding, params) {` && |\n| &&
              `        const [path, operator, value1, value2] = params;` && |\n| &&
              `` && |\n| &&
@@ -727,7 +731,9 @@ CLASS z2ui5_cl_ui5f_ctrlcall_js IMPLEMENTATION.
              `          new Sorter(path, castArg("bool", descending), castArg("bool", group)),` && |\n| &&
              `        ]);` && |\n| &&
              `      },` && |\n| &&
-             `    });` && |\n| &&
+             `    };` && |\n| &&
+             `` && |\n| &&
+             `    Object.setPrototypeOf(BINDING_METHODS, null);` && |\n| &&
              `` && |\n| &&
              `    function evBindingCall(oController, args) {` && |\n| &&
              `      const [, id, aggregation, method] = args;` && |\n| &&


### PR DESCRIPTION
# Description

[#2685](https://github.com/abap2UI5/abap2UI5/pull/2685) merged 35 seconds after it was opened and six seconds after `check_gates` went red, so two failures it introduced reached `main`. Both are reproduced against `origin/main` before this change and green after it.

**1. `check:shared` was red — and stays red for every pull request until fixed.**

`docs/agents/building-apps.md` is mirrored into `abap2UI5/app-template`'s `AGENTS.md`, which **generates** its copy with `npm run agents`. Nothing in this repository can make the two agree, so the guide edit goes back out:

```
docs/agents/building-apps.md differs in app-template/AGENTS.md (read from github)
  this repository is the source — copy it there, or change it here first
```

The text is not lost. The four methods it documented — `_bind_path( )`, `client->get( )` (incl. `t_model_skipped`), `set_app_state_active( )` and `set_session_stateful( )` — are recorded in `check-guide-api`'s `UNDOCUMENTED` map, each marked `PENDING` with what it is. The reverse-direction check added in #2685 asks for them again the moment those entries are dropped. **The guide edit and the app-template regeneration are one change, to be made when both repositories can be touched.**

**2. `check:mirrors` was worse, because it did not fail.** It printed:

```
check-upstream: could not find GLOBAL_TARGETS in the frontendaction class
  — the embedding changed, update parseGlobalTargets
linter-mirror: the sources could not be read — SKIPPED, not verified.
```

`@abap2ui5/linter` finds the three whitelists it hand-mirrors by the **exact source text** `const GLOBAL_TARGETS = {` / `const CONTROL_METHODS = {` / `const BINDING_METHODS = {` in the embedded carrier (its `scripts/check-upstream.mjs`). Wrapping each literal in `Object.assign(Object.create(null), …)` broke all three lookups at once, and the gate degraded to *not checking* rather than to failing — a cross-repository check that stops checking without saying so.

The tables stay prototype-less, which was the point of that change: they are plain literals again, with `Object.setPrototypeOf(x, null)` directly after each. Same effect on the lookup, marker intact. The mirror check verifies again and reports all mirrors in sync.

## How to test

```sh
git checkout main && npm run gates      # check:shared fails; check:mirrors prints "SKIPPED, not verified"
git checkout claude/repository-analysis-improvements-cnhod3
npm run gates                            # 30 checked - all OK
npm run check:mirrors                    # "the linter's copies still match this tree - OK"
npm run verify                           # everything green
```

`npm run verify` was run in full on this branch and reports `verify: everything green`.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — no behaviour change here; the 1&nbsp;001 JS specs and the transpiled suite are unchanged and green
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md) — `src/01/03/z2ui5_cl_ui5f_ctrlcall_js.clas.abap` is regenerated with `npm run app2abap`
- [x] Public API in `src/02/` only changed additively — untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour — no user-visible behaviour change; the frontend tables behave exactly as #2685 made them
- [x] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmqgFmjaEtpEqoG1kooFuG)_