### PR TITLE
Keep an elementary REF TO data across the draft roundtrip

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ unreleased
 * Response header names and values are stripped of CR/LF (response splitting hardening)
 - z2ui5_cl_ui5_util_context=>app_get_url moved to z2ui5_cl_ui5_handler=>app_get_url. A downstream caller of the old spelling gets a compile error until it renames the class (same signature; src/00 is not the guarded API, and the shipped legacy z2ui5_cl_util=>app_get_url keeps working)
 * App-state links and copied launchpad links keep a bare intent hash (opened from the tile, no app part yet) instead of landing the recipient on the FLP home page
+* A REF TO data pointing at an ELEMENTARY value (CREATE DATA mr_input TYPE string) survives the draft roundtrip again - it was cleared without being captured, so the attribute came back initial and the next render dumped in attri_search on a mt_attri row left without o_typedescr (sample z2ui5_cl_smp_app_094)
 
 
 2026-08-30 v1.144.0

--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
@@ -450,7 +450,23 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
             EXIT.
           ENDLOOP.
 
-        WHEN z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_struct1 OR z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_struct2.
+        WHEN OTHERS.
+
+          " EVERY other target is captured whole - a structure, and an
+          " ELEMENTARY one such as `CREATE DATA mr_input TYPE string`. This
+          " branch read `WHEN struct1 OR struct2` and had no OTHERS, so an
+          " elementary target was captured by nothing while the loop below
+          " cleared its reference all the same: the restore found no
+          " srtti_data, left the attribute INITIAL, and `<name>->*` stopped
+          " resolving from there on. That is how a row of mt_attri ends up
+          " without o_typedescr (main_attri_db_load_resolve swallows the
+          " failed ASSIGN) and dumps attri_search on the NEXT render, one
+          " roundtrip after the app looked fine - z2ui5_cl_smp_app_094 in
+          " the samples repository is exactly that shape.
+          " Anything this cannot express raises out of here into
+          " z2ui5_cl_ui5_app_cont=>all_xml_stringify, which restores the
+          " cleared references and retries - a loud failure, where dropping
+          " the reference was a silent one
           lr_attri->srtti_data = z2ui5_cl_ui5_util_context=>xml_srtti_stringify( <val_deref> ).
 
       ENDCASE.
@@ -562,13 +578,25 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
       " compare by name - descriptor instances are not stable in the
       " abaplint transpiler runtime; the data reference check below is
       " the definitive match, this is only a prefilter. Generated names
-      " of anonymous types (containing %) are not comparable either
-      DATA(lv_name_attri) = lr_attri->o_typedescr->absolute_name.
-      DATA(lv_name_val) = lo_datadescr->absolute_name.
-      IF lv_name_attri <> lv_name_val
-          AND lv_name_attri NS `%`
-          AND lv_name_val NS `%`.
-        CONTINUE.
+      " of anonymous types (containing %) are not comparable either.
+      " o_typedescr can be UNBOUND here: it is a REF TO cl_abap_typedescr,
+      " so it does not survive the draft round trip, and the restore
+      " (main_attri_db_load_resolve) re-resolves it through a dynamic ASSIGN
+      " whose failure it swallows on purpose - a row whose attribute cannot
+      " be reached right now keeps an initial descriptor. Reading
+      " ->absolute_name on it dumped CX_SY_REF_IS_INITIAL on the FIRST
+      " _bind( ) of the next render. Skipping only the prefilter, rather
+      " than the row, is what keeps that from hiding a match: the
+      " data-reference compare below still decides, and it needs no
+      " descriptor
+      IF lr_attri->o_typedescr IS BOUND.
+        DATA(lv_name_attri) = lr_attri->o_typedescr->absolute_name.
+        DATA(lv_name_val) = lo_datadescr->absolute_name.
+        IF lv_name_attri <> lv_name_val
+            AND lv_name_attri NS `%`
+            AND lv_name_val NS `%`.
+          CONTINUE.
+        ENDIF.
       ENDIF.
 
       TRY.

--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.testclasses.abap
@@ -559,6 +559,103 @@ CLASS ltcl_test_app_root4 IMPLEMENTATION.
 ENDCLASS.
 
 
+CLASS ltcl_test_app_root5 DEFINITION FINAL
+  FOR TESTING RISK LEVEL HARMLESS DURATION MEDIUM.
+
+  PUBLIC SECTION.
+
+    DATA mr_elem  TYPE REF TO data.
+    DATA mv_value TYPE string.
+
+    METHODS test_elem_ref_gen     FOR TESTING RAISING cx_static_check.
+    METHODS test_search_no_descr  FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_test_app_root5 IMPLEMENTATION.
+
+  METHOD test_elem_ref_gen.
+
+    " the z2ui5_cl_smp_app_094 case: a REF TO data whose target is an
+    " ELEMENTARY value, not a table or a structure. The draft round trip used
+    " to clear the reference without capturing it, so the restore left the
+    " attribute initial - and `MR_ELEM->*` unresolvable, which is what put an
+    " unbound o_typedescr into mt_attri and dumped attri_search on the next
+    " render
+    DATA(lo_app) = NEW ltcl_test_app_root5( ).
+    CREATE DATA lo_app->mr_elem TYPE string.
+    FIELD-SYMBOLS <val> TYPE any.
+    ASSIGN lo_app->mr_elem->* TO <val>.
+    <val> = `ref data - working`.
+
+    DATA(lt_attri) = VALUE z2ui5_if_ui5_types=>ty_t_attri( ).
+    DATA(lo_model) = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                                 app   = lo_app ).
+
+    DATA(ls_attri) = lo_model->main_attri_search( lo_app->mr_elem ).
+    cl_abap_unit_assert=>assert_equals( act = ls_attri->name
+                                        exp = `MR_ELEM->*` ).
+
+    " draft round trip: save into a new app instance and restore
+    lo_model->main_attri_db_save_srtti( ).
+
+    lo_app = NEW ltcl_test_app_root5( ).
+    lo_model = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                           app   = lo_app ).
+    lo_model->main_attri_db_load( ).
+
+    cl_abap_unit_assert=>assert_bound( act = lo_app->mr_elem
+                                       msg = `the elementary dref target was lost in the draft round trip` ).
+    ASSIGN lo_app->mr_elem->* TO <val>.
+    cl_abap_unit_assert=>assert_equals( act = <val>
+                                        exp = `ref data - working` ).
+
+    " every restored row carries its descriptor again - attri_search reads
+    " o_typedescr->absolute_name unguarded on every row the prefilter visits
+    LOOP AT lt_attri REFERENCE INTO DATA(lr_attri).
+      cl_abap_unit_assert=>assert_bound( act = lr_attri->o_typedescr
+                                         msg = |o_typedescr missing for { lr_attri->name }| ).
+    ENDLOOP.
+
+    " and the next render finds the binding again instead of dumping
+    ls_attri = lo_model->main_attri_search( lo_app->mr_elem ).
+    cl_abap_unit_assert=>assert_equals( act = ls_attri->name
+                                        exp = `MR_ELEM->*` ).
+
+  ENDMETHOD.
+
+  METHOD test_search_no_descr.
+
+    " a row whose o_typedescr the restore could not re-resolve must not take
+    " the search down with it - attri_search read ->absolute_name on it
+    " unguarded, so one unreachable attribute dumped CX_SY_REF_IS_INITIAL on
+    " the first _bind( ) of the render instead of being passed over
+    DATA(lo_app) = NEW ltcl_test_app_root5( ).
+    lo_app->mv_value = `value`.
+
+    " same type_kind/kind as the searched value, so the row passes the WHERE
+    " prefilter and is the first one the loop reads - and no o_typedescr,
+    " which is what a swallowed ASSIGN failure in the restore leaves behind
+    DATA(lo_descr) = z2ui5_cl_ui5_util_context=>rtti_get_typedescr_by_data_ref( REF #( lo_app->mv_value ) ).
+    DATA(lt_attri) = VALUE z2ui5_if_ui5_types=>ty_t_attri(
+        ( name            = `MV_GONE`
+          check_dissolved = abap_true
+          type_kind       = lo_descr->type_kind
+          kind            = lo_descr->kind ) ).
+
+    DATA(lo_model) = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                                 app   = lo_app ).
+
+    DATA(ls_attri) = lo_model->main_attri_search( REF #( lo_app->mv_value ) ).
+    cl_abap_unit_assert=>assert_equals( act = ls_attri->name
+                                        exp = `MV_VALUE` ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
 CLASS ltcl_test_diss_complex DEFINITION DEFERRED.
 CLASS z2ui5_cl_ui5_srv_model DEFINITION LOCAL FRIENDS ltcl_test_diss_complex.
 


### PR DESCRIPTION
# Description

A `REF TO data` whose target is an **elementary** value — `CREATE DATA mr_input TYPE string` — did not survive the draft roundtrip. The attribute came back initial, and the next render dumped `CX_SY_REF_IS_INITIAL` inside `attri_search`. Reported from sample `z2ui5_cl_smp_app_094`, which dumped on every render after the first.

Two defects, layered:

**1. The reference was cleared without being captured.** `main_attri_db_save_srtti( )` captured a dref target with S-RTTI only for a table or a structure (`WHEN struct1 OR struct2`, no `OTHERS`), but its second loop then cleared **every** dref unconditionally. An elementary target was therefore captured by nothing and cleared anyway: the restore found no `srtti_data`, left the attribute initial, and `MR_INPUT->*` stopped resolving from that roundtrip on.

**2. `attri_search` read a descriptor it is not guaranteed to have.** `o_typedescr` is a `REF TO cl_abap_typedescr` and does not come back from the draft — which is why `main_attri_db_load_resolve( )` re-resolves it through a dynamic `ASSIGN` after every restore, swallowing failures on purpose (a row whose attribute cannot be reached right now legitimately keeps an initial descriptor). `attri_search` then read `lr_attri->o_typedescr->absolute_name` unguarded, so one unreachable row took the whole search down on the **first** `_bind( )` of the render.

Fixes:

- The struct branch became `WHEN OTHERS`, so every dref target is captured and nothing is cleared that the restore cannot put back. A shape S-RTTI genuinely cannot express now raises into `all_xml_stringify`'s restore-and-retry path instead of dropping the reference silently. `z2ui5_cl_srt_elemdescr` reconstructs a string via `cl_abap_elemdescr=>get_string( )`, so this holds on a real system and not only under the transpiler.
- The descriptor is read only when bound. Only the **prefilter** is skipped, never the row: the data-reference compare below still decides and needs no descriptor, so a missing descriptor cannot hide a match.

Both reasonings sit as comments at the two code sites.

## How to test

Two regression tests in `z2ui5_cl_ui5_srv_model.clas.testclasses.abap`, both of which run in the node suite (unlike `test_tab_ref_gen`, neither needed a transpiler skip entry):

- `ltcl_test_app_root5->test_elem_ref_gen` — the sample-094 shape through a full `main_attri_db_save_srtti( )` / `main_attri_db_load( )` cycle into a fresh app instance. Against the old code it fails at `assert_bound( lo_app->mr_elem )`, which is the defect: the reference is provably gone after the roundtrip.
- `ltcl_test_app_root5->test_search_no_descr` — a row whose `o_typedescr` the restore could not re-resolve must be passed over rather than take the search down.

In an app: a `DATA mr_input TYPE REF TO data` filled with `CREATE DATA mr_input TYPE string`, bound through `client->_bind( <input> )`, now keeps its value and its binding across roundtrips instead of dumping on the second render.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — green end to end; `app/webapp/` untouched
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively — `src/02/` untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour
- [ ] Changes were made via abapGit: no

---
_Generated by [Claude Code](https://claude.ai/code/session_012uN8XhNGx3SCxzf91LbwAf)_