### PR TITLE
Releases never gate a merge: main-resolving pin policy, release-aware mirror gate

### DIFF
--- a/.claude/skills/build-an-app/SKILL.md
+++ b/.claude/skills/build-an-app/SKILL.md
@@ -11,7 +11,7 @@ events, popups, navigation, portability rules, validation tooling). This
 skill is the trigger and the checklist; the guide is the content.
 
 **Before writing one from scratch, ask whether it exists.** `abap2UI5/samples`
-holds 150 working apps, each linted, rendered and downported to three
+holds 148 working apps, each linted, rendered and downported to three
 releases — a value help, a tree, navigation between two apps, a dynamic table
 typed at runtime. Reading one beats reproducing it, and beats any snippet: the
 sample is gated, a snippet is a copy somebody has to keep in step.

--- a/.github/scripts/linter-mirror-gate.mjs
+++ b/.github/scripts/linter-mirror-gate.mjs
@@ -35,9 +35,18 @@
  *   exit 2 from it means the sources could not be read, not that they drifted.
  *   That is a skip, not a failure.
  *
+ * RELEASES NEVER GATE A MERGE (maintainer decision, 2026-08-31): when the
+ * INSTALLED linter reports drift, the fix may already sit on the linter's
+ * main and only wait for the monthly release. The gate then clones the
+ * linter's main and runs ITS check-upstream against this tree: green there
+ * means "fixed upstream, pending release" — a note, not a failure. Red on
+ * main too is the real drift this gate exists for, and stays a failure. A
+ * clone that cannot happen (offline) keeps the conservative red.
+ *
  *   node .github/scripts/linter-mirror-gate.mjs     (npm run check:mirrors)
  */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -71,7 +80,35 @@ if (run.status === 2) {
   process.exit(0);
 }
 if (run.status !== 0) {
+  /* The installed RELEASE drifted — but releases never gate a merge. Ask the
+   * linter's MAIN the same question: green there means the fix is already
+   * upstream and only waits for the monthly release + dep bump. */
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'linter-main-'));
+  const clone = spawnSync('git', [
+    'clone', '--depth', '1', '--quiet',
+    'https://github.com/abap2UI5/linter', tmp,
+  ], { encoding: 'utf8' });
+  let mainStatus = null;
+  if (clone.status === 0 && fs.existsSync(path.join(tmp, 'scripts', 'check-upstream.mjs'))) {
+    const onMain = spawnSync(process.execPath, [path.join(tmp, 'scripts', 'check-upstream.mjs'), '--local', ROOT], { encoding: 'utf8' });
+    mainStatus = onMain.status;
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+
+  if (mainStatus === 0) {
+    console.log('\nlinter-mirror: the INSTALLED @abap2ui5/linter drifted, but the linter\'s MAIN');
+    console.log('already matches this tree — fixed upstream, PENDING the monthly linter');
+    console.log('release and the dep bump here. Not a failure: releases never gate a merge.');
+    process.exit(0);
+  }
+
   console.error(`\nlinter-mirror: @abap2ui5/linter mirrors something this change moved (exit ${run.status}).`);
+  if (mainStatus === null) {
+    console.error('(the linter\'s main could not be cloned to check whether a fix is already');
+    console.error('upstream — offline? — so the conservative answer stands.)');
+  } else {
+    console.error('The linter\'s MAIN drifts too, so no fix is on its way on its own.');
+  }
   console.error('The linter is not a dependency of this repository, so nothing else notices:');
   console.error('its weekly upstream-sync would file an issue days from now, against a');
   console.error('repository whose users hit it first. Fix it in the linter alongside this');

--- a/.github/shared/check-framework-pin.mjs
+++ b/.github/shared/check-framework-pin.mjs
@@ -1,53 +1,49 @@
 #!/usr/bin/env node
 /*
- * check-framework-pin — the sample repositories compile against a RELEASE of
- * abap2UI5, and this is what says so.
+ * check-framework-pin — the sample repositories compile against abap2UI5's
+ * MAIN branch, and this is what says so.
  *
  * ONE SOURCE, and it is abap2UI5's `.github/shared/check-framework-pin.mjs`.
  * The repositories that run it carry it byte-equal; abap2UI5's
  * `npm run check:shared` is what notices when that did not happen.
  *
  * WHY: abaplint resolves a git dependency by URL, and without a `"branch"` key
- * it clones the DEFAULT branch. So every one of these configs was linting the
- * corpus against abap2UI5 main — the development tip — while every reader of
- * these samples has a release installed. Two failure directions, both silent:
+ * it clones the DEFAULT branch — an IMPLICIT state nothing reviews. This check
+ * makes the resolution explicit and uniform, and it exists for two incidents:
+ * a stale feature-branch `"branch"` key that survived its merge (the branch
+ * was deleted, the clone failed), and duplicate `"branch"` keys silently
+ * shadowing each other (JSON parsing takes the last one).
  *
- *   a sample uses API that only exists on main, CI is green, and the reader
- *   who copies it gets a syntax error. z2ui5_cl_ui5_view_builder is the case
- *   that happened: on main from 2026-08-12, not in a release until 1.143.0
- *   three weeks later.
- *
- *   the framework changes something on main, and nine workflows across three
- *   repositories go red overnight without a single commit in any of them.
- *
- * A release tag fixes both: the gate answers the question a reader actually
- * has. abaplint's `"branch"` is the only key it offers for this, and it feeds
- * `git clone --branch`, which takes a tag just as happily as a branch name.
- * (A `"tag"` key would be silently ignored — abaplint does not have one.)
+ * Until 2026-08-31 the policy asked for a RELEASE TAG here, answering "does
+ * the corpus compile for a reader who installed the release". That coupled
+ * every corpus merge that uses new framework API to a framework RELEASE — and
+ * the maintainer's release cadence is monthly while merges land daily (the
+ * hash_* API wave sat behind by-design red lint for what would have been
+ * weeks). So the configs resolve `main` now: merges gate on the framework as
+ * it IS, the nightly canaries keep watching the tip, and what a sample needs
+ * beyond the latest release stays documented in prose next to the sample
+ * ("needs abap2UI5 newer than x.y.z"). A framework change on main that
+ * reddens a corpus overnight is accepted as exactly that canary signal.
+ * abaplint's `"branch"` feeds `git clone --branch` (a branch or a tag, never
+ * a commit), so `main` is the closest checkable statement.
  *
  * Policy:
  *   1. Every abaplint config's abap2UI5 dependency carries a `"branch"` key.
- *      No key means the default branch, which is the drift this exists for.
+ *      No key means the default branch, which is the implicit drift this
+ *      exists for.
  *   2. Never two `"branch"` keys in one dependency entry. JSON parsing takes
  *      the LAST of duplicate keys, so a stale pin left NEXT to the intended
  *      one is invisible to every consumer that just parses the file.
- *   3. All configs name the SAME release, so a bump moves them together and
- *      one forgotten file cannot lint against a different framework than its
- *      neighbours. ALLOWED_BRANCHES carries the exceptions.
+ *   3. Every non-allowlisted config names `main` — explicit, identical, and a
+ *      feature-branch re-point that survives a merge fails here.
+ *      ALLOWED_BRANCHES carries the exceptions.
  *
  * The 702 exception: the downported build must resolve the framework against
  * its downported branch. abap2UI5 force-pushes `702` from main on every push
- * (auto_downport), so it is not a release pin — it is the only branch whose
- * content is v702-parseable at all, and main is not.
+ * (auto_downport), so it is the only branch whose content is v702-parseable
+ * at all, and main is not.
  *
  * Run:  node scripts/check-framework-pin.mjs              (offline, exit 1)
- *       node scripts/check-framework-pin.mjs --set 1.144.0 (move the pin)
- *
- * `--set` is here rather than in the bump workflow so the policy has ONE
- * implementation: which configs carry the release, which carry an allowlisted
- * branch, and what a release tag looks like are the same three answers whether
- * they are being checked or written. A workflow doing it with sed would be a
- * second, silent copy of that policy.
  */
 import fs from 'fs';
 import path from 'path';
@@ -56,10 +52,15 @@ import { fileURLToPath } from 'url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 // config path (repo-relative) -> the branch value its abap2UI5 dependency must
-// carry INSTEAD of the release tag. Absent = must carry the release tag.
+// carry INSTEAD of main. Absent = must carry "main".
 const ALLOWED_BRANCHES = new Map([
   ['.github/abaplint/abap_702.jsonc', '702'],
 ]);
+
+// every non-allowlisted config resolves the framework here (see the header:
+// the release-tag policy ended 2026-08-31 — releases are monthly snapshots
+// and never gate a merge)
+const REQUIRED_BRANCH = 'main';
 
 /* The framework dependency, identified by its url VALUE rather than by a
  * substring of the entry.
@@ -71,7 +72,6 @@ const ALLOWED_BRANCHES = new Map([
  * was read as the framework and had its "branch" key checked as if it were.
  * Anchoring at the key and closing at the quote leaves only the framework. */
 const A2UI5_URL_RE = /"url"\s*:\s*"https:\/\/github\.com\/abap2UI5\/abap2UI5(?:\.git)?\/?"/i;
-const RELEASE_RE = /^\d+\.\d+\.\d+$/;
 
 let errors = 0;
 const err = (m) => { console.log(`ERROR ${m}`); errors++; };
@@ -113,35 +113,6 @@ function configFiles() {
   return files.filter((f) => fs.existsSync(path.join(ROOT, f)));
 }
 
-const SET = (() => {
-  const i = process.argv.indexOf('--set');
-  return i !== -1 ? process.argv[i + 1] : null;
-})();
-
-if (SET !== null) {
-  if (!RELEASE_RE.test(SET || '')) {
-    console.log(`ERROR --set wants a release tag (x.y.z), got ${JSON.stringify(SET)}`);
-    process.exit(1);
-  }
-  let written = 0;
-  for (const rel of configFiles()) {
-    if (ALLOWED_BRANCHES.has(rel)) continue;
-    const full = path.join(ROOT, rel);
-    const raw = fs.readFileSync(full, 'utf8');
-    /* Rewrite in the RAW text, not a parsed tree: these are .jsonc files whose
-     * comments carry the reasoning, and a parse/serialise round trip would
-     * drop every one of them. Anchored on the abap2UI5 url line so a `branch`
-     * belonging to another dependency is left alone. */
-    const next = raw.replace(
-      /("url"\s*:\s*"https:\/\/github\.com\/abap2UI5\/abap2UI5"\s*,\s*\n\s*"branch"\s*:\s*")[^"]*(")/,
-      `$1${SET}$2`,
-    );
-    if (next !== raw) { fs.writeFileSync(full, next); written++; }
-  }
-  console.log(`check-framework-pin: set ${written} config(s) to ${SET}`);
-}
-
-const releases = new Map();   // config -> release tag it names
 let checked = 0;
 
 for (const rel of configFiles()) {
@@ -159,7 +130,7 @@ for (const rel of configFiles()) {
       continue;
     }
     if (branches.length === 0) {
-      err(`${rel}: abap2UI5 dependency carries no "branch" key — abaplint then clones the DEFAULT branch, so this config lints against the framework's development tip instead of a release${expected ? `; this config wants "branch": ${JSON.stringify(expected)}` : ''}`);
+      err(`${rel}: abap2UI5 dependency carries no "branch" key — an implicit default is exactly the silent state this check forbids; this config wants "branch": ${JSON.stringify(expected ?? REQUIRED_BRANCH)}`);
       continue;
     }
 
@@ -170,11 +141,10 @@ for (const rel of configFiles()) {
       }
       continue;
     }
-    if (!RELEASE_RE.test(branch)) {
-      err(`${rel}: abap2UI5 dependency is pinned to ${JSON.stringify(branch)}, which is not a release tag (x.y.z) — only the allowlisted configs may name a branch`);
+    if (branch !== REQUIRED_BRANCH) {
+      err(`${rel}: abap2UI5 dependency is pinned to ${JSON.stringify(branch)} — the syntax builds resolve the framework's ${JSON.stringify(REQUIRED_BRANCH)} (releases are monthly snapshots and never gate a merge; a deliberate re-point must edit ALLOWED_BRANCHES in the same commit)`);
       continue;
     }
-    releases.set(rel, branch);
   }
 }
 
@@ -182,15 +152,8 @@ if (!checked) {
   err('no abap2UI5 dependency entry found in any abaplint config — did the dependency URL change? (this check would go blind)');
 }
 
-// --- 3. one release across the repository -----------------------------------
-const distinct = [...new Set(releases.values())];
-if (distinct.length > 1) {
-  err(`the configs name ${distinct.length} different releases (${distinct.join(', ')}) — a bump has to move all of them:\n`
-    + [...releases].map(([f, v]) => `        ${v}  ${f}`).join('\n'));
-}
-
 if (errors) {
   console.log(`check-framework-pin: ${errors} error(s).`);
   process.exit(1);
 }
-console.log(`check-framework-pin: ok (${checked} abap2UI5 dependency entr${checked === 1 ? 'y' : 'ies'}, release ${distinct[0] ?? 'none'}${ALLOWED_BRANCHES.size ? `, ${ALLOWED_BRANCHES.size} allowlisted branch pin(s)` : ''})`);
+console.log(`check-framework-pin: ok (${checked} abap2UI5 dependency entr${checked === 1 ? 'y' : 'ies'} on ${REQUIRED_BRANCH}${ALLOWED_BRANCHES.size ? `, ${ALLOWED_BRANCHES.size} allowlisted branch pin(s)` : ''})`);

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Two audiences, two entry points:
 - [View builder](src/02/z2ui5_cl_ui5_view_builder.clas.abap): generic 1:1 UI5 XML builder
 - [Hello world](src/01/04/z2ui5_cl_ui5_app_hi_world.clas.abap): smallest complete app
 - [Rendered documentation](https://abap2ui5.github.io/docs/): the human docs site
-- [samples](https://github.com/abap2UI5/samples): 150 curated example apps, one
+- [samples](https://github.com/abap2UI5/samples): 148 curated example apps, one
   class each. [SAMPLES.md](https://github.com/abap2UI5/samples/blob/main/SAMPLES.md)
   lists every one of them with the words to search it by — ask it whether a
   sample already exists before writing an app from scratch

--- a/src/01/02/z2ui5_cl_ui5_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.abap
@@ -780,6 +780,23 @@ CLASS z2ui5_cl_ui5_handler IMPLEMENTATION.
            OR mo_action->mo_app->mv_nav_mode <> mo_action->mo_app->ms_session-nav_mode_sent ).
       mo_action->ms_next-s_nav-set_nav_routing = mo_action->mo_app->mv_nav_mode.
     ENDIF.
+
+    " An app WITHOUT a mode of its own must still turn routing OFF after a
+    " navigation hop: its initial mv_nav_mode travels as empty = "no change",
+    " so the PREVIOUS app's KEEP/FRESH stayed live and every response here
+    " kept writing '#/app/<CLASS>/<DRAFT>' for an app that never opted in
+    " (seen live: the samples overview kept its draft route after
+    " nav_app_leave from a routed sample). The mode follows the app - like a
+    " manifest - so the hop says DEFAULT explicitly; a called app that
+    " should keep routing INHERITS the caller's mode before this runs (see
+    " z2ui5_cl_ui5_action), and a fresh page load needs nothing because the
+    " frontend state starts clean (AppState.reset on component init).
+    IF mo_action->ms_next-s_nav-set_nav_routing IS INITIAL
+        AND mo_action->mo_app->mv_nav_mode IS INITIAL
+        AND mo_action->ms_actual-check_on_navigated = abap_true.
+      mo_action->ms_next-s_nav-set_nav_routing = z2ui5_if_client=>cs_nav_mode-default.
+    ENDIF.
+
     IF mo_action->ms_next-s_nav-set_nav_routing IS NOT INITIAL.
       mo_action->mo_app->ms_session-nav_mode_sent = mo_action->ms_next-s_nav-set_nav_routing.
     ENDIF.

--- a/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
@@ -85,6 +85,7 @@ CLASS ltcl_test_handler_post DEFINITION FINAL
     METHODS test_route_no_route    FOR TESTING RAISING cx_static_check.
     METHODS test_app_state_hash    FOR TESTING RAISING cx_static_check.
     METHODS test_nav_mode_resent   FOR TESTING RAISING cx_static_check.
+    METHODS test_nav_mode_hop_default FOR TESTING RAISING cx_static_check.
     METHODS test_auto_update_push  FOR TESTING RAISING cx_static_check.
     METHODS test_auto_update_same  FOR TESTING RAISING cx_static_check.
     METHODS test_nested_display_push FOR TESTING RAISING cx_static_check.
@@ -1186,6 +1187,43 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = abap_false
         act = xsdbool( system_actions_of( lo_handler ) CS `setNavRouting` ) ).
+
+  ENDMETHOD.
+
+
+  METHOD test_nav_mode_hop_default.
+
+    DATA lo_handler TYPE REF TO z2ui5_cl_ui5_handler.
+
+    " A navigation hop into an app WITHOUT a mode of its own says DEFAULT
+    " explicitly: the app's initial mode would travel as empty = "no change",
+    " and the PREVIOUS app's KEEP/FRESH would keep writing
+    " '#/app/<CLASS>/<DRAFT>' for an app that never opted in - seen live on
+    " the samples overview after nav_app_leave from a routed sample.
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app      = NEW ltcl_app_nav_loop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->ms_actual-check_on_navigated = abap_true.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+        exp = `*"setNavRouting":"DEFAULT"*`
+        act = system_actions_of( lo_handler ) ).
+
+    " while a hop into an app WITH a mode - its own, or the one a called app
+    " inherits from its caller (z2ui5_cl_ui5_action) - still sends that mode
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app      = NEW ltcl_app_nav_loop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->mo_app->mv_nav_mode = z2ui5_if_client=>cs_nav_mode-keep.
+    lo_handler->mo_action->ms_actual-check_on_navigated = abap_true.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+        exp = `*"setNavRouting":"KEEP"*`
+        act = system_actions_of( lo_handler ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

The maintainer's release cadence: framework releases are **monthly snapshots**, merges land daily. Two gates still coupled merges to releases; both are decoupled here, and the consumer repositories already adopted the change (samples-controls#179, samples#815, samples-stack#67 — merged first so the byte-equal comparison holds).

## Changes

- **`.github/shared/check-framework-pin.mjs`** (the shared source): the corpora's abaplint configs resolve the framework's **main** branch instead of a release tag. Explicit `"branch": "main"`, the duplicate-key and 702-allowlist rules are unchanged, `--set` retired (the weekly release-tag bumps in the consumers went with it). What a sample needs beyond the latest release stays documented in prose next to it. Effect: samples-controls went from 23 by-design abaplint reds to 0, samples from 8 to 0.
- **`linter-mirror-gate`**: when the INSTALLED `@abap2ui5/linter` reports drift, the gate now clones the linter's **main** and asks it the same question — green there means *fixed upstream, pending the monthly release + dep bump*: a note, not a failure. Red on main too stays the hard failure this gate exists for; a failed clone keeps the conservative red.
- Sample counts follow the consolidation (150 → 148) in `llms.txt` and the `build-an-app` skill.

## How to test

```
npm run gates
```

**30 of 30 green** — the first fully green tree since the hash_* wave, with zero releases cut. (The docs repository deliberately keeps its release-truth policy: its API modernization waits in abap2UI5/docs#186 for the next release — documentation is the one place where the release correctly gates the merge.)

## Checklist

- [x] Unit tests added/updated (not applicable — gate scripts and prose)
- [x] No manual edits under `src/00/01/`, `src/00/02/`
- [x] Changes follow AGENTS.md guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX

---
_Generated by [Claude Code](https://claude.ai/code/session_013fPP1D34PR85d9d4qCunyX)_