### PR TITLE
Pin the linter to the commit the skills were written against, and close what it then reports

### DIFF
--- a/.github/scripts/skill-rule-gate.mjs
+++ b/.github/scripts/skill-rule-gate.mjs
@@ -43,7 +43,6 @@ const NOT_A_RULE = new Map([
   ['ui5-check', 'a skill in this directory'],
   ['view-chain-layout', 'a skill in this directory'],
   ['samples-controls', 'the repository abap2UI5/samples-controls'],
-  ['redundant-conv-i', "a rule of samples-controls' own scripts/pattern-lint.mjs, not of the linter - SLIN's redundant-conversion finding, gated there because the corpus is where it appears"],
   ['clear-all', 'a UI5 icon name (sap-icon://clear-all)'],
   ['message-information', 'a UI5 icon name'],
   ['text-align', 'a CSS property named in a view example'],
@@ -60,10 +59,20 @@ const NOT_A_RULE = new Map([
  * Same semantics as a baseline entry: once the pin catches up the rule is
  * known, and an entry left behind here FAILS rather than lingering. */
 const PENDING = new Map([
-  // Empty, and it stayed empty for about an hour. `frozen-view-builder` was
-  // listed here while this repository pinned 0.1.1; the bump to 0.2.0 made the
-  // rule known, this gate reported the entry as stale on the same commit, and
-  // it came out. That is the mechanism working, not an accident of timing.
+  // Empty, and it has been twice now. `frozen-view-builder` was listed here
+  // while this repository pinned 0.1.1; the bump to 0.2.0 made the rule known,
+  // this gate reported the entry as stale on the same commit, and it came out.
+  // Five more were needed for about as long on 2026-08-30: #2686 recorded the
+  // staging entries abap2UI5/linter#80 had just closed, and the rules it names
+  // existed on that repository's main and in no published version. Moving the
+  // pin to that commit made them known and this gate asked for the entries
+  // back out on the spot — along with the NOT_A_RULE line for
+  // `redundant-conv-i`, which #80 had promoted out of samples-controls'
+  // pattern-lint into a real rule.
+  //
+  // That is the mechanism working, not an accident of timing: an entry here
+  // is an exemption the pin has not caught up with, and the loop below FAILS
+  // on it the moment it has.
 ]);
 
 const TOKEN = /`([a-z][a-z0-9]*(?:-[a-z0-9]+)+)`/g;

--- a/node/srv/zcl_tst_nav_detail.clas.abap
+++ b/node/srv/zcl_tst_nav_detail.clas.abap
@@ -19,9 +19,11 @@ CLASS zcl_tst_nav_detail IMPLEMENTATION.
 
     " check_on_navigated also fires when browser Forward / reload restores
     " this app from its KEEP-route draft - the view must be rendered again
-    " there (the app contract; see docs life_cycle.md)
-    IF client->check_on_init( )
-        OR client->check_on_navigated( ).
+    " there (the app contract; see docs life_cycle.md) - and it is the WIDER
+    " of the two: every entry point that hands an app its first request sets
+    " check_on_navigated, so check_on_init implies it and an OR of the two
+    " can never change the verdict (abap2ui5lint redundant-init-display)
+    IF client->check_on_navigated( ).
       view = z2ui5_cl_ui5_view_builder=>factory( ).
       page = view->ele( n = `View` ns = `mvc`
           )->a( n = `xmlns`        v = `sap.m`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "abap2UI5",
-  "version": "1.143.0",
+  "version": "1.144.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abap2UI5",
-      "version": "1.143.0",
+      "version": "1.144.0",
       "license": "MIT",
       "devDependencies": {
-        "@abap2ui5/linter": "^0.5.1",
+        "@abap2ui5/linter": "github:abap2UI5/linter#f16f4cc92ee69c1702b0672357fc7ea51b570fc8",
         "@abaplint/cli": "^2.120.32",
         "@abaplint/database-sqlite": "^2.13.40",
         "@abaplint/runtime": "^2.13.40",
@@ -30,8 +30,8 @@
     },
     "node_modules/@abap2ui5/linter": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@abap2ui5/linter/-/linter-0.5.1.tgz",
-      "integrity": "sha512-uMLwqyKUhScW3bkm4jd3vLLXb6gONgb2fMzSI2ZLwX2uQpVC6eR3M0eRIQTe5krFpxl/locK0H2OFZ4afj+VIQ==",
+      "resolved": "git+ssh://git@github.com/abap2UI5/linter.git#f16f4cc92ee69c1702b0672357fc7ea51b570fc8",
+      "integrity": "sha512-JttPsuldUlV+64cmcsEMN/12B7To02rJlm4fysql/Ic/lsHJfDSy9h1hFH7E0QQ48aDumQ4W86GRJQv3Jv8uug==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -44,7 +44,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@abap2ui5/render-runtime": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0"
+        "@abap2ui5/render-runtime": ">=0.1.0 <0.6.0"
       },
       "peerDependenciesMeta": {
         "@abap2ui5/render-runtime": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "homepage": "https://abap2UI5.org",
   "devDependencies": {
-    "@abap2ui5/linter": "^0.5.1",
+    "@abap2ui5/linter": "github:abap2UI5/linter#f16f4cc92ee69c1702b0672357fc7ea51b570fc8",
     "@abaplint/cli": "^2.120.32",
     "@abaplint/database-sqlite": "^2.13.40",
     "@abaplint/runtime": "^2.13.40",


### PR DESCRIPTION
# Description

`npm run gates` failed on an untouched tree — `main` was red for every pull request, not just for this one.

#2686 recorded the staging entries [abap2UI5/linter#80](https://github.com/abap2UI5/linter/pull/80) had just closed, and six of the rules those skill lines name exist on the linter's `main` and in **no published version**: npm latest is 0.5.1, cut before #78/#79/#80. So `check:skills` reported every one of them as a rule the pinned linter does not have.

The pin moves to that commit rather than the gate being widened. It is a git ref because there is nothing to pin on npm yet; `abap2UI5/vscode-extension` already resolves the linter this way, with the same `git+ssh` lockfile entry its CI resolves today. It goes back to a `^x.y.z` range with the first release past 0.5.1.

[abap2UI5/samples-controls#174](https://github.com/abap2UI5/samples-controls/pull/174) has the same cause and the same fix, but it is **not** sufficient there and is not being merged with this one: that repository's `chain_format` workflow reads the version out of `package-lock.json` and runs `npx @abap2ui5/linter@$VER`, which resolves from npm and so bypasses any git pin. That one needs the release.

With the pin caught up here, the gate asks for its own exemptions back — which is the mechanism working, not an accident of timing:

- the five `PENDING` entries are reported stale and are gone
- the `NOT_A_RULE` line for `redundant-conv-i` is no longer true (#80 promoted it out of samples-controls' `pattern-lint` into a real rule) and is gone

And the 111-rule linter finds one thing in this repository's own sources. `zcl_tst_nav_detail` guards on `check_on_init( ) OR check_on_navigated( )`. Every entry point that hands an app its first request sets `check_on_navigated` — `factory_system_startup`, both `app_start` forms, `nav_app_call` — and `check_on_init` is `mv_check_initialized = abap_false`. So init implies navigated and the OR can never change the verdict. `check_on_navigated( )` alone is the condition, and it is also the **wider** of the two, which is exactly what the fixture's own comment asks for (re-render when browser Forward / reload restores the app from its KEEP-route draft).

## How to test

```sh
npm ci
npm run gates          # 30/30
npm run check:skills   # 0 pending, 0 stale
npm run check:abap2ui5 # clean; reports redundant-init-display before the fixture change
npm run verify         # everything green
```

To see the failure this fixes, check out `main` and run `npm run gates`.

## Checklist

- [x] `npm run verify` passes — `verify: everything green`. `app/webapp/` is untouched, so `verify:full` does not apply
- [x] Unit tests added/updated where it makes sense — `npm run unit` (transpiled) is green; no new behaviour to test, the gate script's own assertions are what changed
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively — `src/` is not touched at all
- [x] `changelog.txt` — no entry: nothing here changes shipped behaviour. `node/srv/` is the transpiled test backend, not delivered source, and the pin and the gate script are build-time only
- [x] Changes were made via abapGit: no