### PR TITLE
A navigation hop into a mode-less app turns routing off explicitly

### DIFF
--- a/src/01/02/z2ui5_cl_ui5_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.abap
@@ -780,6 +780,23 @@ CLASS z2ui5_cl_ui5_handler IMPLEMENTATION.
            OR mo_action->mo_app->mv_nav_mode <> mo_action->mo_app->ms_session-nav_mode_sent ).
       mo_action->ms_next-s_nav-set_nav_routing = mo_action->mo_app->mv_nav_mode.
     ENDIF.
+
+    " An app WITHOUT a mode of its own must still turn routing OFF after a
+    " navigation hop: its initial mv_nav_mode travels as empty = "no change",
+    " so the PREVIOUS app's KEEP/FRESH stayed live and every response here
+    " kept writing '#/app/<CLASS>/<DRAFT>' for an app that never opted in
+    " (seen live: the samples overview kept its draft route after
+    " nav_app_leave from a routed sample). The mode follows the app - like a
+    " manifest - so the hop says DEFAULT explicitly; a called app that
+    " should keep routing INHERITS the caller's mode before this runs (see
+    " z2ui5_cl_ui5_action), and a fresh page load needs nothing because the
+    " frontend state starts clean (AppState.reset on component init).
+    IF mo_action->ms_next-s_nav-set_nav_routing IS INITIAL
+        AND mo_action->mo_app->mv_nav_mode IS INITIAL
+        AND mo_action->ms_actual-check_on_navigated = abap_true.
+      mo_action->ms_next-s_nav-set_nav_routing = z2ui5_if_client=>cs_nav_mode-default.
+    ENDIF.
+
     IF mo_action->ms_next-s_nav-set_nav_routing IS NOT INITIAL.
       mo_action->mo_app->ms_session-nav_mode_sent = mo_action->ms_next-s_nav-set_nav_routing.
     ENDIF.

--- a/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
@@ -85,6 +85,7 @@ CLASS ltcl_test_handler_post DEFINITION FINAL
     METHODS test_route_no_route    FOR TESTING RAISING cx_static_check.
     METHODS test_app_state_hash    FOR TESTING RAISING cx_static_check.
     METHODS test_nav_mode_resent   FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_mode_hop_default FOR TESTING RAISING cx_static_check.
     METHODS test_auto_update_push  FOR TESTING RAISING cx_static_check.
     METHODS test_auto_update_same  FOR TESTING RAISING cx_static_check.
     METHODS test_nested_display_push FOR TESTING RAISING cx_static_check.
@@ -1186,6 +1187,43 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = abap_false
         act = xsdbool( system_actions_of( lo_handler ) CS `setNavRouting` ) ).
+
+  ENDMETHOD.
+
+
+  METHOD test_nav_mode_hop_default.
+
+    DATA lo_handler TYPE REF TO z2ui5_cl_ui5_handler.
+
+    " A navigation hop into an app WITHOUT a mode of its own says DEFAULT
+    " explicitly: the app's initial mode would travel as empty = "no change",
+    " and the PREVIOUS app's KEEP/FRESH would keep writing
+    " '#/app/<CLASS>/<DRAFT>' for an app that never opted in - seen live on
+    " the samples overview after nav_app_leave from a routed sample.
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app      = NEW ltcl_app_nav_loop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->ms_actual-check_on_navigated = abap_true.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+        exp = `*"setNavRouting":"DEFAULT"*`
+        act = system_actions_of( lo_handler ) ).
+
+    " while a hop into an app WITH a mode - its own, or the one a called app
+    " inherits from its caller (z2ui5_cl_ui5_action) - still sends that mode
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app      = NEW ltcl_app_nav_loop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->mo_app->mv_nav_mode = z2ui5_if_client=>cs_nav_mode-keep.
+    lo_handler->mo_action->ms_actual-check_on_navigated = abap_true.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+        exp = `*"setNavRouting":"KEEP"*`
+        act = system_actions_of( lo_handler ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

Reported live by the maintainer: after `nav_app_leave` from a routed sample back to the samples overview, the URL kept a draft route (`…#/app/Z2UI5_CL_SMP_APP_000/<draft-id>`) although the overview never opted into routing.

Cause: the routing mode is remembered per app and re-sent on a navigation hop — but an app whose `mv_nav_mode` is initial sent **empty**, which the frontend reads as "no change". The previous app's KEEP/FRESH stayed live in the session, and every response of the mode-less app kept writing its `#/app/<CLASS>/<DRAFT>` route.

## Changes

- **`main_end`**: a navigation hop (`check_on_navigated`) into an app without a mode of its own now sends an explicit `setNavRouting: DEFAULT` — routing switches off and the router's per-response cleanup clears the route from the URL. The mode follows the app, like a manifest, which is what the existing comments already promise.
- Untouched on purpose: the `nav_app_call` inheritance (a called app copies the caller's mode in `z2ui5_cl_ui5_action` **before** this runs, so called apps keep routing), and fresh page loads (frontend state starts clean via `AppState.reset`, nothing needs to travel).
- **Test**: `test_nav_mode_hop_default` — a hop into a mode-less app sends `DEFAULT`, a hop into an app with a mode still sends that mode; the existing `test_nav_mode_resent` cases stay green.

## How to test

```
npm run downport && npm run auto_transpile && npm run unit && npm run check:js
```

All green (ABAP unit suite incl. the new test, 1014 JS specs). The `linter-mirror` gate stays red for the known cross-release reason (#2693) until the linter release + dep bump.

## Checklist

- [x] Unit tests added/updated (handler testclasses)
- [x] No manual edits under `src/00/01/`, `src/00/02/` (no mirror affected — backend-only change)
- [x] Changes follow AGENTS.md guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX

---
_Generated by [Claude Code](https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX)_