### PR TITLE
Fix eleven framework bugs the gates do not catch

### DIFF
--- a/app/webapp/cc/MultiInputExt.js
+++ b/app/webapp/cc/MultiInputExt.js
@@ -127,8 +127,32 @@ sap.ui.define(
           // free-text entry becomes a Token whose key and visible text are
           // both the input string.
           input.addValidator((args) => {
-            const row = args && args.suggestionObject;
-            if (row) return this.tokenFromRow(row);
+            const picked = args && args.suggestionObject;
+            if (picked && typeof picked.getCells === "function") {
+              // a tabular suggestion ROW: a Token only once TokenKeyCell
+              // says which cell; an unconfigured instance stays inert
+              return this.tokenFromRow(picked);
+            }
+            if (picked) {
+              // a plain suggestionItems pick (a sap.ui.core.Item): MultiInput
+              // hands it over together with the Token it already built from
+              // the item's key and text (suggestedToken, 1.71 and 1.120
+              // alike). It used to go through tokenFromRow like a row and
+              // came back null - no token, no change event, the pick simply
+              // vanished. Return that Token; build it from the item when a
+              // release hands over none.
+              if (args.suggestedToken) return args.suggestedToken;
+              return new Token({
+                key:
+                  typeof picked.getKey === "function"
+                    ? picked.getKey()
+                    : args.text,
+                text:
+                  typeof picked.getText === "function"
+                    ? picked.getText()
+                    : args.text,
+              });
+            }
             return new Token({ key: args.text, text: args.text });
           });
         } catch (e) {

--- a/app/webapp/cc/UITableExt.js
+++ b/app/webapp/cc/UITableExt.js
@@ -63,9 +63,15 @@ sap.ui.define(
           // _applyFilters).
           this._filterBinding = binding;
           // Prefer the public getFilters API (UI5 >= 1.96); older releases
-          // only expose the private aFilters member.
+          // only expose the private aFilters member. The column filter row
+          // is applied by sap.ui.table.Column.filter( ) as FilterType.CONTROL
+          // (1.71 and 1.120 alike), and the private aFilters IS the control
+          // filter array - so the public call has to ask for "Control" too.
+          // "Application" answered the app's own binding filters (usually
+          // none), and on every release with getFilters the user's column
+          // filter was gone after a view rebuild while 1.71 kept it.
           this.aFilters = binding?.getFilters
-            ? binding.getFilters("Application")
+            ? binding.getFilters("Control")
             : binding?.aFilters;
         } catch (e) {
           Lib.logError("UITableExt.readFilter failed", e);

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -95,12 +95,15 @@ sap.ui.define(
           // The app may have been torn down (reset / FLP re-launch) while the
           // pending views loaded; don't mutate history or fire onAfterRendering
           // hooks against a dead app (the custom-JS phase below guards the same
-          // way via isDestroyed). And a response a PARALLEL request replaced
+          // way via isControllerAlive). And a response a PARALLEL request replaced
           // mid-phase must not push its model or write its ids into the URL -
           // the push would read the NEWER response's data into this stale
           // render, and the sync would mix this draft id with the newer app.
           // The newer response runs its own push and sync.
-          if (Lib.isDestroyed(this) || oResponse !== AppState.state.oResponse) {
+          if (
+            !Lib.isControllerAlive(this) ||
+            oResponse !== AppState.state.oResponse
+          ) {
             return;
           }
           // A MODEL key in the response IS the model push - run it after the
@@ -137,6 +140,10 @@ sap.ui.define(
           // - rather than as an early microtask - guarantees render-dependent
           // actions like SET_FOCUS find their target control in the DOM.
           this._runPendingCustomJs(oResponse);
+          // an app-hash change (Back/Forward under app-owned routing) that
+          // arrived while this roundtrip was in flight was parked by the
+          // router - deliver it now that the busy guard would let it through
+          Router.dispatchPendingAppHash();
         }
       },
 
@@ -156,7 +163,8 @@ sap.ui.define(
           // response - the remaining actions would tear down or overwrite
           // what the newer response builds (the per-display guards check
           // the same stamp, but the synchronous teardowns do not).
-          if (Lib.isDestroyed(this) || seq !== Server._requestSeq) return;
+          if (!Lib.isControllerAlive(this) || seq !== Server._requestSeq)
+            return;
           await FrontendAction.runSystem(item, this, {
             seq,
             response: oResponse,
@@ -170,7 +178,7 @@ sap.ui.define(
         const customJs = oResponse?._pendingCustomJs;
         if (oResponse) oResponse._pendingCustomJs = null;
         if (!customJs) return;
-        if (Lib.isDestroyed(this)) return;
+        if (!Lib.isControllerAlive(this)) return;
         for (const item of customJs) {
           FrontendAction.runCustom(item, this);
         }

--- a/app/webapp/core/AppState.js
+++ b/app/webapp/core/AppState.js
@@ -174,6 +174,11 @@ sap.ui.define([], () => {
       //  appHash        the app hash last written or dispatched under that
       //                 listener - the echo guard, mirroring what
       //                 currentDraftId does for the draft routes.
+      //  pendingAppHash a hash change that arrived while a roundtrip was in
+      //                 flight (the busy guard would have dropped its
+      //                 event); the roundtrip's end dispatches it
+      //                 (Router.dispatchPendingAppHash). null = nothing
+      //                 parked.
       navRouting: false,
       navMode: null,
       currentApp: null,
@@ -181,6 +186,7 @@ sap.ui.define([], () => {
       navFromHash: false,
       hashEvent: null,
       appHash: "",
+      pendingAppHash: null,
       // How many app hashes this PAGE LOAD has pushed (listener, legacy and
       // KEEP-suffix pushes alike) - Router.navBack's stand-in for UI5's
       // History.getPreviousHash(): zero means a cold deep link with no

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -163,7 +163,35 @@ sap.ui.define(
       if (state.errors.length > MAX_ERRORS) state.errors.shift();
     }
 
+    // True while `oController` is one of the slot controllers the CURRENT
+    // app state owns. This is the liveness test for a View1 controller,
+    // and isDestroyed( ) below is NOT: sap.ui.core.mvc.Controller is no
+    // ManagedObject - it has neither isDestroyed() nor bIsDestroyed on any
+    // release (checked on 1.71 and 1.144) - and the five controllers are
+    // created once per component (App.controller) and never destroyed, so
+    // isDestroyed( controller ) answered "alive" for a torn-down app and
+    // every guard on it was dead code: variant poll chains kept resolving
+    // the NEXT app's controls after an FLP teardown. What does end a
+    // controller's life is Component.exit -> AppState.reset( ): the state
+    // is rebuilt with the slot fields null and the next launch registers a
+    // fresh set. Membership in the current state is the test, so it holds
+    // across every release and needs no flag on the controller.
+    const CONTROLLER_FIELDS = [
+      "oController",
+      "oControllerNest",
+      "oControllerNest2",
+      "oControllerPopup",
+      "oControllerPopover",
+    ];
+    function isControllerAlive(oController) {
+      if (!oController) return false;
+      const state = AppState.state;
+      return CONTROLLER_FIELDS.some((field) => state[field] === oController);
+    }
+
     // True when the object supports isDestroyed() and reports destroyed.
+    // For a CONTROL (a ManagedObject). A controller is asked with
+    // isControllerAlive( ) above - see there for why this one cannot tell.
     function isDestroyed(obj) {
       if (!obj) return false;
       // ManagedObject#isDestroyed( ) is @since 1.93 - on the 1.71 floor the
@@ -723,6 +751,7 @@ sap.ui.define(
     return {
       logError,
       isDestroyed,
+      isControllerAlive,
       isAlive,
       claimOnce,
       isTextInput,

--- a/app/webapp/core/Router.js
+++ b/app/webapp/core/Router.js
@@ -288,10 +288,32 @@ sap.ui.define(
       if (!state.hashEvent) return;
       const appHash = appHashNormalized(sNewHash);
       if (appHash === state.appHash) return;
-      state.appHash = appHash;
       const controller = state.oController;
-      if (!controller || Lib.isDestroyed(controller)) return;
+      if (!controller || !Lib.isControllerAlive(controller)) return;
+      // A roundtrip in flight: View1.eB drops an ordinary event on its busy
+      // guard. The hash used to be adopted BEFORE that dispatch, so the drop
+      // was final - the URL said the new page, the app still showed the old
+      // one, and no later change re-dispatched it (Back during a click was
+      // enough). Park it instead; the roundtrip's end delivers it through
+      // dispatchPendingAppHash. Only the LAST change matters: a browser
+      // that went Back twice meanwhile lands on the second.
+      if (state.isBusy) {
+        state.pendingAppHash = sNewHash;
+        return;
+      }
+      state.pendingAppHash = null;
+      state.appHash = appHash;
       controller.eB([state.hashEvent]);
+    }
+
+    // The write side of the parking above: called once a roundtrip has
+    // landed (View1._processAfterRendering, after isBusy went false).
+    function dispatchPendingAppHash() {
+      const state = AppState.state;
+      const pending = state.pendingAppHash;
+      if (pending === null || pending === undefined) return;
+      state.pendingAppHash = null;
+      dispatchAppHashChange(pending);
     }
 
     // ------------------------------------------------------------------
@@ -551,6 +573,7 @@ sap.ui.define(
       navTo,
       navBack,
       onHashChanged,
+      dispatchPendingAppHash,
       sync,
     };
   },

--- a/app/webapp/core/actions/Shortcuts.js
+++ b/app/webapp/core/actions/Shortcuts.js
@@ -117,7 +117,7 @@ sap.ui.define(
           // switch clears the registry, an in-app teardown does not) must
           // not dispatch into a destroyed controller - same guard as
           // ViewOps.evStartTimer
-          if (Lib.isDestroyed(entry.controller)) return;
+          if (!Lib.isControllerAlive(entry.controller)) return;
           // the browser's own default for the combo (Ctrl+S saves the page,
           // Ctrl+D bookmarks it) must not fire alongside the app command
           oEvent.preventDefault();

--- a/app/webapp/core/actions/Variants.js
+++ b/app/webapp/core/actions/Variants.js
@@ -96,7 +96,7 @@ sap.ui.define(["z2ui5/core/Lib", "z2ui5/core/ViewSlots"], (Lib, ViewSlots) => {
       // and because ids repeat across views, it could then resolve and wire
       // the NEXT app's controls. Every other timer-shaped handler checks the
       // controller first (see ViewOps evStartTimer); this one now does too.
-      if (Lib.isDestroyed(oController)) {
+      if (!Lib.isControllerAlive(oController)) {
         finish();
         return;
       }
@@ -280,7 +280,7 @@ sap.ui.define(["z2ui5/core/Lib", "z2ui5/core/ViewSlots"], (Lib, ViewSlots) => {
     const finish = () => activeInits.delete(key);
     let tries = 0;
     const run = () => {
-      if (Lib.isDestroyed(oController)) {
+      if (!Lib.isControllerAlive(oController)) {
         finish();
         return;
       }

--- a/app/webapp/core/actions/ViewOps.js
+++ b/app/webapp/core/actions/ViewOps.js
@@ -8,6 +8,10 @@ sap.ui.define(
   (ODataModel, Lib, ViewSlots, AppState) => {
     "use strict";
 
+    // how long a backend timer tick waits before asking again whether the
+    // roundtrip it collided with has landed (evStartTimer)
+    const TIMER_BUSY_RETRY_MS = 50;
+
     // ------------------------------------------------------------------
     // Actions against the running VIEWS and their models: focus, scrolling,
     // element binding, model size limits, the OData model switch, backend
@@ -130,18 +134,32 @@ sap.ui.define(
       const delay = Number(args[2]) || 0;
       const timers = AppState.state.timers;
       clearTimeout(timers[timerKey]);
-      timers[timerKey] = setTimeout(() => {
+      const fire = () => {
         delete timers[timerKey];
         // nothing cancels a pending timer on app teardown - an FLP close or
         // re-launch leaves it armed, so it must not fire the old app's event
         // into the new session
-        if (Lib.isDestroyed(oController)) return;
-        // dispatch as a background event (args[2] = ignore busy) - a timer
-        // firing while an ordinary roundtrip is in flight must not be
-        // swallowed by the busy guard, or a self-rescheduling poll chain
-        // dies on the first collision with a user click
+        if (!Lib.isControllerAlive(oController)) return;
+        // A roundtrip in flight (a Back/Forward restore, a hash-listener
+        // event, a popup's own event): the tick waits for it. It used to
+        // dispatch right away as a background event, and Server.readHttp
+        // treats every new request as superseding - it ABORTED the fetch in
+        // flight, whose response was then dropped as stale: the user's
+        // action was lost without any feedback. Re-arming into the same
+        // single slot keeps the poll chain alive (the reason the tick must
+        // not simply be swallowed by the busy guard) without taking the
+        // request down with it.
+        if (AppState.state.isBusy) {
+          timers[timerKey] = setTimeout(fire, TIMER_BUSY_RETRY_MS);
+          return;
+        }
+        // dispatch as a background event (args[2] = ignore busy): between
+        // the check above and the dispatch nothing can start a roundtrip,
+        // and the flag keeps a tick from being dropped by a busy guard that
+        // a stale state.isBusy would otherwise raise
         oController.eB([callbackEvent, false, true]);
-      }, delay);
+      };
+      timers[timerKey] = setTimeout(fire, delay);
     }
 
     // The three handlers below resolve their target with ViewSlots.resolveById
@@ -201,7 +219,7 @@ sap.ui.define(
             // all onAfterRendering delegates ran - focusing here would be
             // overridden right away.
             setTimeout(() => {
-              if (Lib.isDestroyed(oController)) return;
+              if (!Lib.isControllerAlive(oController)) return;
               // Only when the focus was not actively moved elsewhere in
               // between - a re-render at some arbitrary later point must
               // never steal the user's focus.

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,17 @@ unreleased
 * Response header names and values are stripped of CR/LF (response splitting hardening)
 - z2ui5_cl_ui5_util_context=>app_get_url moved to z2ui5_cl_ui5_handler=>app_get_url. A downstream caller of the old spelling gets a compile error until it renames the class (same signature; src/00 is not the guarded API, and the shipped legacy z2ui5_cl_util=>app_get_url keeps working)
 * App-state links and copied launchpad links keep a bare intent hash (opened from the tile, no app part yet) instead of landing the recipient on the FLP home page
+* A table cell edit of a TYPE d / t / timestamp column arriving as a delta no longer corrupts the field: the ISO spelling ajson wrote (2024-01-15, 12:30:45, 2024-01-15T12:30:45Z) is parsed back, as the whole-attribute path always did
+* set_session_stateful over a nav_app_call hop: the switch compares against the state the request started in instead of toggling per app container, so two apps switching on in one roundtrip no longer leave a sticky app without a stateful session (next click: NO_DRAFT_ENTRY 500)
+* An anonymous elementary data reference (CREATE DATA mr TYPE string) bound via mr->* survives the draft save; it used to be cleared and never restored
+* _bind( omit_initial ) also omits an initial packed field with decimals (0.00) and an initial float (0.0E+00)
+* url_param_get / url_param_get_tab: only the sap-startup-params value is percent-decoded (an encoded & or = inside any other value stays that value's own), and a literal ? inside a value no longer cuts away the parameters before it
+* z2ui5_cl_ui5_json=>get_boolean answers abap_true only for a JSON boolean true, as documented (a number or a string used to read as true)
+* MultiInputExt: a pick from plain suggestionItems makes its Token again (it used to be routed through the row validator and vanished)
+* UITableExt: the column filter row is restored after a view rebuild on UI5 >= 1.96 as well (getFilters was asked for the Application filters, the column filter is a Control filter)
+* App-owned hash routing: a Back/Forward that lands while a roundtrip is in flight is delivered once the roundtrip landed, instead of being dropped by the busy guard for good
+* A backend timer tick that fires while a roundtrip is in flight waits for it instead of aborting it (Server.readHttp treats the newer request as superseding, and the user's action was lost silently)
+* The controller liveness guards (timers, shortcuts, variant polls, the render phase) use a real test - membership in the current app state - instead of isDestroyed( ), which no sap.ui.core.mvc.Controller ever answers; the old guards were dead code and a variant poll chain could resolve the next app's controls after an FLP teardown
 
 
 2026-08-30 v1.144.0

--- a/node/tests/actionRunner.spec.js
+++ b/node/tests/actionRunner.spec.js
@@ -26,7 +26,11 @@ function loadFrontendAction(deps = {}) {
       "z2ui5/core/actions/Variants": noHandlers,
       "z2ui5/core/actions/Shortcuts": noHandlers,
       "z2ui5/core/actions/ViewOps": noHandlers,
-      "z2ui5/core/Lib": { logError: () => {}, runCallbacks: () => {} },
+      "z2ui5/core/Lib": {
+        logError: () => {},
+        runCallbacks: () => {},
+        isControllerAlive: () => true,
+      },
       "z2ui5/core/AppState": { state: { onBeforeEventFrontend: [] } },
       ...deps,
     },

--- a/node/tests/frontendAction.spec.js
+++ b/node/tests/frontendAction.spec.js
@@ -49,6 +49,9 @@ function load({ sandbox, requires = {} } = {}) {
     toText: (val) => (val == null ? "" : String(val)),
     whenRendered: (_control, _owner, fn) => fn(),
     isDestroyed: (o) => Boolean(o?.isDestroyed && o.isDestroyed()),
+    // the controller fixtures answer their own liveness (see START_TIMER);
+    // the many specs that pass no controller at all run as "alive"
+    isControllerAlive: (o) => !(o?.isDestroyed && o.isDestroyed()),
     // same shape as the real validator (core/Lib.js): empty and malformed
     // values are unsafe, data:/blob:/http(s) pass - relative URLs resolve
     isSafeDownloadURL: (url) => {
@@ -2508,6 +2511,46 @@ test.describe("START_TIMER (backend timer liveness)", () => {
     destroyed = true;
     timers[1].fn();
     expect(ebCalls).toHaveLength(1);
+    expect(AppState.state.timers).toEqual({});
+  });
+
+  test("a tick during a roundtrip waits for it instead of superseding it", () => {
+    // a background eB while a request is in flight makes Server.readHttp
+    // abort that request (newest wins) - the user's action was lost without
+    // feedback. The tick re-arms itself into the same slot until the
+    // roundtrip has landed, so the poll chain survives AND the request does
+    const timers = [];
+    const { FrontendAction, AppState } = load({
+      sandbox: {
+        setTimeout: (fn, ms) => {
+          timers.push({ fn, ms });
+          return timers.length;
+        },
+        clearTimeout: () => {},
+      },
+    });
+    AppState.state.timers = {};
+    const ebCalls = [];
+    const oController = { eB: (a) => ebCalls.push(a) };
+
+    FrontendAction.execute(oController, ["START_TIMER", "POLL", "1000"]);
+    AppState.state.isBusy = true;
+    timers[0].fn();
+    // not dispatched, re-armed with a short retry, slot still occupied
+    expect(ebCalls).toEqual([]);
+    expect(timers).toHaveLength(2);
+    expect(timers[1].ms).toBeLessThan(1000);
+    expect(AppState.state.timers).toEqual({ START_TIMER: 2 });
+
+    // still busy: keeps waiting
+    timers[1].fn();
+    expect(ebCalls).toEqual([]);
+    expect(timers).toHaveLength(3);
+
+    // the roundtrip landed: the next retry dispatches as a background event
+    AppState.state.isBusy = false;
+    timers[2].fn();
+    expect(ebCalls).toEqual([["POLL", false, true]]);
     expect(AppState.state.timers).toEqual({});
   });
 });

--- a/node/tests/multiInputExt.spec.js
+++ b/node/tests/multiInputExt.spec.js
@@ -186,6 +186,44 @@ test("an unconfigured instance makes NO token from a suggestion row", () => {
   ).toBe(null);
 });
 
+// a plain suggestionItems pick: MultiInput hands the sap.ui.core.Item over
+// as suggestionObject TOGETHER with the Token it built from key and text
+const suggestionItem = (key, text) => ({ getKey: () => key, getText: () => text });
+
+test("a plain suggestionItems pick returns the Token MultiInput built", () => {
+  const target = inputStub();
+  const { makeInstance, Token } = load({ input: target });
+  const inst = makeInstance();
+  inst.setControl();
+
+  // it used to be routed through tokenFromRow like a row and came back
+  // null: no token, no change event, the pick vanished
+  const built = new Token({ key: "HT-1000", text: "Notebook" });
+  const created = target.validators[0]({
+    text: "Note",
+    suggestedToken: built,
+    suggestionObject: suggestionItem("HT-1000", "Notebook"),
+  });
+
+  expect(created).toBe(built);
+});
+
+test("a plain pick without a prebuilt Token is built from the item", () => {
+  const target = inputStub();
+  const { makeInstance, Token } = load({ input: target });
+  const inst = makeInstance();
+  inst.setControl();
+
+  const created = target.validators[0]({
+    text: "Note",
+    suggestionObject: suggestionItem("HT-1000", "Notebook"),
+  });
+
+  expect(created).toBeInstanceOf(Token);
+  expect(created.key).toBe("HT-1000");
+  expect(created.text).toBe("Notebook");
+});
+
 test("TokenKeyCell alone makes a Token keyed and titled by that cell", () => {
   const target = inputStub();
   const { makeInstance, Token } = load({ input: target });

--- a/node/tests/router.spec.js
+++ b/node/tests/router.spec.js
@@ -62,7 +62,7 @@ function loadRouter({ state: stateOverrides = {}, hash = "", href } = {}) {
       "z2ui5/core/AppState": { state },
       "z2ui5/core/Lib": {
         logError: (msg, e) => errors.push({ msg, e }),
-        isDestroyed: (o) => !!(o && o.destroyed),
+        isControllerAlive: (o) => !!(o && !o.destroyed),
       },
     },
     sandbox: {
@@ -488,6 +488,38 @@ test("the listener fires on a foreign hash change and swallows its own echo", ()
   // browser Forward to the pushed entry again
   Router.onHashChanged("/Page2");
   expect(fired).toEqual([["HASH_CHANGED"], ["HASH_CHANGED"]]);
+});
+
+test("a hash change during a roundtrip is parked and delivered when it lands", () => {
+  // the busy guard in View1.eB drops an ordinary event while a roundtrip is
+  // in flight; the hash used to be adopted BEFORE the dispatch, so Back
+  // during a click left the URL on Page2 and the app on Page1 for good
+  const { Router, state } = loadRouter({ state: { navRouting: false } });
+  const fired = [];
+  state.oController = { eB: (a) => fired.push(a) };
+  Router.sync({ setHashEvent: "HASH_CHANGED", id: "D1" });
+  state.isBusy = true;
+  Router.onHashChanged("/Page2");
+  expect(fired).toEqual([]);
+  expect(state.appHash).toBe("");
+  expect(state.pendingAppHash).toBe("/Page2");
+  // a second change while still busy replaces the first - the browser is
+  // standing on the second one
+  Router.onHashChanged("/Page3");
+  expect(state.pendingAppHash).toBe("/Page3");
+  // nothing to deliver while still busy
+  Router.dispatchPendingAppHash();
+  expect(fired).toEqual([]);
+  expect(state.pendingAppHash).toBe("/Page3");
+  // the roundtrip landed (View1 calls this from its finally)
+  state.isBusy = false;
+  Router.dispatchPendingAppHash();
+  expect(fired).toEqual([["HASH_CHANGED"]]);
+  expect(state.appHash).toBe("/Page3");
+  expect(state.pendingAppHash).toBe(null);
+  // idempotent - a second delivery finds nothing parked
+  Router.dispatchPendingAppHash();
+  expect(fired).toEqual([["HASH_CHANGED"]]);
 });
 
 test("a hash listener keeps the per-response cleanup off the hash", () => {

--- a/node/tests/uiTableExt.spec.js
+++ b/node/tests/uiTableExt.spec.js
@@ -108,7 +108,11 @@ function makeBinding({ filters = [], sorters = [] } = {}) {
   const calls = { filter: 0, sort: 0, lastFilters: null, lastSorters: null };
   return {
     aSorters: sorters,
-    getFilters: () => filters,
+    // the real ListBinding answers the CONTROL filters (what the column
+    // filter row applies) only for "Control"; "Application" is the app's own
+    // binding filters, which the fixture leaves empty - asking for the wrong
+    // type reads [] and restores nothing after a rebuild
+    getFilters: (type) => (type === "Control" ? filters : []),
     filter(f) {
       calls.filter++;
       calls.lastFilters = f;
@@ -167,6 +171,31 @@ test.describe("filter preservation across a binding rebuild", () => {
     ]);
     expect(col.state.filterValue).toBe("Bob");
     expect(col.state.filtered).toBe(true);
+  });
+
+  test("reads the CONTROL filters - the ones the column filter row applies", () => {
+    // sap.ui.table.Column.filter( ) applies the row as FilterType.Control;
+    // "Application" (what was asked for) answers the app's binding filters,
+    // so on every release with getFilters (>= 1.96) nothing was restored
+    const env = load();
+    const ext = makeExt(env);
+    const col = makeColumn("NAME");
+    const asked = [];
+    const b0 = makeBinding();
+    b0.getFilters = (type) => {
+      asked.push(type);
+      return type === "Control"
+        ? [{ sPath: "NAME", sOperator: "EQ", oValue1: "Bob" }]
+        : [{ sPath: "APP", sOperator: "EQ", oValue1: "own" }];
+    };
+    env.setTable(makeTable(b0, [col]));
+
+    ext.readFilter();
+
+    expect(asked).toEqual(["Control"]);
+    expect(ext.aFilters).toEqual([
+      { sPath: "NAME", sOperator: "EQ", oValue1: "Bob" },
+    ]);
   });
 
   const displayCases = [

--- a/node/tests/utilHelpers.spec.js
+++ b/node/tests/utilHelpers.spec.js
@@ -8,6 +8,35 @@ const { loadLib } = require("./loadLibModule");
 
 const ORIGIN = "http://localhost:3000";
 
+test.describe("isControllerAlive (slot-controller liveness)", () => {
+  test("alive while the current state owns the controller, dead after a reset", () => {
+    // a sap.ui.core.mvc.Controller carries no destroyed flag on any release
+    // and the slot controllers are never destroyed - the one thing that ends
+    // their life is AppState.reset( ), which drops them from the state
+    const main = { eB() {} };
+    const popup = { eB() {} };
+    const state = { oController: main, oControllerPopup: popup };
+    const { Lib } = loadLib({ z2ui5: state });
+    expect(Lib.isControllerAlive(main)).toBe(true);
+    expect(Lib.isControllerAlive(popup)).toBe(true);
+    // a stray object that only LOOKS like a controller is not alive
+    expect(Lib.isControllerAlive({ eB() {} })).toBe(false);
+    expect(Lib.isControllerAlive(null)).toBe(false);
+    expect(Lib.isControllerAlive(undefined)).toBe(false);
+    // FLP teardown / re-launch: a fresh set is registered, the old one is dead
+    state.oController = { eB() {} };
+    state.oControllerPopup = null;
+    expect(Lib.isControllerAlive(main)).toBe(false);
+    expect(Lib.isControllerAlive(popup)).toBe(false);
+    expect(Lib.isControllerAlive(state.oController)).toBe(true);
+  });
+
+  test("isDestroyed cannot tell - a controller without any flag reads alive", () => {
+    const { Lib } = loadLib();
+    expect(Lib.isDestroyed({ eB() {} })).toBe(false);
+  });
+});
+
 test.describe("isDestroyed (async-continuation guard, 1.71 floor)", () => {
   const { Lib } = loadLib();
 

--- a/node/tests/view1Events.spec.js
+++ b/node/tests/view1Events.spec.js
@@ -193,6 +193,7 @@ test.describe("_processAfterRendering (action-free responses)", () => {
         "z2ui5/core/Server": { _requestSeq: 1, responseError: () => {} },
         "z2ui5/core/Lib": {
           isDestroyed: () => false,
+          isControllerAlive: () => true,
           runCallbacks: (arr) => (arr || []).forEach((f) => f()),
           logError: () => {},
         },
@@ -202,7 +203,10 @@ test.describe("_processAfterRendering (action-free responses)", () => {
         },
         "z2ui5/core/actions/Slots": { action: (method) => pushes.push(method) },
         "z2ui5/core/ViewSlots": { destroy: (key) => destroys.push(key) },
-        "z2ui5/core/Router": { sync: (o) => syncs.push(o) },
+        "z2ui5/core/Router": {
+          sync: (o) => syncs.push(o),
+          dispatchPendingAppHash: () => {},
+        },
         "z2ui5/core/AppState": { state },
       },
     });

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
@@ -57,7 +57,18 @@ CLASS z2ui5_cl_ui5_util_context DEFINITION
 
     CLASS-DATA cv_typedescr_typekind_struct2 TYPE c LENGTH 1 READ-ONLY.
 
+    " the three elementary kinds whose JSON form is not their ABAP form (ISO
+    " date/time strings, ISO timestamps) - what a delta cell must convert
+    " before assigning (see z2ui5_cl_ui5_srv_model=>delta_apply_scalar)
+    CLASS-DATA cv_typedescr_typekind_date    TYPE c LENGTH 1 READ-ONLY.
+
+    CLASS-DATA cv_typedescr_typekind_time    TYPE c LENGTH 1 READ-ONLY.
+
+    CLASS-DATA cv_typedescr_typekind_packed  TYPE c LENGTH 1 READ-ONLY.
+
     CLASS-DATA cv_typedescr_kind_struct      TYPE c LENGTH 1 READ-ONLY.
+
+    CLASS-DATA cv_typedescr_kind_elem        TYPE c LENGTH 1 READ-ONLY.
 
     CLASS-DATA cv_typedescr_kind_ref         TYPE c LENGTH 1 READ-ONLY.
 
@@ -777,7 +788,11 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
     cv_typedescr_typekind_oref       = cl_abap_typedescr=>typekind_oref.
     cv_typedescr_typekind_struct1    = cl_abap_typedescr=>typekind_struct1.
     cv_typedescr_typekind_struct2    = cl_abap_typedescr=>typekind_struct2.
+    cv_typedescr_typekind_date       = cl_abap_typedescr=>typekind_date.
+    cv_typedescr_typekind_time       = cl_abap_typedescr=>typekind_time.
+    cv_typedescr_typekind_packed     = cl_abap_typedescr=>typekind_packed.
     cv_typedescr_kind_struct         = cl_abap_typedescr=>kind_struct.
+    cv_typedescr_kind_elem           = cl_abap_typedescr=>kind_elem.
     cv_typedescr_kind_ref            = cl_abap_typedescr=>kind_ref.
     cv_objectdescr_public            = cl_abap_objectdescr=>public.
 
@@ -1269,36 +1284,46 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
 
   METHOD url_param_get_tab.
 
-    DATA(lv_search) = replace( val  = val
-                               sub  = `%3D`
-                               with = `=`
-                               occ  = 0 ).
+    " a full URL or a request URI carries a path before its query: cut at
+    " the FIRST `?` only. A later `?` is a legal, unencoded character of a
+    " value (`title=why?`) - cutting there dropped every parameter before
+    " it, app_start included, and the shell fell back to the start page
+    DATA(lv_search) = val.
+    IF lv_search CS `?`.
+      lv_search = substring_after( val = lv_search
+                                   sub = `?` ).
+    ENDIF.
 
-    " RFC 3986 allows lowercase hex digits in percent-encodings, so decode
-    " %3d the same way as %3D (%26 contains no letters and needs no twin)
-    lv_search = replace( val  = lv_search
-                         sub  = `%3d`
-                         with = `=`
-                         occ  = 0 ).
-
-    lv_search = replace( val  = lv_search
-                         sub  = `%26`
-                         with = `&`
-                         occ  = 0 ).
-
-    lv_search = shift_left( val = lv_search
-                            sub = `?` ).
-
-    " prepend & before searching so sap-startup-params is also unwrapped
-    " when it is the first/only query parameter (typical FLP target mapping)
-    DATA(lv_search2) = substring_after( val = |&{ lv_search }|
+    " The FLP packs the target's own parameters into ONE value,
+    " sap-startup-params, with its `=` and `&` percent-encoded. Prepend &
+    " before searching so it is also unwrapped when it is the first/only
+    " query parameter (typical FLP target mapping). Only THAT value is
+    " decoded: decoding the whole query first tore every legitimately
+    " encoded `&` or `=` in any other value apart (`a=x%26y` became the
+    " two parameters a=x and y=), and app_get_url wrote the damage back
+    " into every generated link
+    DATA(lv_startup) = substring_after( val = |&{ lv_search }|
                                         sub = `&sap-startup-params=` ).
-    lv_search = COND #( WHEN lv_search2 IS NOT INITIAL THEN lv_search2 ELSE lv_search ).
-
-    lv_search2 = substring_after( val = lv_search
-                                  sub = `?` ).
-    IF lv_search2 IS NOT INITIAL.
-      lv_search = lv_search2.
+    IF lv_startup IS NOT INITIAL.
+      SPLIT lv_startup AT `&` INTO DATA(lv_packed) DATA(lv_rest).
+      lv_packed = replace( val  = lv_packed
+                           sub  = `%3D`
+                           with = `=`
+                           occ  = 0 ).
+      " RFC 3986 allows lowercase hex digits in percent-encodings, so decode
+      " %3d the same way as %3D (%26 contains no letters and needs no twin)
+      lv_packed = replace( val  = lv_packed
+                           sub  = `%3d`
+                           with = `=`
+                           occ  = 0 ).
+      lv_packed = replace( val  = lv_packed
+                           sub  = `%26`
+                           with = `&`
+                           occ  = 0 ).
+      lv_search = lv_packed.
+      IF lv_rest IS NOT INITIAL.
+        lv_search = |{ lv_packed }&{ lv_rest }|.
+      ENDIF.
     ENDIF.
 
     SPLIT lv_search AT `&` INTO TABLE DATA(lt_param).

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
@@ -13,6 +13,9 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_url_param_case       FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_no_phantom FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_startup    FOR TESTING RAISING cx_static_check.
+    METHODS test_url_param_encoded    FOR TESTING RAISING cx_static_check.
+    METHODS test_url_param_question   FOR TESTING RAISING cx_static_check.
+    METHODS test_url_param_full_url   FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -134,6 +137,56 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = 1
         act = lines( z2ui5_cl_ui5_util_context=>url_param_get_tab( `?a=1&` ) ) ).
+
+  ENDMETHOD.
+
+  METHOD test_url_param_encoded.
+
+    " a percent-encoded & or = inside a value is that value's own - only
+    " the sap-startup-params wrapper is decoded, nothing else is split
+    DATA(lt_params) = z2ui5_cl_ui5_util_context=>url_param_get_tab( `?a=x%26y&b=1%3D2` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 2
+                                        act = lines( lt_params ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `x%26y`
+                                        act = lt_params[ n = `a` ]-v ).
+    cl_abap_unit_assert=>assert_equals( exp = `1%3D2`
+                                        act = lt_params[ n = `b` ]-v ).
+
+    " ...and a parameter AFTER the wrapper is still a parameter of its own
+    lt_params = z2ui5_cl_ui5_util_context=>url_param_get_tab(
+                    `?sap-startup-params=app_start%3Dfoo%26x%3D1&sap-ui-theme=dark` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `foo`
+                                        act = lt_params[ n = `app_start` ]-v ).
+    cl_abap_unit_assert=>assert_equals( exp = `1`
+                                        act = lt_params[ n = `x` ]-v ).
+    cl_abap_unit_assert=>assert_equals( exp = `dark`
+                                        act = lt_params[ n = `sap-ui-theme` ]-v ).
+
+  ENDMETHOD.
+
+  METHOD test_url_param_question.
+
+    " a literal ? in a value is legal and left unencoded by browsers - it
+    " must not cut away the parameters before it
+    DATA(lt_params) = z2ui5_cl_ui5_util_context=>url_param_get_tab( `?app_start=zcl_x&title=why?` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `zcl_x`
+                                        act = lt_params[ n = `app_start` ]-v ).
+    cl_abap_unit_assert=>assert_equals( exp = `why?`
+                                        act = lt_params[ n = `title` ]-v ).
+
+  ENDMETHOD.
+
+  METHOD test_url_param_full_url.
+
+    " a request URI / full URL: the path before the query is not a parameter
+    cl_abap_unit_assert=>assert_equals(
+        exp = `zcl_x`
+        act = z2ui5_cl_ui5_util_context=>url_param_get(
+                  val = `app_start`
+                  url = `/sap/bc/z2ui5?app_start=zcl_x&b=2` ) ).
 
   ENDMETHOD.
 

--- a/src/00/03/z2ui5_cl_ui5_util_json_fl.clas.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_json_fl.clas.abap
@@ -34,7 +34,9 @@ CLASS z2ui5_cl_ui5_util_json_fl IMPLEMENTATION.
           WHEN z2ui5_if_ajson_types=>node_type-boolean.
             rv_keep = xsdbool( is_node-value <> `false` ).
           WHEN z2ui5_if_ajson_types=>node_type-number.
-            rv_keep = xsdbool( is_node-value <> `0` ).
+            " every spelling of zero (`0`, `0.00`, `0.0E+00`) is empty - see
+            " lcl_empty_filter_keep_rows in z2ui5_cl_ui5_client
+            rv_keep = xsdbool( is_node-value CN `0.-+Ee` ).
           WHEN z2ui5_if_ajson_types=>node_type-string.
             rv_keep = xsdbool( is_node-value <> `` ).
         ENDCASE.

--- a/src/00/03/z2ui5_cl_ui5_util_json_fl.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_json_fl.clas.testclasses.abap
@@ -22,6 +22,8 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_drops_empty_string   FOR TESTING RAISING cx_static_check.
     METHODS test_keeps_number         FOR TESTING RAISING cx_static_check.
     METHODS test_drops_zero           FOR TESTING RAISING cx_static_check.
+    METHODS test_drops_zero_decimals  FOR TESTING RAISING cx_static_check.
+    METHODS test_keeps_small_number   FOR TESTING RAISING cx_static_check.
     METHODS test_keeps_true           FOR TESTING RAISING cx_static_check.
     METHODS test_drops_false          FOR TESTING RAISING cx_static_check.
     METHODS test_keeps_filled_object  FOR TESTING RAISING cx_static_check.
@@ -80,6 +82,26 @@ CLASS ltcl_test IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_false( keep_node( iv_type  = z2ui5_if_ajson_types=>node_type-number
                                                   iv_value = `0` ) ).
+
+  ENDMETHOD.
+
+  METHOD test_drops_zero_decimals.
+
+    " a packed field with decimals and a float serialize their zero with a
+    " fraction / an exponent - still initial
+    cl_abap_unit_assert=>assert_false( keep_node( iv_type  = z2ui5_if_ajson_types=>node_type-number
+                                                  iv_value = `0.00` ) ).
+    cl_abap_unit_assert=>assert_false( keep_node( iv_type  = z2ui5_if_ajson_types=>node_type-number
+                                                  iv_value = `0.0E+00` ) ).
+
+  ENDMETHOD.
+
+  METHOD test_keeps_small_number.
+
+    cl_abap_unit_assert=>assert_true( keep_node( iv_type  = z2ui5_if_ajson_types=>node_type-number
+                                                 iv_value = `0.01` ) ).
+    cl_abap_unit_assert=>assert_true( keep_node( iv_type  = z2ui5_if_ajson_types=>node_type-number
+                                                 iv_value = `-1` ) ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_action.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_action.clas.abap
@@ -6,6 +6,13 @@ CLASS z2ui5_cl_ui5_action DEFINITION PUBLIC FINAL.
 
     DATA ms_actual  TYPE z2ui5_if_ui5_types=>ty_s_actual.
     DATA ms_next    TYPE z2ui5_if_ui5_types=>ty_s_next.
+    " the sticky state the REQUEST started in - what set_session_stateful
+    " compares the end state against. It is a property of the request, not
+    " of an app container: a nav hop builds a fresh container (mv_check_sticky
+    " abap_false) while the ICF session is still whatever it was, so the
+    " value is taken from the container the request began with and carried
+    " through prepare_app_stack like the switch itself
+    DATA mv_check_sticky_start TYPE abap_bool.
 
     METHODS factory_system_startup
       RETURNING
@@ -63,6 +70,7 @@ CLASS z2ui5_cl_ui5_action IMPLEMENTATION.
 
     result->mo_app->ms_draft-id      = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
     result->mo_app->ms_draft-id_prev = mo_handler->ms_request-s_front-id.
+    result->mv_check_sticky_start    = result->mo_app->mv_check_sticky.
 
     IF mo_handler->ms_request-o_model->is_empty( ) = abap_false.
       " what the delta could not convert travels on the action, not on the
@@ -88,6 +96,7 @@ CLASS z2ui5_cl_ui5_action IMPLEMENTATION.
           TRY.
 
               result->mo_app = z2ui5_cl_ui5_app_cont=>db_load( mo_handler->ms_request-s_control-app_start_draft ).
+              result->mv_check_sticky_start = result->mo_app->mv_check_sticky.
               result->ms_actual-check_on_navigated = abap_true.
               result->ms_next-s_nav-set_app_state_active = abap_true.
               " on the app as well, not only on this request: ms_next is
@@ -275,6 +284,7 @@ CLASS z2ui5_cl_ui5_action IMPLEMENTATION.
     " leak it into the called app's response
     CLEAR result->ms_next-s_nav-set_nav_routing.
     result->ms_next-s_stateful = ms_next-s_stateful.
+    result->mv_check_sticky_start = mv_check_sticky_start.
 
     IF ms_next-next_event IS NOT INITIAL.
       result->ms_actual-event = ms_next-next_event.

--- a/src/01/02/z2ui5_cl_ui5_action.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_action.clas.testclasses.abap
@@ -40,6 +40,9 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_nav_mode_inherited FOR TESTING RAISING cx_static_check.
     METHODS test_nav_mode_own_wins  FOR TESTING RAISING cx_static_check.
     METHODS test_hop_clears_routing_req FOR TESTING RAISING cx_static_check.
+    METHODS test_stateful_across_hop FOR TESTING RAISING cx_static_check.
+    METHODS test_stateful_cancels_out FOR TESTING RAISING cx_static_check.
+    METHODS test_stateful_start_sticky FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS z2ui5_cl_ui5_action DEFINITION LOCAL FRIENDS ltcl_test.
@@ -293,6 +296,91 @@ CLASS ltcl_test IMPLEMENTATION.
     lo_called = lo_own->factory_stack_call( ).
 
     cl_abap_unit_assert=>assert_initial( lo_called->mo_app->mv_nav_mode ).
+
+  ENDMETHOD.
+
+  METHOD test_stateful_across_hop.
+    DATA lo_http TYPE REF TO z2ui5_cl_ui5_handler.
+    DATA lo_action TYPE REF TO z2ui5_cl_ui5_action.
+    DATA lo_called TYPE REF TO z2ui5_cl_ui5_action.
+
+    " app A switches the session stateful and calls B in the same roundtrip,
+    " and B (the "stateful app" template) switches it on as well. The end
+    " state differs from the start state, so the response must carry the
+    " switch - B runs in a FRESH container, and a per-container toggle used
+    " to flip back to abap_false here (then B was sticky without a stateful
+    " session: no draft saved, next click NO_DRAFT_ENTRY)
+    lo_http = NEW #( val = `` ).
+    lo_action = NEW #( val = lo_http ).
+    lo_action->mo_app->mo_app      = NEW ltcl_test_app( ).
+    lo_action->mo_app->ms_draft-id = `CURRENT_DRAFT`.
+
+    NEW z2ui5_cl_ui5_client( action = lo_action )->z2ui5_if_client~set_session_stateful( abap_true ).
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_action->ms_next-s_stateful-switched ).
+
+    lo_action->ms_next-o_app_call = NEW ltcl_test_app( ).
+    lo_called = lo_action->factory_stack_call( ).
+
+    NEW z2ui5_cl_ui5_client( action = lo_called )->z2ui5_if_client~set_session_stateful( abap_true ).
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_called->ms_next-s_stateful-switched ).
+    cl_abap_unit_assert=>assert_equals( exp = 1
+                                        act = lo_called->ms_next-s_stateful-active ).
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_called->mo_app->mv_check_sticky ).
+
+  ENDMETHOD.
+
+  METHOD test_stateful_cancels_out.
+    DATA lo_http TYPE REF TO z2ui5_cl_ui5_handler.
+    DATA lo_action TYPE REF TO z2ui5_cl_ui5_action.
+    DATA lo_client TYPE REF TO z2ui5_cl_ui5_client.
+
+    " on, then off in one roundtrip: the end state equals the start state,
+    " so nothing is switched and the server call is skipped
+    lo_http = NEW #( val = `` ).
+    lo_action = NEW #( val = lo_http ).
+    lo_action->mo_app->mo_app = NEW ltcl_test_app( ).
+    lo_client = NEW #( action = lo_action ).
+
+    lo_client->z2ui5_if_client~set_session_stateful( abap_true ).
+    lo_client->z2ui5_if_client~set_session_stateful( abap_false ).
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_false
+                                        act = lo_action->ms_next-s_stateful-switched ).
+    cl_abap_unit_assert=>assert_equals( exp = 0
+                                        act = lo_action->ms_next-s_stateful-active ).
+
+  ENDMETHOD.
+
+  METHOD test_stateful_start_sticky.
+    DATA lo_http TYPE REF TO z2ui5_cl_ui5_handler.
+    DATA lo_action TYPE REF TO z2ui5_cl_ui5_action.
+    DATA lo_client TYPE REF TO z2ui5_cl_ui5_client.
+
+    " a request that began in a stateful session (the sticky handler's
+    " container): switching off is a change, switching back on is not
+    lo_http = NEW #( val = `` ).
+    lo_action = NEW #( val = lo_http ).
+    lo_action->mo_app->mo_app          = NEW ltcl_test_app( ).
+    lo_action->mo_app->mv_check_sticky = abap_true.
+    lo_action->mv_check_sticky_start   = abap_true.
+    lo_client = NEW #( action = lo_action ).
+
+    lo_client->z2ui5_if_client~set_session_stateful( abap_false ).
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_true
+                                        act = lo_action->ms_next-s_stateful-switched ).
+    cl_abap_unit_assert=>assert_equals( exp = 0
+                                        act = lo_action->ms_next-s_stateful-active ).
+
+    lo_client->z2ui5_if_client~set_session_stateful( abap_true ).
+
+    cl_abap_unit_assert=>assert_equals( exp = abap_false
+                                        act = lo_action->ms_next-s_stateful-switched ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_client.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_client.clas.abap
@@ -639,14 +639,18 @@ CLASS z2ui5_cl_ui5_client IMPLEMENTATION.
     mo_action->ms_next-s_stateful-active = COND #( WHEN val = abap_true THEN 1 ELSE 0 ).
     mo_action->mo_app->mv_check_sticky = val.
 
-    " a TOGGLE on purpose, not `= abap_true`: switched says "the state at the
-    " END of this roundtrip differs from the state at its start". Two calls
-    " in one roundtrip (on, then off - the early RETURN above lets only real
-    " changes through) cancel out to abap_false, and
-    " z2ui5_cl_ui5_http_handler=>set_response then skips its
-    " set_session_stateful call entirely - while `active` always carries the
-    " final state for the roundtrips where switched stays abap_true
-    mo_action->ms_next-s_stateful-switched = xsdbool( mo_action->ms_next-s_stateful-switched = abap_false ).
+    " switched says "the state at the END of this roundtrip differs from the
+    " state at its START", and z2ui5_cl_ui5_http_handler=>set_response calls
+    " the server's set_session_stateful only then - while `active` always
+    " carries the final state. Two calls in one roundtrip (on, then off)
+    " cancel out to abap_false. The start state is the REQUEST's
+    " (mv_check_sticky_start), not this container's: it used to be a toggle
+    " guarded by the container's own mv_check_sticky, and over a nav hop the
+    " called app runs in a fresh container, so app A switching on and app B
+    " switching on in the same roundtrip toggled back to abap_false - the
+    " session never went stateful, B was still marked sticky, its draft was
+    " never saved, and the next click was a NO_DRAFT_ENTRY 500
+    mo_action->ms_next-s_stateful-switched = xsdbool( val <> mo_action->mv_check_sticky_start ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_client.clas.locals_imp.abap
+++ b/src/01/02/z2ui5_cl_ui5_client.clas.locals_imp.abap
@@ -47,7 +47,12 @@ CLASS lcl_empty_filter_keep_rows IMPLEMENTATION.
     " everything below mirrors the vendored lcl_empty_filter
     IF iv_visit = z2ui5_if_ajson_filter=>visit_type-value.
       IF is_node-type = z2ui5_if_ajson_types=>node_type-number.
-        rv_keep = xsdbool( is_node-value <> `0` ).
+        " any spelling of a numeric zero is initial - ajson writes a packed
+        " field with decimals as `0.00` and a float as `0.0E+00` (both are
+        " |{ value }|), and a plain compare against `0` kept exactly the
+        " "price" column omit_initial is documented for. CN: the value holds
+        " a character that is not one of these, i.e. a non-zero digit
+        rv_keep = xsdbool( is_node-value CN `0.-+Ee` ).
       ELSE.
         " string & bool & null
         rv_keep = xsdbool( is_node-value IS NOT INITIAL ).
@@ -136,7 +141,12 @@ CLASS lcl_initial_paths_filter IMPLEMENTATION.
     ENDIF.
 
     IF is_node-type = z2ui5_if_ajson_types=>node_type-number.
-      rv_keep = xsdbool( is_node-value <> `0` ).
+      " any spelling of a numeric zero is initial - ajson writes a packed
+      " field with decimals as `0.00` and a float as `0.0E+00` (both are
+      " |{ value }|), and a plain compare against `0` kept exactly the
+      " "price" column omit_initial is documented for. CN: the value holds
+      " a character that is not one of these, i.e. a non-zero digit
+      rv_keep = xsdbool( is_node-value CN `0.-+Ee` ).
     ELSE.
       rv_keep = xsdbool( is_node-value IS NOT INITIAL ).
     ENDIF.

--- a/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
@@ -106,6 +106,7 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_set_app_state_active FOR TESTING RAISING cx_static_check.
     METHODS test_omit_initial_paths   FOR TESTING RAISING cx_static_check.
     METHODS test_omit_initial_keeps_rows FOR TESTING RAISING cx_static_check.
+    METHODS test_omit_initial_decimals FOR TESTING RAISING cx_static_check.
     METHODS test_omit_filters_serial  FOR TESTING RAISING cx_static_check.
     METHODS test_bind_filter_not_serial FOR TESTING RAISING cx_static_check.
     METHODS test_omit_initial_db_save FOR TESTING RAISING cx_static_check.
@@ -1121,6 +1122,42 @@ CLASS ltcl_test_client IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD test_omit_initial_decimals.
+
+    " the "price" column the parameter is documented for: an initial
+    " p DECIMALS serializes as 0.00 and was kept by a compare against `0`
+    TYPES:
+      BEGIN OF ty_s_row,
+        name   TYPE string,
+        price  TYPE p LENGTH 9 DECIMALS 2,
+        weight TYPE f,
+        count  TYPE i,
+      END OF ty_s_row.
+
+    DATA(ls_row) = VALUE ty_s_row( name = `A` ).
+
+    DATA(lo_ajson) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty( ) ).
+    lo_ajson->set( iv_ignore_empty = abap_false
+                   iv_path         = `/row`
+                   iv_val          = ls_row ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `{"row":{"name":"A"}}`
+        act = lo_ajson->filter( NEW lcl_empty_filter_keep_rows( ) )->stringify( ) ).
+
+    " a non-zero value in the same spelling survives
+    ls_row-price = '0.01'.
+    lo_ajson = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>create_empty( ) ).
+    lo_ajson->set( iv_ignore_empty = abap_false
+                   iv_path         = `/row`
+                   iv_val          = ls_row ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `{"row":{"name":"A","price":0.01}}`
+        act = lo_ajson->filter( NEW lcl_empty_filter_keep_rows( ) )->stringify( ) ).
+
+  ENDMETHOD.
 
   METHOD test_omit_initial_keeps_rows.
 

--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
@@ -140,6 +140,14 @@ CLASS z2ui5_cl_ui5_srv_model DEFINITION PUBLIC FINAL.
       RAISING
         z2ui5_cx_ajson_error.
 
+    METHODS delta_apply_scalar
+      IMPORTING
+        io_delta TYPE REF TO z2ui5_if_ajson
+        iv_path  TYPE string
+        ir_comp  TYPE REF TO data
+      RAISING
+        z2ui5_cx_ajson_error.
+
 ENDCLASS.
 
 
@@ -452,6 +460,20 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
 
         WHEN z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_struct1 OR z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_struct2.
           lr_attri->srtti_data = z2ui5_cl_ui5_util_context=>xml_srtti_stringify( <val_deref> ).
+
+        WHEN OTHERS.
+          " an ELEMENTARY deref (CREATE DATA mr TYPE string / i / ...) is
+          " neither a table (one dissolved child, above) nor a structure and
+          " used to fall through this CASE: the loop below then cleared the
+          " reference and nothing ever restored it, so a bound `mr->*` was
+          " gone after the first roundtrip - in memory and in the draft.
+          " Same stringify as the struct branch, restored the same way by
+          " main_attri_db_load_resolve. A deref that is itself a reference
+          " is left alone: S-RTTI cannot serialize it, and clearing it is
+          " what happened before
+          IF lo_descr->kind = z2ui5_cl_ui5_util_context=>cv_typedescr_kind_elem.
+            lr_attri->srtti_data = z2ui5_cl_ui5_util_context=>xml_srtti_stringify( <val_deref> ).
+          ENDIF.
 
       ENDCASE.
 
@@ -957,6 +979,55 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD delta_apply_scalar.
+
+    FIELD-SYMBOLS <comp> TYPE any.
+    ASSIGN ir_comp->* TO <comp>.
+
+    " numbers intentionally go through get_string: the raw JSON text
+    " converts losslessly into any numeric target type, while get_number
+    " would round through a binary float first
+    DATA(lv_value) = io_delta->get_string( iv_path ).
+
+    " Outbound, ajson writes a d as `2024-01-15`, a t as `12:30:00` and a
+    " timestamp as `2024-01-15T12:30:00Z` (its own format_date/_time/
+    " _timestamp), and the whole-attribute path (to_abap) parses those
+    " forms back. A delta cell assigned the raw text instead: the c->d
+    " conversion copies the first eight characters WITHOUT validation, so
+    " `2024-01-15` silently became `2024-01-` - no exception, no
+    " t_model_skipped entry, and the next serialization shipped garbage.
+    " Only the ISO spelling is unpacked here; any other text (a plain
+    " `20240115`, an empty cleared value) keeps the direct assignment, so a
+    " cell that never went through ajson's formatting stays as it was.
+    CASE z2ui5_cl_ui5_util_context=>rtti_get_type_kind( <comp> ).
+
+      WHEN z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_date.
+        IF strlen( lv_value ) >= 10 AND lv_value+4(1) = `-` AND lv_value+7(1) = `-`.
+          lv_value = lv_value(4) && lv_value+5(2) && lv_value+8(2).
+        ENDIF.
+
+      WHEN z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_time.
+        IF strlen( lv_value ) >= 8 AND lv_value+2(1) = `:` AND lv_value+5(1) = `:`.
+          lv_value = lv_value(2) && lv_value+3(2) && lv_value+6(2).
+        ENDIF.
+
+      WHEN z2ui5_cl_ui5_util_context=>cv_typedescr_typekind_packed.
+        " a TIMESTAMP/TIMESTAMPL is a packed number on the ABAP side and an
+        " ISO instant on the wire; the `T` at offset 10 is what tells it
+        " from a price. get_timestampl parses both spellings (Z, +hh:mm),
+        " and the p-to-p assignment drops the fraction a short timestamp
+        " does not carry
+        IF strlen( lv_value ) >= 19 AND lv_value+10(1) = `T`.
+          <comp> = io_delta->get_timestampl( iv_path ).
+          RETURN.
+        ENDIF.
+
+    ENDCASE.
+
+    <comp> = lv_value.
+
+  ENDMETHOD.
+
   METHOD delta_apply_field.
 
     FIELD-SYMBOLS <comp> TYPE any.
@@ -1000,10 +1071,9 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
                                                  IMPORTING ev_container     = <comp> ).
 
           WHEN OTHERS.
-            " numbers intentionally go through get_string: the raw JSON text
-            " converts losslessly into any numeric target type, while
-            " get_number would round through a binary float first
-            <comp> = io_delta->get_string( iv_path ).
+            delta_apply_scalar( io_delta = io_delta
+                                iv_path  = iv_path
+                                ir_comp  = ir_comp ).
         ENDCASE.
 
       CATCH cx_root.

--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.testclasses.abap
@@ -559,6 +559,60 @@ CLASS ltcl_test_app_root4 IMPLEMENTATION.
 ENDCLASS.
 
 
+CLASS ltcl_test_app_root5 DEFINITION FINAL
+  FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+
+  PUBLIC SECTION.
+
+    " an anonymous ELEMENTARY data object - CREATE DATA ... TYPE string.
+    " Neither a table nor a structure, so the dref save path used to skip
+    " it and the value was gone after the first db_save
+    DATA mr_value TYPE REF TO data.
+    METHODS test_elem_ref_survives FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_test_app_root5 IMPLEMENTATION.
+
+  METHOD test_elem_ref_survives.
+
+    DATA(lo_app) = NEW ltcl_test_app_root5( ).
+
+    CREATE DATA lo_app->mr_value TYPE string.
+    FIELD-SYMBOLS <value> TYPE string.
+    ASSIGN lo_app->mr_value->* TO <value>.
+    <value> = `abc`.
+
+    DATA(lt_attri) = VALUE z2ui5_if_ui5_types=>ty_t_attri( ).
+    DATA(lo_model) = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                                  app  = lo_app ).
+
+    DATA(ls_attri) = lo_model->main_attri_search( lo_app->mr_value ).
+    cl_abap_unit_assert=>assert_equals( exp = `MR_VALUE->*`
+                                        act = ls_attri->name ).
+
+    lo_model->main_attri_db_save_srtti( ).
+
+    " the reference is detached from the serialization by the save...
+    cl_abap_unit_assert=>assert_not_bound( lo_app->mr_value ).
+
+    " ...and comes back, value and all, on the load into a new instance
+    lo_app = NEW ltcl_test_app_root5( ).
+    lo_model = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                            app  = lo_app ).
+    lo_model->main_attri_db_load( ).
+
+    cl_abap_unit_assert=>assert_bound( lo_app->mr_value ).
+    ASSIGN lo_app->mr_value->* TO <value>.
+    cl_abap_unit_assert=>assert_equals( exp = `abc`
+                                        act = <value> ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
 CLASS ltcl_test_diss_complex DEFINITION DEFERRED.
 CLASS z2ui5_cl_ui5_srv_model DEFINITION LOCAL FRIENDS ltcl_test_diss_complex.
 
@@ -1396,6 +1450,10 @@ CLASS ltcl_app_typed DEFINITION FINAL
         name  TYPE string,
         price TYPE p LENGTH 9 DECIMALS 2,
         t_pos TYPE ty_t_pos,
+        " the three kinds whose wire form is ISO text, not their ABAP form
+        dt    TYPE d,
+        tm    TYPE t,
+        ts    TYPE timestamp,
       END OF ty_s_row.
     TYPES ty_t_tab TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
 
@@ -1423,6 +1481,9 @@ CLASS ltcl_test_delta_apply DEFINITION FINAL
     " the trace of a cell the delta could not apply - see
     " z2ui5_if_client=>ty_s_model_skip
     METHODS test_skip_cell_converts FOR TESTING RAISING cx_static_check.
+    " a d/t/timestamp cell arrives in the ISO spelling ajson wrote it in
+    METHODS test_cell_iso_date_time  FOR TESTING RAISING cx_static_check.
+    METHODS test_cell_plain_date     FOR TESTING RAISING cx_static_check.
     METHODS test_skip_cell_refused  FOR TESTING RAISING cx_static_check.
     METHODS test_skip_one_of_two    FOR TESTING RAISING cx_static_check.
     METHODS test_skip_absent_field  FOR TESTING RAISING cx_static_check.
@@ -1641,6 +1702,62 @@ CLASS ltcl_test_delta_apply IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = CONV decfloat34( '1250.00' )
                                         act = CONV decfloat34( lo_app->mt_tab[ 1 ]-price ) ).
+    cl_abap_unit_assert=>assert_initial( lo_model->mt_skipped ).
+
+  ENDMETHOD.
+
+  METHOD test_cell_iso_date_time.
+
+    DATA(lo_app) = typed_app_create( ).
+    DATA lt_attri TYPE z2ui5_if_ui5_types=>ty_t_attri.
+    DATA(lo_model) = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                                  app  = lo_app ).
+
+    " exactly what the model holds after the outbound serialization - a
+    " DatePicker with valueFormat yyyy-MM-dd edits the value in this form
+    DATA(lo_delta) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>parse(
+        `{"__delta":{"0":{"DT":"2024-01-15","TM":"12:30:45","TS":"2024-01-15T12:30:45Z"}}}` ) ).
+
+    lo_model->delta_apply_to_table( io_val_front = lo_delta
+                                    iv_name      = `MT_TAB` ).
+
+    DATA lv_date TYPE d.
+    lv_date = '20240115'.
+    DATA lv_time TYPE t.
+    lv_time = '123045'.
+    DATA lv_ts TYPE timestamp.
+    lv_ts = '20240115123045'.
+    cl_abap_unit_assert=>assert_equals( exp = lv_date
+                                        act = lo_app->mt_tab[ 1 ]-dt ).
+    cl_abap_unit_assert=>assert_equals( exp = lv_time
+                                        act = lo_app->mt_tab[ 1 ]-tm ).
+    cl_abap_unit_assert=>assert_equals( exp = lv_ts
+                                        act = lo_app->mt_tab[ 1 ]-ts ).
+    cl_abap_unit_assert=>assert_initial( lo_model->mt_skipped ).
+
+  ENDMETHOD.
+
+  METHOD test_cell_plain_date.
+
+    DATA(lo_app) = typed_app_create( ).
+    DATA lt_attri TYPE z2ui5_if_ui5_types=>ty_t_attri.
+    DATA(lo_model) = NEW z2ui5_cl_ui5_srv_model( attri = REF #( lt_attri )
+                                                  app  = lo_app ).
+
+    " a value that never went through ajson's formatting keeps the direct
+    " assignment, and a cleared cell clears the field
+    DATA(lo_delta) = CAST z2ui5_if_ajson( z2ui5_cl_ajson=>parse(
+        `{"__delta":{"0":{"DT":"20240115","TM":""}}}` ) ).
+    lo_app->mt_tab[ 1 ]-tm = '120000'.
+
+    lo_model->delta_apply_to_table( io_val_front = lo_delta
+                                    iv_name      = `MT_TAB` ).
+
+    DATA lv_date TYPE d.
+    lv_date = '20240115'.
+    cl_abap_unit_assert=>assert_equals( exp = lv_date
+                                        act = lo_app->mt_tab[ 1 ]-dt ).
+    cl_abap_unit_assert=>assert_initial( lo_app->mt_tab[ 1 ]-tm ).
     cl_abap_unit_assert=>assert_initial( lo_model->mt_skipped ).
 
   ENDMETHOD.

--- a/src/01/03/z2ui5_cl_ui5f_appstate_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_appstate_js.clas.abap
@@ -62,6 +62,7 @@ CLASS z2ui5_cl_ui5f_appstate_js IMPLEMENTATION.
              `      navFromHash: false,` && |\n| &&
              `      hashEvent: null,` && |\n| &&
              `      appHash: "",` && |\n| &&
+             `      pendingAppHash: null,` && |\n| &&
              `` && |\n| &&
              `      hashPushCount: 0,` && |\n| &&
              `` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_lib_js.clas.abap
@@ -117,6 +117,19 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      if (state.errors.length > MAX_ERRORS) state.errors.shift();` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    const CONTROLLER_FIELDS = [` && |\n| &&
+             `      "oController",` && |\n| &&
+             `      "oControllerNest",` && |\n| &&
+             `      "oControllerNest2",` && |\n| &&
+             `      "oControllerPopup",` && |\n| &&
+             `      "oControllerPopover",` && |\n| &&
+             `    ];` && |\n| &&
+             `    function isControllerAlive(oController) {` && |\n| &&
+             `      if (!oController) return false;` && |\n| &&
+             `      const state = AppState.state;` && |\n| &&
+             `      return CONTROLLER_FIELDS.some((field) => state[field] === oController);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function isDestroyed(obj) {` && |\n| &&
              `      if (!obj) return false;` && |\n| &&
              `` && |\n| &&
@@ -411,7 +424,8 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      for (const key of ROOT_MODEL_SLOTS) {` && |\n| &&
              `        const limit = viewSizeLimits[key];` && |\n| &&
              `        if (limit !== undefined && (max === undefined || limit > max)) {` && |\n| &&
-             `          max = limit;` && |\n| &&
+             `          max = limit;` && |\n|.
+    result = result &&
              `        }` && |\n| &&
              `      }` && |\n| &&
              `      return max;` && |\n| &&
@@ -424,8 +438,7 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      oRm.close("span");` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
-             `    const EMPTY_RENDERER = { apiVersion: 2, render() {} };` && |\n|.
-    result = result &&
+             `    const EMPTY_RENDERER = { apiVersion: 2, render() {} };` && |\n| &&
              `` && |\n| &&
              `    function hookCallback(owner, callbackName, method) {` && |\n| &&
              `      const bound = owner[method].bind(owner);` && |\n| &&
@@ -487,6 +500,7 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `    return {` && |\n| &&
              `      logError,` && |\n| &&
              `      isDestroyed,` && |\n| &&
+             `      isControllerAlive,` && |\n| &&
              `      isAlive,` && |\n| &&
              `      claimOnce,` && |\n| &&
              `      isTextInput,` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_multiinp_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_multiinp_js.clas.abap
@@ -132,8 +132,23 @@ CLASS z2ui5_cl_ui5f_multiinp_js IMPLEMENTATION.
              `          input.attachTokenUpdate(this.onTokenUpdate.bind(this));` && |\n| &&
              `` && |\n| &&
              `          input.addValidator((args) => {` && |\n| &&
-             `            const row = args && args.suggestionObject;` && |\n| &&
-             `            if (row) return this.tokenFromRow(row);` && |\n| &&
+             `            const picked = args && args.suggestionObject;` && |\n| &&
+             `            if (picked && typeof picked.getCells === "function") {` && |\n| &&
+             `              return this.tokenFromRow(picked);` && |\n| &&
+             `            }` && |\n| &&
+             `            if (picked) {` && |\n| &&
+             `              if (args.suggestedToken) return args.suggestedToken;` && |\n| &&
+             `              return new Token({` && |\n| &&
+             `                key:` && |\n| &&
+             `                  typeof picked.getKey === "function"` && |\n| &&
+             `                    ? picked.getKey()` && |\n| &&
+             `                    : args.text,` && |\n| &&
+             `                text:` && |\n| &&
+             `                  typeof picked.getText === "function"` && |\n| &&
+             `                    ? picked.getText()` && |\n| &&
+             `                    : args.text,` && |\n| &&
+             `              });` && |\n| &&
+             `            }` && |\n| &&
              `            return new Token({ key: args.text, text: args.text });` && |\n| &&
              `          });` && |\n| &&
              `        } catch (e) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_router_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_router_js.clas.abap
@@ -165,10 +165,24 @@ CLASS z2ui5_cl_ui5f_router_js IMPLEMENTATION.
              `      if (!state.hashEvent) return;` && |\n| &&
              `      const appHash = appHashNormalized(sNewHash);` && |\n| &&
              `      if (appHash === state.appHash) return;` && |\n| &&
-             `      state.appHash = appHash;` && |\n| &&
              `      const controller = state.oController;` && |\n| &&
-             `      if (!controller || Lib.isDestroyed(controller)) return;` && |\n| &&
+             `      if (!controller || !Lib.isControllerAlive(controller)) return;` && |\n| &&
+             `` && |\n| &&
+             `      if (state.isBusy) {` && |\n| &&
+             `        state.pendingAppHash = sNewHash;` && |\n| &&
+             `        return;` && |\n| &&
+             `      }` && |\n| &&
+             `      state.pendingAppHash = null;` && |\n| &&
+             `      state.appHash = appHash;` && |\n| &&
              `      controller.eB([state.hashEvent]);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
+             `    function dispatchPendingAppHash() {` && |\n| &&
+             `      const state = AppState.state;` && |\n| &&
+             `      const pending = state.pendingAppHash;` && |\n| &&
+             `      if (pending === null || pending === undefined) return;` && |\n| &&
+             `      state.pendingAppHash = null;` && |\n| &&
+             `      dispatchAppHashChange(pending);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    function repointCallerEntry(mOptions, draftForRoute) {` && |\n| &&
@@ -315,6 +329,7 @@ CLASS z2ui5_cl_ui5f_router_js IMPLEMENTATION.
              `      navTo,` && |\n| &&
              `      navBack,` && |\n| &&
              `      onHashChanged,` && |\n| &&
+             `      dispatchPendingAppHash,` && |\n| &&
              `      sync,` && |\n| &&
              `    };` && |\n| &&
              `  },` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_shortcut_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_shortcut_js.clas.abap
@@ -108,7 +108,7 @@ CLASS z2ui5_cl_ui5f_shortcut_js IMPLEMENTATION.
              `          const entry = shortcutEntry(shortcutFromEvent(oEvent));` && |\n| &&
              `          if (!entry) return;` && |\n| &&
              `` && |\n| &&
-             `          if (Lib.isDestroyed(entry.controller)) return;` && |\n| &&
+             `          if (!Lib.isControllerAlive(entry.controller)) return;` && |\n| &&
              `` && |\n| &&
              `          oEvent.preventDefault();` && |\n| &&
              `          entry.controller.eB([entry.event]);` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_uitable_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_uitable_js.clas.abap
@@ -80,7 +80,7 @@ CLASS z2ui5_cl_ui5f_uitable_js IMPLEMENTATION.
              `          this._filterBinding = binding;` && |\n| &&
              `` && |\n| &&
              `          this.aFilters = binding?.getFilters` && |\n| &&
-             `            ? binding.getFilters("Application")` && |\n| &&
+             `            ? binding.getFilters("Control")` && |\n| &&
              `            : binding?.aFilters;` && |\n| &&
              `        } catch (e) {` && |\n| &&
              `          Lib.logError("UITableExt.readFilter failed", e);` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_variants_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_variants_js.clas.abap
@@ -68,7 +68,7 @@ CLASS z2ui5_cl_ui5f_variants_js IMPLEMENTATION.
              `    const finish = () => activeInits.delete(key);` && |\n| &&
              `    let tries = 0;` && |\n| &&
              `    const run = () => {` && |\n| &&
-             `      if (Lib.isDestroyed(oController)) {` && |\n| &&
+             `      if (!Lib.isControllerAlive(oController)) {` && |\n| &&
              `        finish();` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
@@ -212,7 +212,7 @@ CLASS z2ui5_cl_ui5f_variants_js IMPLEMENTATION.
              `    const finish = () => activeInits.delete(key);` && |\n| &&
              `    let tries = 0;` && |\n| &&
              `    const run = () => {` && |\n| &&
-             `      if (Lib.isDestroyed(oController)) {` && |\n| &&
+             `      if (!Lib.isControllerAlive(oController)) {` && |\n| &&
              `        finish();` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_view1_js.clas.abap
@@ -79,7 +79,10 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `            await this._runSystemActions(oResponse, seq);` && |\n| &&
              `          }` && |\n| &&
              `` && |\n| &&
-             `          if (Lib.isDestroyed(this) || oResponse !== AppState.state.oResponse) {` && |\n| &&
+             `          if (` && |\n| &&
+             `            !Lib.isControllerAlive(this) ||` && |\n| &&
+             `            oResponse !== AppState.state.oResponse` && |\n| &&
+             `          ) {` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
              `` && |\n| &&
@@ -102,6 +105,8 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `          AppState.state.isBusy = false;` && |\n| &&
              `` && |\n| &&
              `          this._runPendingCustomJs(oResponse);` && |\n| &&
+             `` && |\n| &&
+             `          Router.dispatchPendingAppHash();` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -109,7 +114,8 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `        const systemJs = oResponse?.S_ACTION?.T_SYSTEM;` && |\n| &&
              `        if (!systemJs) return;` && |\n| &&
              `        for (const item of systemJs) {` && |\n| &&
-             `          if (Lib.isDestroyed(this) || seq !== Server._requestSeq) return;` && |\n| &&
+             `          if (!Lib.isControllerAlive(this) || seq !== Server._requestSeq)` && |\n| &&
+             `            return;` && |\n| &&
              `          await FrontendAction.runSystem(item, this, {` && |\n| &&
              `            seq,` && |\n| &&
              `            response: oResponse,` && |\n| &&
@@ -121,7 +127,7 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `        const customJs = oResponse?._pendingCustomJs;` && |\n| &&
              `        if (oResponse) oResponse._pendingCustomJs = null;` && |\n| &&
              `        if (!customJs) return;` && |\n| &&
-             `        if (Lib.isDestroyed(this)) return;` && |\n| &&
+             `        if (!Lib.isControllerAlive(this)) return;` && |\n| &&
              `        for (const item of customJs) {` && |\n| &&
              `          FrontendAction.runCustom(item, this);` && |\n| &&
              `        }` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_viewops_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_viewops_js.clas.abap
@@ -35,6 +35,8 @@ CLASS z2ui5_cl_ui5f_viewops_js IMPLEMENTATION.
              `  (ODataModel, Lib, ViewSlots, AppState) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
+             `    const TIMER_BUSY_RETRY_MS = 50;` && |\n| &&
+             `` && |\n| &&
              `    const SMOOTH_SCROLL_MS = 300;` && |\n| &&
              `` && |\n| &&
              `    function evSetSizeLimit(oController, args) {` && |\n| &&
@@ -126,13 +128,19 @@ CLASS z2ui5_cl_ui5f_viewops_js IMPLEMENTATION.
              `      const delay = Number(args[2]) || 0;` && |\n| &&
              `      const timers = AppState.state.timers;` && |\n| &&
              `      clearTimeout(timers[timerKey]);` && |\n| &&
-             `      timers[timerKey] = setTimeout(() => {` && |\n| &&
+             `      const fire = () => {` && |\n| &&
              `        delete timers[timerKey];` && |\n| &&
              `` && |\n| &&
-             `        if (Lib.isDestroyed(oController)) return;` && |\n| &&
+             `        if (!Lib.isControllerAlive(oController)) return;` && |\n| &&
+             `` && |\n| &&
+             `        if (AppState.state.isBusy) {` && |\n| &&
+             `          timers[timerKey] = setTimeout(fire, TIMER_BUSY_RETRY_MS);` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
              `` && |\n| &&
              `        oController.eB([callbackEvent, false, true]);` && |\n| &&
-             `      }, delay);` && |\n| &&
+             `      };` && |\n| &&
+             `      timers[timerKey] = setTimeout(fire, delay);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
              `    function evSetFocus(oController, args) {` && |\n| &&
@@ -171,7 +179,7 @@ CLASS z2ui5_cl_ui5f_viewops_js IMPLEMENTATION.
              `            oElement.removeEventDelegate(delegate);` && |\n| &&
              `` && |\n| &&
              `            setTimeout(() => {` && |\n| &&
-             `              if (Lib.isDestroyed(oController)) return;` && |\n| &&
+             `              if (!Lib.isControllerAlive(oController)) return;` && |\n| &&
              `` && |\n| &&
              `              if (!samePlace(document.activeElement)) return;` && |\n| &&
              `              applyFocus();` && |\n| &&

--- a/src/02/z2ui5_cl_ui5_json.clas.abap
+++ b/src/02/z2ui5_cl_ui5_json.clas.abap
@@ -106,7 +106,12 @@ CLASS z2ui5_cl_ui5_json IMPLEMENTATION.
   METHOD get_boolean.
 
     DATA(lv_path) = CONV string( path ).
-    result = mi_json->get_boolean( lv_path ).
+    " ajson's get_boolean answers abap_true for ANY non-empty value that is
+    " not a JSON boolean - the number 0, the string "false", "abc" - which
+    " is not what the contract above promises. Only a boolean node is asked
+    IF mi_json->get_node_type( lv_path ) = z2ui5_if_ajson_types=>node_type-boolean.
+      result = mi_json->get_boolean( lv_path ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_ui5_json.clas.testclasses.abap
+++ b/src/02/z2ui5_cl_ui5_json.clas.testclasses.abap
@@ -46,11 +46,20 @@ CLASS ltcl_test_json IMPLEMENTATION.
 
   METHOD test_get_boolean.
 
-    DATA(lo_json) = z2ui5_cl_ui5_json=>factory( `{"active":true,"closed":false}` ).
+    DATA(lo_json) = z2ui5_cl_ui5_json=>factory(
+        `{"active":true,"closed":false,"zero":0,"one":1,"word":"false","text":"abc","nil":null}` ).
 
     cl_abap_unit_assert=>assert_true( lo_json->get_boolean( `/active` ) ).
     cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/closed` ) ).
     cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/missing` ) ).
+
+    " "abap_false when missing or not true" - a number or a string is not
+    " true, whatever it says (ajson itself answers abap_true for all four)
+    cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/zero` ) ).
+    cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/one` ) ).
+    cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/word` ) ).
+    cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/text` ) ).
+    cl_abap_unit_assert=>assert_false( lo_json->get_boolean( `/nil` ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
# Description

An adversarial review of the framework (ABAP core, view/model layer, utilities, frontend core, custom controls) against a green baseline - abaplint 0 findings, transpiled unit suite green, 1034 JS specs green. Everything here is a defect no gate catches; each fix carries a unit test and a comment at the code site with the reasoning.

**Backend**

- **Delta cell edit of a `d` / `t` / timestamp column corrupted the field.** `delta_apply_field` assigned the raw ISO text ajson had written outbound (`2024-01-15` became `2024-01-`, no exception, no `t_model_skipped` entry). New `delta_apply_scalar` unpacks the ISO spelling by the target's type kind, as the whole-attribute path (`to_abap`) always did. Three new type-kind constants on `z2ui5_cl_ui5_util_context`.
- **`set_session_stateful` over a `nav_app_call` hop.** `switched` was a toggle guarded by the *container's* `mv_check_sticky`; the called app runs in a fresh container, so A and B both switching on in one roundtrip cancelled out: the ICF session never went stateful while B was marked sticky and its draft was never saved - the next click was a `NO_DRAFT_ENTRY_OF_PREVIOUS_REQUEST_FOUND` 500. The switch now compares the end state against the state the *request* started in (`z2ui5_cl_ui5_action->mv_check_sticky_start`, carried through `prepare_app_stack`).
- **An anonymous elementary data reference (`CREATE DATA mr TYPE string`) was cleared on every draft save and never restored.** The dref save path only handled table and structure derefs; an elementary deref now stringifies like a structure and `main_attri_db_load_resolve` restores it.
- **`_bind( omit_initial )` kept an initial `p DECIMALS` field as `0.00`** (and a float as `0.0E+00`) - the compare was against the literal `0`. Every spelling of a numeric zero is initial now (both client filters and `z2ui5_cl_ui5_util_json_fl`).
- **`url_param_get_tab` decoded `%26`/`%3D` over the whole query before splitting** (`?a=x%26y&b=1` became three parameters, and `app_get_url` wrote the damage back into generated links) **and cut at any `?` inside the query** (`?app_start=zcl_x&title=why?` lost `app_start`). Only the `sap-startup-params` value is decoded; only the first `?` separates path and query.
- **`z2ui5_cl_ui5_json=>get_boolean` answered `abap_true` for any non-empty non-boolean** (`0`, `"false"`, `"abc"`), against its own doc. Only a JSON boolean node is asked now. `src/02` body-only change, no signature touched.

**Frontend** (`src/01/03` regenerated via `npm run app2abap`)

- **`MultiInputExt`: a pick from plain `suggestionItems` vanished.** MultiInput hands a non-tabular pick over as `suggestionObject` together with the Token it built (1.71 and 1.120 alike); the validator routed it through `tokenFromRow` and returned `null` - no token, no `change`. That Token is returned now; tabular rows keep the TokenKeyCell rule.
- **`UITableExt` asked `getFilters("Application")`.** `sap.ui.table.Column.filter()` applies the column filter row as `FilterType.Control`, so on every release with `getFilters` (>= 1.96) nothing was restored after a view rebuild while 1.71 (private `aFilters`) kept it. Now `getFilters("Control")`; the spec stub honours the argument.
- **App-owned hash routing lost a Back/Forward that landed during a roundtrip.** `dispatchAppHashChange` adopted the hash *before* the dispatch and `View1.eB` dropped the event on its busy guard - URL on Page2, app on Page1, nothing ever re-dispatched. The change is parked (`AppState.pendingAppHash`) and delivered from View1's `finally` via `Router.dispatchPendingAppHash()`.
- **A backend timer tick aborted the user's in-flight request.** The tick fired as a background event; `Server.readHttp` treats every new request as superseding and aborted the fetch in flight, whose response was then dropped as stale. The tick re-arms itself (50 ms) while `isBusy` instead.
- **Every `Lib.isDestroyed( controller )` guard was dead code.** `sap.ui.core.mvc.Controller` has neither `isDestroyed()` nor `bIsDestroyed` on any release (checked 1.71 / 1.144) and the five slot controllers are never destroyed, so timers, shortcuts, variant poll chains and the render phase never saw a torn-down app (a variant poll could resolve the *next* app's controls after an FLP teardown). New `Lib.isControllerAlive()` tests membership in the current app state - what `Component.exit -> AppState.reset()` actually ends.

Found in the same review and left open (medium / low): sorted or hashed tables silently drop delta edits, an app that only inherited FRESH routing turns routing off after a Back/Forward fresh start, popup edits are overwritten by a MAIN-triggered `MODEL` push, `UploadSetExt` loses files on multi-select, `Scrolling` restores the wrong axis on a `ScrollContainer`, `Websocket` never leaves its give-up state on a `checkActive` toggle, `xml_escape` passes XML-illegal control characters, `nav_app_leave` on an empty stack leaves to itself.

## How to test

- `npm run check` (abaplint, 0 findings), `npm run downport && npm run auto_transpile && npm run unit` (14 new ABAP tests: `test_cell_iso_date_time`, `test_cell_plain_date`, `test_stateful_across_hop`, `test_stateful_cancels_out`, `test_stateful_start_sticky`, `test_elem_ref_survives`, `test_omit_initial_decimals`, `test_drops_zero_decimals`, `test_keeps_small_number`, `test_url_param_encoded`, `test_url_param_question`, `test_url_param_full_url`, extended `test_get_boolean`), `npm run check:js` (1041 specs, 7 new).
- On a system: a `DatePicker` with `valueFormat="yyyy-MM-dd"` bound to a `TYPE d` table column, edit a row - the ABAP value is `20240115`, not `2024-01-`. An app calling `set_session_stateful( abap_true )` and `nav_app_call( )` into an app that does the same - the next click no longer 500s.
- `npm run gates`: 31 of 32 green. `check:counts` is red on `main` as well (llms.txt / build-an-app say 148 sample apps, samples/SAMPLES.md has 150) - a live comparison against another repository, unrelated to this change and not touched here.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) - run as its parts: check, gates, downport, auto_transpile, unit, check:js, app2abap drift
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively - `z2ui5_cl_ui5_json=>get_boolean` body only, signature untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour - eleven `*` lines
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsvVb8kcFTK95LRwEcHB9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsvVb8kcFTK95LRwEcHB9r)_