### PR TITLE
List the five 2026-08-30 linter rules the pinned version does not have

### DIFF
--- a/.github/scripts/skill-rule-gate.mjs
+++ b/.github/scripts/skill-rule-gate.mjs
@@ -56,14 +56,33 @@ const NOT_A_RULE = new Map([
   ['unit-tests', 'the abapGit round-trip rule name in this skill\'s own table'],
 ]);
 
-/* Rules that exist in a released linter this repository has NOT pinned yet.
- * Same semantics as a baseline entry: once the pin catches up the rule is
- * known, and an entry left behind here FAILS rather than lingering. */
+/* Rules that exist upstream but not in the linter this repository has pinned -
+ * either released under a version not pinned yet, or merged on the linter's
+ * main and not published at all. Same semantics either way: once the pin
+ * catches up the rule is known, and an entry left behind here FAILS rather
+ * than lingering.
+ *
+ * The second case is why the wording above says "upstream" rather than
+ * "released". #2686 documented seven rules the linter shipped on 2026-08-30,
+ * but npm `latest` is 0.5.1 (published 2026-08-27) and package.json pins
+ * `^0.5.1` - so five of those names were true statements about the linter and
+ * still unknown here, and check:skills went red on main for every pull
+ * request until they were listed. */
 const PENDING = new Map([
   // Empty, and it stayed empty for about an hour. `frozen-view-builder` was
   // listed here while this repository pinned 0.1.1; the bump to 0.2.0 made the
   // rule known, this gate reported the entry as stale on the same commit, and
   // it came out. That is the mechanism working, not an accident of timing.
+  //
+  // The 2026-08-30 round (#2686). Each of these ships in the linter's main and
+  // in no published version, so `bump-linter.yaml` removes them here as soon as
+  // a release past 0.5.1 lands - this gate fails on the entry the moment the
+  // pinned linter knows the rule.
+  ['class-constructor-visibility', 'linter main, unreleased - was check:abapgit only before'],
+  ['value-header-default-reassigned', 'linter main, unreleased - was an open gate before'],
+  ['into-corresponding-inline-decl', 'linter main, unreleased - was an open gate before'],
+  ['validating-setter-out-of-range', 'linter main, unreleased - fires on target release 1.149+'],
+  ['absent-boolean-overrides-default', 'linter main, unreleased - companion of the setter rule'],
 ]);
 
 const TOKEN = /`([a-z][a-z0-9]*(?:-[a-z0-9]+)+)`/g;


### PR DESCRIPTION
# Description

**`main` is currently red, and every pull request opened against it fails.** `npm run gates` on `997e73d` reports `1 of 30 failed → check:skills`:

```
class-constructor-visibility · value-header-default-reassigned
into-corresponding-inline-decl · validating-setter-out-of-range
absent-boolean-overrides-default
    … is not a rule of the pinned abap2ui5lint
```

This is not a defect in any of those skills. [#2686](https://github.com/abap2UI5/abap2UI5/pull/2686) documents seven rules the linter shipped on **2026-08-30**, but npm `latest` for `@abap2ui5/linter` is **0.5.1, published 2026-08-27**, and `package.json` pins `^0.5.1`. Five of those names are therefore true statements about the linter and still unknown to the pinned copy.

(This fix was part of [#2687](https://github.com/abap2UI5/abap2UI5/pull/2687) but did not make it into the squash — `main` carries that PR's `ControlCall.js` change and not this one, so the gate is still failing.)

## The fix

`PENDING` in `skill-rule-gate.mjs` is the mechanism for exactly this, and it cleans itself up: the gate **fails** on an entry whose rule the pinned linter has, so `bump-linter.yaml` takes these five out on the first release past 0.5.1.

Its comment said “rules that exist in a **released** linter this repository has not pinned yet”. These are not released at all — they are merged on the linter's `main`. The wording now says “upstream” and each entry records which of the two cases it is, so widening the meaning is written down rather than assumed.

No skill text changes: the `Linter:` lines #2686 added are correct and stay as they are.

## How to test

```sh
git checkout main && npm run gates     # 1 of 30 failed → check:skills
git checkout claude/repository-analysis-improvements-cnhod3
npm run gates                           # 30 checked - all OK
npm run check:skills                    # "5 pending a pin bump" … "every rule id a skill names exists - OK"
```

`npm run verify` was run in full on this branch: `verify: everything green`.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed)
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) — n/a, one gate exemption list
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md) — none, `src/` untouched
- [x] Public API in `src/02/` only changed additively — untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour — no user-visible behaviour change
- [x] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmqgFmjaEtpEqoG1kooFuG)_