### PR TITLE
Add Launchpad and BTP integration to README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * **Cloud & On-Premise Ready** – Runs in ABAP Cloud and Standard ABAP environments
 * **Broad Compatibility** – Supports all ABAP releases from NW 7.02 to ABAP Cloud
 * **Easy Installation** – Install via abapGit – no extra app deployment needed
+* **Seamless Integration** – Runs in SAP Fiori Launchpads and on SAP BTP, right next to your RAP and Fiori Elements apps
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * **Cloud & On-Premise Ready** – Runs in ABAP Cloud and Standard ABAP environments
 * **Broad Compatibility** – Supports all ABAP releases from NW 7.02 to ABAP Cloud
 * **Easy Installation** – Install via abapGit – no extra app deployment needed
-* **Seamless Integration** – Runs in SAP Fiori Launchpads and on SAP BTP, right next to your RAP and Fiori Elements apps
+* **Seamless Integration** – Runs in Launchpads and on BTP alongside your RAP and Fiori Elements apps
 
 ## Quick Start
 


### PR DESCRIPTION
# Description

Updates the README to highlight seamless integration with SAP Launchpads and Business Technology Platform (BTP), positioning the solution alongside RAP and Fiori Elements applications. This addition emphasizes deployment flexibility and modern SAP ecosystem compatibility.

## How to test

N/A — Documentation-only change. Verify the new bullet point appears correctly in the rendered README.

## Checklist

- [x] No code changes (documentation only)
- [x] No `npm run verify` needed for README updates
- [x] No unit tests needed
- [x] No changes to generated or protected directories
- [x] No public API changes
- [x] No behavioral changes requiring changelog entry

https://claude.ai/code/session_01TSwNrgRUPcPdyoFEgW7fVN