### PR TITLE
Fix the last review findings: traced scalar refusals, sticky drafts for routed apps, error-path restore, one file per roundtrip

### DIFF
--- a/app/webapp/cc/FileUploader.js
+++ b/app/webapp/cc/FileUploader.js
@@ -87,13 +87,33 @@ sap.ui.define(
         },
       },
 
-      _readFile(file) {
+      // `value` holds ONE file and every upload event is one roundtrip. With
+      // `multiple` the inner control hands over every selected file, and only
+      // files[0] was ever read - the rest were dropped without a word. They
+      // go one at a time now, the next after the previous roundtrip landed
+      // (Lib.afterRoundtrip), the way cc/UploadSetExt does it.
+      _readFiles(files) {
+        this._queue = (this._queue || []).concat(files);
+        if (!this._reading) this._readNext();
+      },
+
+      _readNext() {
+        const file = this._queue.shift();
+        if (!file) {
+          this._reading = false;
+          return;
+        }
+        this._reading = true;
         Lib.readFileAsDataURL(
           file,
           this,
           (result) => {
             this.setProperty("value", result);
             this.fireUpload();
+            this._cancelWait = Lib.afterRoundtrip(this, () => {
+              this._cancelWait = null;
+              this._readNext();
+            });
           },
           "FileUploader",
         );
@@ -101,6 +121,11 @@ sap.ui.define(
 
       exit() {
         if (this._oHBox) this._oHBox.destroy();
+        this._queue = [];
+        if (this._cancelWait) {
+          this._cancelWait();
+          this._cancelWait = null;
+        }
       },
 
       // Build the inner controls ONCE and update their properties per
@@ -124,8 +149,8 @@ sap.ui.define(
             enabled: this.getProperty("path") !== "",
             press: () => {
               this.setProperty("path", this.oFileUploader.getProperty("value"));
-              if (this._pendingFile) {
-                this._readFile(this._pendingFile);
+              if (this._pendingFiles?.length) {
+                this._readFiles(this._pendingFiles);
               }
             },
           });
@@ -134,12 +159,12 @@ sap.ui.define(
         this.oFileUploader = new FileUploader({
           uploadOnChange: directUpload,
           change: (oEvent) => {
-            // Remember the selected file from the event's public "files"
-            // parameter (the inner file input is private API). It is
+            // Remember the selected files from the event's public "files"
+            // parameter (the inner file input is private API). They are
             // consumed by the upload button press or, in direct-upload
             // mode, by uploadComplete below.
             const files = oEvent.getParameter("files");
-            this._pendingFile = files?.[0];
+            this._pendingFiles = files ? Array.from(files) : [];
             if (directUpload) return;
             const value = oEvent.getSource().getProperty("value");
             this.setProperty("path", value);
@@ -151,8 +176,8 @@ sap.ui.define(
             if (!directUpload) return;
             const source = oEvent.getSource();
             this.setProperty("path", source.getProperty("value"));
-            if (this._pendingFile) {
-              this._readFile(this._pendingFile);
+            if (this._pendingFiles?.length) {
+              this._readFiles(this._pendingFiles);
             }
           },
         });

--- a/app/webapp/cc/UploadSetExt.js
+++ b/app/webapp/cc/UploadSetExt.js
@@ -1,11 +1,6 @@
 sap.ui.define(
-  [
-    "sap/ui/core/Control",
-    "z2ui5/core/Lib",
-    "z2ui5/core/ViewSlots",
-    "z2ui5/core/AppState",
-  ],
-  (Control, Lib, ViewSlots, AppState) => {
+  ["sap/ui/core/Control", "z2ui5/core/Lib", "z2ui5/core/ViewSlots"],
+  (Control, Lib, ViewSlots) => {
     "use strict";
 
     // Invisible companion control for a sap.m.upload.UploadSet (referenced
@@ -63,9 +58,9 @@ sap.ui.define(
       exit() {
         this._unhook();
         this._queue = [];
-        if (this._afterRoundtrip) {
-          Lib.unregisterCallback("onAfterRendering", this._afterRoundtrip);
-          this._afterRoundtrip = null;
+        if (this._cancelWait) {
+          this._cancelWait();
+          this._cancelWait = null;
         }
       },
 
@@ -97,28 +92,13 @@ sap.ui.define(
             this.setProperty("mediaType", file.type);
             this.setProperty("fileSize", String(file.size));
             this.fireChange();
-            this._whenRoundtripLanded(() => this._readNext());
+            this._cancelWait = Lib.afterRoundtrip(this, () => {
+              this._cancelWait = null;
+              this._readNext();
+            });
           },
           "UploadSetExt",
         );
-      },
-
-      // Runs `fn` once the roundtrip the change just started has landed -
-      // right away when it started none (no event bound to change), which
-      // is what state.isBusy says synchronously after fireChange.
-      _whenRoundtripLanded(fn) {
-        if (!AppState.state.isBusy) {
-          fn();
-          return;
-        }
-        const once = () => {
-          Lib.unregisterCallback("onAfterRendering", once);
-          this._afterRoundtrip = null;
-          if (Lib.isDestroyed(this)) return;
-          fn();
-        };
-        this._afterRoundtrip = once;
-        Lib.registerCallback("onAfterRendering", once);
       },
 
       onItemAdded(oEvent) {

--- a/app/webapp/cc/Websocket.js
+++ b/app/webapp/cc/Websocket.js
@@ -93,6 +93,7 @@ sap.ui.define(
           // a NEW target gets a fresh set of attempts - the give-up above
           // is about hammering the same dead endpoint
           this._failedAttempts = 0;
+          this._doneAfterFirst = false;
         }
         this._url = url;
         const active = this.getProperty("checkActive");
@@ -102,8 +103,11 @@ sap.ui.define(
         // trigger the contract above promises next to a path change
         if (active && this._wasInactive) {
           this._failedAttempts = 0;
+          this._doneAfterFirst = false;
         }
         this._wasInactive = !active;
+        // checkRepeat back on: the app wants to listen again
+        if (this.getProperty("checkRepeat")) this._doneAfterFirst = false;
         if (active) {
           this._connect();
         } else {
@@ -126,6 +130,12 @@ sap.ui.define(
       _connect() {
         if (this._ws || !this._url) return;
         if (this._failedAttempts >= MAX_CONNECT_ATTEMPTS) return;
+        // "close after the first message" (checkRepeat = false) has to hold
+        // past the next re-render: every roundtrip runs onAfterRendering,
+        // and reconnecting from there turned "once" into "once per
+        // roundtrip". A path change or a checkActive/checkRepeat toggle
+        // (above) is what asks for the next one
+        if (this._doneAfterFirst) return;
         const url = this._url;
         let ws;
         try {
@@ -152,7 +162,10 @@ sap.ui.define(
             Lib.logError("Websocket: ignored a non-text message");
             return;
           }
-          if (!this.getProperty("checkRepeat")) this._disconnect();
+          if (!this.getProperty("checkRepeat")) {
+            this._doneAfterFirst = true;
+            this._disconnect();
+          }
           this._report({ kind: "message", value: event.data });
         };
         ws.onerror = () => {

--- a/app/webapp/controller/View1.controller.js
+++ b/app/webapp/controller/View1.controller.js
@@ -44,6 +44,7 @@ sap.ui.define(
       // response being processed belongs to (Server.responseSuccess); the
       // onAfterRendering entry above has none and falls back to the newest.
       async _processAfterRendering(reqSeq) {
+        let superseded = false;
         // The claim happens BEFORE the try: the MAIN rebuild is a system
         // action now, so slots render (and re-enter here via their own
         // onAfterRendering - possibly with a NESTED controller as `this`)
@@ -104,6 +105,10 @@ sap.ui.define(
             !Lib.isControllerAlive(this) ||
             oResponse !== AppState.state.oResponse
           ) {
+            // a NEWER request owns the busy state, the pending custom JS and
+            // the parked hash from here on (see the finally below) - this
+            // response only stops
+            superseded = true;
             return;
           }
           // A MODEL key in the response IS the model push - run it after the
@@ -133,17 +138,26 @@ sap.ui.define(
             "Unexpected Error Occurred - App Terminated",
           );
         } finally {
-          BusyIndicator.hide();
-          AppState.state.isBusy = false;
-          // Now that the view is rendered (and any busy indicator is gone),
-          // run the follow-up JS snippets the backend asked for. Doing it here
-          // - rather than as an early microtask - guarantees render-dependent
-          // actions like SET_FOCUS find their target control in the DOM.
-          this._runPendingCustomJs(oResponse);
-          // an app-hash change (Back/Forward under app-owned routing) that
-          // arrived while this roundtrip was in flight was parked by the
-          // router - deliver it now that the busy guard would let it through
-          Router.dispatchPendingAppHash();
+          // A superseded response (a Back/Forward restore or a parallel
+          // request replaced it while its views were still loading) leaves
+          // the busy protocol to the request that superseded it: hiding
+          // the indicator here ended the busy state the restore relied on
+          // and let a click dispatch a third request that aborted it, and
+          // running its custom JS (SET_FOCUS, toasts, timers) acted on a
+          // screen the newer response is about to replace.
+          if (!superseded) {
+            BusyIndicator.hide();
+            AppState.state.isBusy = false;
+            // Now that the view is rendered (and any busy indicator is gone),
+            // run the follow-up JS snippets the backend asked for. Doing it here
+            // - rather than as an early microtask - guarantees render-dependent
+            // actions like SET_FOCUS find their target control in the DOM.
+            this._runPendingCustomJs(oResponse);
+            // an app-hash change (Back/Forward under app-owned routing) that
+            // arrived while this roundtrip was in flight was parked by the
+            // router - deliver it now that the busy guard would let it through
+            Router.dispatchPendingAppHash();
+          }
         }
       },
 

--- a/app/webapp/core/Lib.js
+++ b/app/webapp/core/Lib.js
@@ -269,6 +269,28 @@ sap.ui.define(
     // Run every callback in `callbacks` (the shared callback arrays above),
     // swallowing individual failures so one bad callback cannot break the
     // whole event sequence.
+    // Runs `fn` once the roundtrip a control just started has landed - right
+    // away when it started none (state.isBusy is set synchronously by
+    // View1.eB, so the answer is known the moment the event was fired). A
+    // control that reports several files/values one roundtrip each hands
+    // the next one over from here; firing them back to back lost every one
+    // but the first on the busy guard. The one-shot hook takes itself off
+    // the onAfterRendering list again; `owner` destroyed meanwhile ends it.
+    // Returns a function that cancels the wait (for the owner's exit).
+    function afterRoundtrip(owner, fn) {
+      if (!AppState.state.isBusy) {
+        fn();
+        return () => {};
+      }
+      const once = () => {
+        unregisterCallback("onAfterRendering", once);
+        if (isDestroyed(owner)) return;
+        fn();
+      };
+      registerCallback("onAfterRendering", once);
+      return () => unregisterCallback("onAfterRendering", once);
+    }
+
     function runCallbacks(callbacks, ...args) {
       if (!callbacks) return;
       for (const fn of callbacks) {
@@ -752,6 +774,7 @@ sap.ui.define(
       logError,
       isDestroyed,
       isControllerAlive,
+      afterRoundtrip,
       isAlive,
       claimOnce,
       isTextInput,

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,16 @@ unreleased
 - z2ui5_cl_ui5_util_context=>app_get_url moved to z2ui5_cl_ui5_handler=>app_get_url. A downstream caller of the old spelling gets a compile error until it renames the class (same signature; src/00 is not the guarded API, and the shipped legacy z2ui5_cl_util=>app_get_url keeps working)
 * App-state links and copied launchpad links keep a bare intent hash (opened from the tile, no app part yet) instead of landing the recipient on the FLP home page
 - The corpus-count gate (npm run check:counts): a number about another repository's catalogue went red on main whenever that corpus grew by one app - too strict for what it protected. The counts in llms.txt and the build-an-app skill stay prose
+* A bound scalar the client sends in a form its ABAP type refuses (`1,250.00` into a packed field) is recorded in t_model_skipped (attribute name, row 0) and keeps its value, like a table cell - it used to raise JSON_PARSING_ERROR and fail the whole roundtrip
+* A sticky app under KEEP routing or with an active app-state link saves its draft, so Back/Forward, a reload and a shared link restore it instead of "bookmarked app state expired"
+* A failing roundtrip in a stateful session puts the request's starting action back on the sticky handler, so the next request no longer runs against a called app the frontend never saw
+* The 500 body strips app_start to class-name-safe characters, like the app-start error already did
+* A percent-encoded namespace in ?app_start= (%2Fns%2Fclass) resolves to the class it spells
+* nav_app_leave( r_data = an object reference ) copies the reference instead of dereferencing it as data
+* dissolve( ) refreshes once per pass - a persistently failing dissolve_run no longer recurses without end
+* A superseded response (a Back/Forward restore or a parallel request replaced it mid-render) leaves the busy state, its custom JS and the parked app hash to the newer request instead of ending them
+* Websocket with checkRepeat = false stays closed across re-renders - "once" no longer meant once per roundtrip
+* FileUploader with multiple reads every selected file, one roundtrip each (new Lib.afterRoundtrip, shared with UploadSetExt); only the first was read before
 * A row delta on a bound SORTED or HASHED table is recorded in t_model_skipped, one entry per cell, instead of vanishing silently
 * An app that only inherited its routing mode keeps it on a fresh route start (a reload, Back/Forward under FRESH): the explicit DEFAULT is sent on a navigation hop only
 * nav_app_leave( ) without a target on an empty app stack is a no-op instead of a navigation to the app itself

--- a/node/tests/fileUploader.spec.js
+++ b/node/tests/fileUploader.spec.js
@@ -32,7 +32,7 @@ function load() {
   const { readers, FakeFileReader } = makeFileReaderStub();
   // The real Lib (readFileAsDataURL, isDestroyed) with the FileReader global
   // stubbed inside Lib's own module sandbox.
-  const { Lib } = loadLib({ FileReader: FakeFileReader });
+  const { Lib, sandbox } = loadLib({ FileReader: FakeFileReader });
 
   class Button {
     constructor(settings) {
@@ -142,7 +142,7 @@ function load() {
     getSource: () => uploader,
   });
 
-  return { makeInstance, render, changeEvent, readers };
+  return { makeInstance, render, changeEvent, readers, state: sandbox.z2ui5 };
 }
 
 test("button mode renders uploader + Upload button, disabled while no file", () => {
@@ -195,6 +195,43 @@ test("pressing Upload reads the pending file and fires upload with the data URL"
 
   expect(inst._props.value).toBe("data:mock;base64,doc.txt");
   expect(inst.uploads).toBe(1);
+});
+
+test("with multiple, every selected file is read - one after the other", () => {
+  const { makeInstance, render, readers, state } = load();
+  const inst = makeInstance({ multiple: true });
+  render(inst);
+  const files = [{ name: "a.txt" }, { name: "b.txt" }, { name: "c.txt" }];
+  // the upload event starts a roundtrip - what View1.eB does synchronously
+  inst.fireUpload = () => {
+    inst.uploads++;
+    state.isBusy = true;
+  };
+
+  inst.oFileUploader.settings.value = "a.txt";
+  inst.oFileUploader.settings.change({
+    getParameter: (name) => (name === "files" ? files : null),
+    getSource: () => inst.oFileUploader,
+  });
+  inst.oUploadButton.settings.press();
+
+  // only files[0] was ever read before; now the rest wait in the queue
+  expect(readers).toHaveLength(1);
+  readers[0].finish();
+  expect(inst._props.value).toBe("data:mock;base64,a.txt");
+  expect(inst.uploads).toBe(1);
+  expect(readers).toHaveLength(1);
+
+  // the roundtrip lands: the next file follows
+  state.isBusy = false;
+  for (const fn of state.onAfterRendering) fn();
+  readers[1].finish();
+  expect(inst._props.value).toBe("data:mock;base64,b.txt");
+  state.isBusy = false;
+  for (const fn of state.onAfterRendering) fn();
+  readers[2].finish();
+  expect(inst._props.value).toBe("data:mock;base64,c.txt");
+  expect(inst.uploads).toBe(3);
 });
 
 test("direct-upload mode renders no button and reads on uploadComplete", () => {

--- a/node/tests/utilHelpers.spec.js
+++ b/node/tests/utilHelpers.spec.js
@@ -37,6 +37,46 @@ test.describe("isControllerAlive (slot-controller liveness)", () => {
   });
 });
 
+test.describe("afterRoundtrip (one value per roundtrip)", () => {
+  test("runs right away when no roundtrip is in flight", () => {
+    const state = { isBusy: false, onAfterRendering: [] };
+    const { Lib } = loadLib({ z2ui5: state });
+    let ran = 0;
+    Lib.afterRoundtrip({}, () => ran++);
+    expect(ran).toBe(1);
+    expect(state.onAfterRendering).toEqual([]);
+  });
+
+  test("waits for the roundtrip to land, once, and unhooks itself", () => {
+    const state = { isBusy: true, onAfterRendering: [] };
+    const { Lib } = loadLib({ z2ui5: state });
+    let ran = 0;
+    Lib.afterRoundtrip({}, () => ran++);
+    expect(ran).toBe(0);
+    expect(state.onAfterRendering).toHaveLength(1);
+    // the roundtrip lands (View1 runs the hooks)
+    for (const fn of state.onAfterRendering) fn();
+    expect(ran).toBe(1);
+    expect(state.onAfterRendering).toEqual([]);
+  });
+
+  test("a destroyed owner is not called, and the wait can be cancelled", () => {
+    const state = { isBusy: true, onAfterRendering: [] };
+    const { Lib } = loadLib({ z2ui5: state });
+    let ran = 0;
+    const owner = { bIsDestroyed: false };
+    Lib.afterRoundtrip(owner, () => ran++);
+    owner.bIsDestroyed = true;
+    for (const fn of state.onAfterRendering) fn();
+    expect(ran).toBe(0);
+    expect(state.onAfterRendering).toEqual([]);
+
+    const cancel = Lib.afterRoundtrip({}, () => ran++);
+    cancel();
+    expect(state.onAfterRendering).toEqual([]);
+  });
+});
+
 test.describe("isDestroyed (async-continuation guard, 1.71 floor)", () => {
   const { Lib } = loadLib();
 

--- a/node/tests/view1Events.spec.js
+++ b/node/tests/view1Events.spec.js
@@ -209,11 +209,13 @@ test.describe("_processAfterRendering (action-free responses)", () => {
     const syncs = [];
     const hooks = [];
     const destroys = [];
-    const state = { onAfterRendering: [() => hooks.push("ran")] };
+    const busy = [];
+    const pendingHash = [];
+    const state = { onAfterRendering: [() => hooks.push("ran")], isBusy: true };
     const { module: ctrl } = loadModule("controller/View1.controller.js", {
       deps: {
         "sap/ui/core/mvc/Controller": { extend: (name, methods) => methods },
-        "sap/ui/core/BusyIndicator": { hide: () => {} },
+        "sap/ui/core/BusyIndicator": { hide: () => busy.push("hide") },
         "sap/m/MessageBox": {},
         "z2ui5/core/Server": { _requestSeq: 1, responseError: () => {} },
         "z2ui5/core/Lib": {
@@ -223,20 +225,59 @@ test.describe("_processAfterRendering (action-free responses)", () => {
           logError: () => {},
         },
         "z2ui5/core/FrontendAction": {
-          runSystem: () => {},
+          // a spec may replace the response mid-phase, the way a parallel
+          // request does while the system actions are still awaiting
+          runSystem: () => hooks.onRunSystem?.(),
           runCustom: () => {},
         },
         "z2ui5/core/actions/Slots": { action: (method) => pushes.push(method) },
         "z2ui5/core/ViewSlots": { destroy: (key) => destroys.push(key) },
         "z2ui5/core/Router": {
           sync: (o) => syncs.push(o),
-          dispatchPendingAppHash: () => {},
+          dispatchPendingAppHash: () => pendingHash.push("delivered"),
         },
         "z2ui5/core/AppState": { state },
       },
     });
-    return { ctrl, state, pushes, syncs, hooks, destroys };
+    return { ctrl, state, pushes, syncs, hooks, destroys, busy, pendingHash };
   }
+
+  test("a superseded response leaves busy, custom JS and the parked hash to the newer one", async () => {
+    const { ctrl, state, pushes, syncs, hooks, busy, pendingHash } = loadForAfterRendering();
+    state.oResponse = {
+      ID: "D1",
+      MODELPRESENT: true,
+      S_ACTION: { T_SYSTEM: [{}] },
+      _pendingCustomJs: [["TOAST"]],
+    };
+    // a newer request replaces the response while this one's system
+    // actions are still running
+    hooks.onRunSystem = () => {
+      state.oResponse = { ID: "D2", MODELPRESENT: false };
+    };
+
+    await ctrl._processAfterRendering(1);
+
+    // nothing of this response reached the screen ...
+    expect(pushes).toEqual([]);
+    expect(syncs).toEqual([]);
+    // ... and it did not end the busy state the newer request relies on,
+    // ran no custom JS and delivered no parked hash - the newer response does
+    expect(busy).toEqual([]);
+    expect(state.isBusy).toBe(true);
+    expect(pendingHash).toEqual([]);
+  });
+
+  test("the winning response ends the busy state and delivers the parked hash", async () => {
+    const { ctrl, state, busy, pendingHash } = loadForAfterRendering();
+    state.oResponse = { ID: "D1", MODELPRESENT: false };
+
+    await ctrl._processAfterRendering(1);
+
+    expect(busy).toEqual(["hide"]);
+    expect(state.isBusy).toBe(false);
+    expect(pendingHash).toEqual(["delivered"]);
+  });
 
   test("no actions at all: model push, router sync and hooks still run", async () => {
     const { ctrl, state, pushes, syncs, hooks } = loadForAfterRendering();

--- a/node/tests/websocket.spec.js
+++ b/node/tests/websocket.spec.js
@@ -204,6 +204,26 @@ test("checkRepeat=false closes the connection after the first message", () => {
   expect(sockets[0].closed).toBe(true);
 });
 
+test("checkRepeat=false stays closed across the next re-renders", () => {
+  const { makeInstance, sockets } = load();
+  const inst = makeInstance({ path: "/apc", checkRepeat: false });
+  inst.onAfterRendering();
+  sockets[0].onmessage({ data: "once" });
+  expect(sockets[0].closed).toBe(true);
+
+  // every roundtrip re-renders; "once" used to become "once per roundtrip"
+  inst.onAfterRendering();
+  inst.onAfterRendering();
+  expect(sockets).toHaveLength(1);
+
+  // the app asks again: checkActive toggled, or checkRepeat back on
+  inst._props.checkActive = false;
+  inst.onAfterRendering();
+  inst._props.checkActive = true;
+  inst.onAfterRendering();
+  expect(sockets).toHaveLength(2);
+});
+
 test("a non-text message is logged and ignored - never thrown", () => {
   const { makeInstance, sockets, errors } = load();
   const inst = makeInstance({ path: "/apc" });

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
@@ -1103,7 +1103,16 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
         " cl_abap_refdescr covers data and object references alike, and so
         " does kind_ref
         DATA(lo_typdescr) = cl_abap_typedescr=>describe_by_data( val ).
-        result = xsdbool( lo_typdescr->kind = cl_abap_typedescr=>kind_ref ).
+        IF lo_typdescr->kind <> cl_abap_typedescr=>kind_ref.
+          RETURN.
+        ENDIF.
+        " kind_ref covers object references too, and the one caller that
+        " dereferences on a true answer (conv_copy_ref_data: `from->*`)
+        " cannot do that to an object reference - nav_app_leave( r_data =
+        " lo_object ) reached it. Only a reference to DATA answers true
+        DATA(lo_referenced) = CAST cl_abap_refdescr( lo_typdescr )->get_referenced_type( ).
+        result = xsdbool( lo_referenced->kind <> cl_abap_typedescr=>kind_class
+                      AND lo_referenced->kind <> cl_abap_typedescr=>kind_intf ).
       CATCH cx_root ##NO_HANDLER.
     ENDTRY.
 

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
@@ -15,6 +15,7 @@ CLASS ltcl_test DEFINITION FINAL
     METHODS test_url_param_startup    FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_encoded    FOR TESTING RAISING cx_static_check.
     METHODS test_c_trim_mixed          FOR TESTING RAISING cx_static_check.
+    METHODS test_copy_ref_object       FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_question   FOR TESTING RAISING cx_static_check.
     METHODS test_url_param_full_url   FOR TESTING RAISING cx_static_check.
 
@@ -138,6 +139,27 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = 1
         act = lines( z2ui5_cl_ui5_util_context=>url_param_get_tab( `?a=1&` ) ) ).
+
+  ENDMETHOD.
+
+  METHOD test_copy_ref_object.
+
+    " an OBJECT reference handed to nav_app_leave( r_data = ... ): not a data
+    " reference to dereference, copied as the value it is - the previous
+    " app gets a reference to a copy of the reference variable
+    DATA(lo_obj) = NEW z2ui5_cl_ui5_util_context( ).
+    cl_abap_unit_assert=>assert_false( z2ui5_cl_ui5_util_context=>rtti_check_ref_data( lo_obj ) ).
+
+    DATA lv_text TYPE string VALUE `x`.
+    DATA(lr_text) = REF #( lv_text ).
+    cl_abap_unit_assert=>assert_true( z2ui5_cl_ui5_util_context=>rtti_check_ref_data( lr_text ) ).
+
+    DATA(lr_copy) = z2ui5_cl_ui5_util_context=>conv_copy_ref_data( lo_obj ).
+    cl_abap_unit_assert=>assert_bound( lr_copy ).
+    FIELD-SYMBOLS <copy> TYPE any.
+    ASSIGN lr_copy->* TO <copy>.
+    cl_abap_unit_assert=>assert_equals( exp = lo_obj
+                                        act = <copy> ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
@@ -1429,6 +1429,9 @@ CLASS ltcl_app_price_editor DEFINITION FINAL.
     TYPES ty_t_product TYPE STANDARD TABLE OF ty_s_product WITH EMPTY KEY.
 
     DATA mt_product TYPE ty_t_product.
+    " a bound SCALAR of a numeric type - the shape whose refusal used to
+    " fail the whole roundtrip instead of landing in the trace
+    DATA mv_discount TYPE p LENGTH 9 DECIMALS 2.
 
     " what the user is told - empty exactly when the write-back was complete
     DATA mv_message TYPE string.
@@ -1518,6 +1521,7 @@ CLASS ltcl_app_price_editor IMPLEMENTATION.
     ENDIF.
 
     mv_bind_path = client->_bind_edit( mt_product ).
+    client->_bind( mv_discount ).
 
   ENDMETHOD.
 
@@ -1549,6 +1553,7 @@ CLASS ltcl_test_model_skipped DEFINITION FINAL
     METHODS test_trace_is_per_roundtrip FOR TESTING RAISING cx_static_check.
     METHODS test_nested_row_unresolved  FOR TESTING RAISING cx_static_check.
     METHODS test_bind_path_is_not_name  FOR TESTING RAISING cx_static_check.
+    METHODS test_refused_scalar_reported FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS ltcl_test_model_skipped IMPLEMENTATION.
@@ -1607,6 +1612,30 @@ CLASS ltcl_test_model_skipped IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( mo_app->mv_message ).
     cl_abap_unit_assert=>assert_equals( exp = abap_true
                                         act = mo_app->mv_saved ).
+
+  ENDMETHOD.
+
+  METHOD test_refused_scalar_reported.
+
+    " `1,250.00` typed into an Input bound to a packed SCALAR: the same
+    " refusal a table cell gets - traced with the attribute name, row 0 and
+    " the raw value, the old value kept, the roundtrip alive. It used to
+    " raise JSON_PARSING_ERROR and end in the fatal overlay
+    mo_app->mv_discount = '5.00'.
+    roundtrip( model = `{"MV_DISCOUNT":"1,250.00"}`
+               event = `SAVE` ).
+
+    DATA(lt_skipped) = mo_action->ms_actual-t_model_skipped.
+    cl_abap_unit_assert=>assert_equals( exp = 1
+                                        act = lines( lt_skipped ) ).
+    cl_abap_unit_assert=>assert_equals( exp = `MV_DISCOUNT`
+                                        act = lt_skipped[ 1 ]-name ).
+    cl_abap_unit_assert=>assert_equals( exp = 0
+                                        act = lt_skipped[ 1 ]-row ).
+    cl_abap_unit_assert=>assert_equals( exp = `1,250.00`
+                                        act = lt_skipped[ 1 ]-value ).
+    cl_abap_unit_assert=>assert_equals( exp = CONV decfloat34( '5.00' )
+                                        act = CONV decfloat34( mo_app->mv_discount ) ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_handler.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.abap
@@ -85,6 +85,10 @@ CLASS z2ui5_cl_ui5_handler DEFINITION PUBLIC FINAL.
 
     METHODS main_end.
 
+    "! the draft save at the end of main_end - a sticky app saves only when
+    "! a route or app-state link carries its draft id
+    METHODS main_end_save.
+
     METHODS response_abap_to_json
       IMPORTING
         val           TYPE z2ui5_if_ui5_types=>ty_s_response
@@ -362,6 +366,14 @@ CLASS z2ui5_cl_ui5_handler IMPLEMENTATION.
     result = z2ui5_cl_ui5_util_context=>c_trim_upper(
         z2ui5_cl_ui5_util_context=>url_param_get( val = `app_start`
                                                url    = iv_search ) ).
+    " a namespaced class name carries slashes, and a client that
+    " percent-encodes the value (%2Fns%2Fclass) is well within the URL
+    " rules; url_param_get leaves values encoded, so the one encoding a
+    " class name can carry is unpacked here
+    result = replace( val  = result
+                      sub  = `%2F`
+                      with = `/`
+                      occ  = 0 ).
   ENDMETHOD.
 
   METHOD hash_get_app_part.
@@ -684,13 +696,19 @@ CLASS z2ui5_cl_ui5_handler IMPLEMENTATION.
                           len = 300 ) && `...`.
     ENDIF.
 
+    " app_start is client-controlled and is reflected into the error body:
+    " the same class-name-safe strip as z2ui5_cl_ui5_action=>factory_first_start
+    " applies, so a crafted value cannot smuggle markup into the response
+    DATA(lv_app_start) = ms_request-s_control-app_start.
+    REPLACE ALL OCCURRENCES OF REGEX `[^A-Za-z0-9_/]` IN lv_app_start WITH `` ##REGEX_POSIX.
+
     result = |Request failed| &&
              COND #( WHEN lv_app   IS NOT INITIAL THEN | in app { lv_app }| ) &&
              COND #( WHEN lv_event IS NOT INITIAL THEN |, event { lv_event }|
                      ELSE |, no event (initial rendering)| ) &&
              COND #( WHEN lv_draft IS NOT INITIAL THEN |, draft { lv_draft }| ) &&
-             COND #( WHEN ms_request-s_control-app_start IS NOT INITIAL
-                     THEN |, app_start { ms_request-s_control-app_start }| ) &&
+             COND #( WHEN lv_app_start IS NOT INITIAL
+                     THEN |, app_start { lv_app_start }| ) &&
              COND #( WHEN lv_url IS NOT INITIAL THEN |, url { lv_url }| ).
 
   ENDMETHOD.
@@ -983,7 +1001,23 @@ CLASS z2ui5_cl_ui5_handler IMPLEMENTATION.
 
     mv_response = response_abap_to_json( ms_response ).
 
+    main_end_save( ).
+
+  ENDMETHOD.
+
+  METHOD main_end_save.
+
     IF mo_action->mo_app->mv_check_sticky = abap_false.
+      mo_action->mo_app->db_save( ).
+    ELSEIF mo_action->mo_app->mv_nav_mode = z2ui5_if_client=>cs_nav_mode-keep
+        OR mo_action->mo_app->mv_app_state_active = abap_true.
+      " a sticky app whose route (KEEP) or app-state link carries this
+      " draft id: the id is written into the URL and into copied links
+      " either way, and without a saved draft every Back/Forward, reload or
+      " shared link landed in factory_first_start's CATCH - "bookmarked app
+      " state expired" and a fresh app. The draft is saved for exactly
+      " these two modes; a sticky app that asked for neither keeps skipping
+      " the serialization
       mo_action->mo_app->db_save( ).
     ELSE.
       " a sticky session skips the draft save, but the lifecycle latch must

--- a/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_handler.clas.testclasses.abap
@@ -80,6 +80,9 @@ CLASS ltcl_test_handler_post DEFINITION FINAL
     METHODS load_startup_app       FOR TESTING RAISING cx_static_check.
     METHODS test_dispatch_loop_guard FOR TESTING RAISING cx_static_check.
     METHODS test_leave_root_ends_roundtrip FOR TESTING RAISING cx_static_check.
+    METHODS test_sticky_keep_saves_draft FOR TESTING RAISING cx_static_check.
+    METHODS test_context_info_sanitized FOR TESTING RAISING cx_static_check.
+    METHODS test_app_start_encoded_slash FOR TESTING RAISING cx_static_check.
     METHODS test_request_parse     FOR TESTING RAISING cx_static_check.
     METHODS test_request_origin    FOR TESTING RAISING cx_static_check.
     METHODS test_request_launchpad FOR TESTING RAISING cx_static_check.
@@ -1131,6 +1134,74 @@ CLASS ltcl_test_handler_post IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD test_sticky_keep_saves_draft.
+
+    DATA lo_handler TYPE REF TO z2ui5_cl_ui5_handler.
+    DATA(lo_draft) = NEW z2ui5_cl_ui5_srv_draft( ).
+
+    " a sticky app under KEEP routing: its draft id goes into the URL, so
+    " the draft has to exist for Back/Forward and a bookmark to restore it
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app          = NEW ltcl_app_noop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id     = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->mo_app->mv_check_sticky = abap_true.
+    lo_handler->mo_action->mo_app->mv_nav_mode     = z2ui5_if_client=>cs_nav_mode-keep.
+    DATA(lv_id_keep) = lo_handler->mo_action->mo_app->ms_draft-id.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_true( lo_draft->check_exists( lv_id_keep ) ).
+    cl_abap_unit_assert=>assert_true( lo_handler->mo_action->mo_app->mv_check_initialized ).
+
+    " a sticky app that asked for neither keeps skipping the serialization
+    lo_handler = NEW #( val = `` ).
+    lo_handler->mo_action->mo_app->mo_app          = NEW ltcl_app_noop( ).
+    lo_handler->mo_action->mo_app->ms_draft-id     = z2ui5_cl_ui5_util_context=>uuid_get_c32( ).
+    lo_handler->mo_action->mo_app->mv_check_sticky = abap_true.
+    DATA(lv_id_plain) = lo_handler->mo_action->mo_app->ms_draft-id.
+
+    lo_handler->main_end( ).
+
+    cl_abap_unit_assert=>assert_false( lo_draft->check_exists( lv_id_plain ) ).
+    cl_abap_unit_assert=>assert_true( lo_handler->mo_action->mo_app->mv_check_initialized ).
+
+  ENDMETHOD.
+
+  METHOD test_context_info_sanitized.
+
+    DATA lo_handler TYPE REF TO z2ui5_cl_ui5_handler.
+
+    " the 500 body quotes app_start - client-controlled, so markup in it is
+    " stripped the way factory_first_start strips it
+    lo_handler = NEW #( val = `` ).
+    lo_handler->ms_request-s_control-app_start = `ZCL_X<script>alert(1)</script>`.
+
+    DATA(lv_info) = lo_handler->request_context_info( ).
+
+    cl_abap_unit_assert=>assert_char_cp( act = lv_info
+                                         exp = `*app_start ZCL_Xscriptalert1/script*` ).
+    cl_abap_unit_assert=>assert_false( xsdbool( lv_info CS `<` ) ).
+
+  ENDMETHOD.
+
+  METHOD test_app_start_encoded_slash.
+
+    DATA lo_handler TYPE REF TO z2ui5_cl_ui5_handler.
+    DATA lo_no_comp_data TYPE REF TO z2ui5_if_ajson.
+    lo_handler = NEW #( val = `` ).
+
+    " a percent-encoded namespace in the query is the class name it spells
+    cl_abap_unit_assert=>assert_equals(
+        exp = `/NS/ZCL_APP`
+        act = lo_handler->request_app_start( iv_search    = `?app_start=%2Fns%2Fzcl_app`
+                                             io_comp_data = lo_no_comp_data ) ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `ZCL_APP`
+        act = lo_handler->request_app_start( iv_search    = `?app_start=zcl_app`
+                                             io_comp_data = lo_no_comp_data ) ).
+
+  ENDMETHOD.
 
   METHOD test_leave_root_ends_roundtrip.
 

--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
@@ -149,6 +149,9 @@ CLASS z2ui5_cl_ui5_srv_model DEFINITION PUBLIC FINAL.
         iv_table      TYPE string
         iv_row_parent TYPE i DEFAULT 0.
 
+    " re-entrancy latch of dissolve( ) - see the CATCH there
+    DATA mv_dissolve_refreshing TYPE abap_bool.
+
     METHODS delta_apply_scalar
       IMPORTING
         io_delta TYPE REF TO z2ui5_if_ajson
@@ -205,17 +208,40 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
 
           ASSIGN lr_ref->* TO FIELD-SYMBOL(<val>).
 
-          lo_val_front->to_abap( EXPORTING iv_corresponding = abap_true
-                                 IMPORTING ev_container     = <val> ).
+          " to_abap clears the target before it fills it, so a refused value
+          " would leave the attribute initial - the trace below promises the
+          " OLD value stays. Kept aside for the one path that can refuse;
+          " only attributes the request actually carries get this far
+          DATA lr_before TYPE REF TO data.
+          CREATE DATA lr_before LIKE <val>.
+          FIELD-SYMBOLS <before> TYPE any.
+          ASSIGN lr_before->* TO <before>.
+          <before> = <val>.
 
-        CATCH cx_root INTO DATA(x).
-          " chain the cause instead of inlining its text: the parser error
-          " below carries the position/attributes that say WHICH value did
-          " not fit, and only the chain transports them to the client
-          RAISE EXCEPTION TYPE z2ui5_cx_ui5_util_error
-            EXPORTING
-              val      = |JSON_PARSING_ERROR - attribute '{ lr_attri->name }' (model path '{ lr_attri->name_client }')|
-              previous = x.
+          TRY.
+              lo_val_front->to_abap( EXPORTING iv_corresponding = abap_true
+                                     IMPORTING ev_container     = <val> ).
+            CATCH cx_root INTO DATA(lx_refused).
+              <val> = <before>.
+              RAISE EXCEPTION lx_refused.
+          ENDTRY.
+
+        CATCH cx_root.
+          " A bound SCALAR (or a whole structure/table shipped as one value)
+          " the client sent in a form the ABAP type refuses - `1,250.00`
+          " typed into an Input bound to a packed field. This used to raise
+          " JSON_PARSING_ERROR and fail the whole roundtrip with the fatal
+          " overlay, while the same value in a table CELL was traced in
+          " t_model_skipped and the roundtrip went on. Same treatment now:
+          " the attribute is recorded (name = the attribute, row 0, no
+          " field), its old value stays, and the app decides what to tell
+          " the user - the reason the trace exists (see delta_apply_field)
+          DATA(ls_skip) = VALUE z2ui5_if_client=>ty_s_model_skip( name = lr_attri->name ).
+          TRY.
+              ls_skip-value = lo_val_front->get_string( `` ).
+            CATCH cx_root ##NO_HANDLER.
+          ENDTRY.
+          APPEND ls_skip TO mt_skipped.
       ENDTRY.
     ENDLOOP.
 
@@ -735,7 +761,15 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
       TRY.
           dissolve_run( ).
         CATCH cx_root.
+          " main_attri_refresh dissolves again - a dissolve_run that keeps
+          " raising would recurse without end. One refresh per dissolve;
+          " the second failure ends the pass with what was resolved so far
+          IF mv_dissolve_refreshing = abap_true.
+            EXIT.
+          ENDIF.
+          mv_dissolve_refreshing = abap_true.
           main_attri_refresh( ).
+          mv_dissolve_refreshing = abap_false.
       ENDTRY.
 
     ENDDO.

--- a/src/01/03/z2ui5_cl_ui5f_lib_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_lib_js.clas.abap
@@ -182,6 +182,20 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      control.setProperty("removedTokens", isRemoved ? tokens : []);` && |\n| &&
              `    }` && |\n| &&
              `` && |\n| &&
+             `    function afterRoundtrip(owner, fn) {` && |\n| &&
+             `      if (!AppState.state.isBusy) {` && |\n| &&
+             `        fn();` && |\n| &&
+             `        return () => {};` && |\n| &&
+             `      }` && |\n| &&
+             `      const once = () => {` && |\n| &&
+             `        unregisterCallback("onAfterRendering", once);` && |\n| &&
+             `        if (isDestroyed(owner)) return;` && |\n| &&
+             `        fn();` && |\n| &&
+             `      };` && |\n| &&
+             `      registerCallback("onAfterRendering", once);` && |\n| &&
+             `      return () => unregisterCallback("onAfterRendering", once);` && |\n| &&
+             `    }` && |\n| &&
+             `` && |\n| &&
              `    function runCallbacks(callbacks, ...args) {` && |\n| &&
              `      if (!callbacks) return;` && |\n| &&
              `      for (const fn of callbacks) {` && |\n| &&
@@ -410,7 +424,8 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      }` && |\n| &&
              `      _sanitizeEl.textContent = doc.body.textContent;` && |\n| &&
              `      return _sanitizeEl.innerHTML;` && |\n| &&
-             `    }` && |\n| &&
+             `    }` && |\n|.
+    result = result &&
              `` && |\n| &&
              `    const ROOT_MODEL_SLOTS = ["MAIN", "NEST", "NEST2"];` && |\n| &&
              `` && |\n| &&
@@ -424,8 +439,7 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      for (const key of ROOT_MODEL_SLOTS) {` && |\n| &&
              `        const limit = viewSizeLimits[key];` && |\n| &&
              `        if (limit !== undefined && (max === undefined || limit > max)) {` && |\n| &&
-             `          max = limit;` && |\n|.
-    result = result &&
+             `          max = limit;` && |\n| &&
              `        }` && |\n| &&
              `      }` && |\n| &&
              `      return max;` && |\n| &&
@@ -501,6 +515,7 @@ CLASS z2ui5_cl_ui5f_lib_js IMPLEMENTATION.
              `      logError,` && |\n| &&
              `      isDestroyed,` && |\n| &&
              `      isControllerAlive,` && |\n| &&
+             `      afterRoundtrip,` && |\n| &&
              `      isAlive,` && |\n| &&
              `      claimOnce,` && |\n| &&
              `      isTextInput,` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_upldset_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_upldset_js.clas.abap
@@ -26,13 +26,8 @@ CLASS z2ui5_cl_ui5f_upldset_js IMPLEMENTATION.
   METHOD get.
 
     result = `sap.ui.define(` && |\n| &&
-             `  [` && |\n| &&
-             `    "sap/ui/core/Control",` && |\n| &&
-             `    "z2ui5/core/Lib",` && |\n| &&
-             `    "z2ui5/core/ViewSlots",` && |\n| &&
-             `    "z2ui5/core/AppState",` && |\n| &&
-             `  ],` && |\n| &&
-             `  (Control, Lib, ViewSlots, AppState) => {` && |\n| &&
+             `  ["sap/ui/core/Control", "z2ui5/core/Lib", "z2ui5/core/ViewSlots"],` && |\n| &&
+             `  (Control, Lib, ViewSlots) => {` && |\n| &&
              `    "use strict";` && |\n| &&
              `` && |\n| &&
              `    return Control.extend("z2ui5.cc.UploadSetExt", {` && |\n| &&
@@ -86,9 +81,9 @@ CLASS z2ui5_cl_ui5f_upldset_js IMPLEMENTATION.
              `      exit() {` && |\n| &&
              `        this._unhook();` && |\n| &&
              `        this._queue = [];` && |\n| &&
-             `        if (this._afterRoundtrip) {` && |\n| &&
-             `          Lib.unregisterCallback("onAfterRendering", this._afterRoundtrip);` && |\n| &&
-             `          this._afterRoundtrip = null;` && |\n| &&
+             `        if (this._cancelWait) {` && |\n| &&
+             `          this._cancelWait();` && |\n| &&
+             `          this._cancelWait = null;` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
@@ -113,25 +108,13 @@ CLASS z2ui5_cl_ui5f_upldset_js IMPLEMENTATION.
              `            this.setProperty("mediaType", file.type);` && |\n| &&
              `            this.setProperty("fileSize", String(file.size));` && |\n| &&
              `            this.fireChange();` && |\n| &&
-             `            this._whenRoundtripLanded(() => this._readNext());` && |\n| &&
+             `            this._cancelWait = Lib.afterRoundtrip(this, () => {` && |\n| &&
+             `              this._cancelWait = null;` && |\n| &&
+             `              this._readNext();` && |\n| &&
+             `            });` && |\n| &&
              `          },` && |\n| &&
              `          "UploadSetExt",` && |\n| &&
              `        );` && |\n| &&
-             `      },` && |\n| &&
-             `` && |\n| &&
-             `      _whenRoundtripLanded(fn) {` && |\n| &&
-             `        if (!AppState.state.isBusy) {` && |\n| &&
-             `          fn();` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        const once = () => {` && |\n| &&
-             `          Lib.unregisterCallback("onAfterRendering", once);` && |\n| &&
-             `          this._afterRoundtrip = null;` && |\n| &&
-             `          if (Lib.isDestroyed(this)) return;` && |\n| &&
-             `          fn();` && |\n| &&
-             `        };` && |\n| &&
-             `        this._afterRoundtrip = once;` && |\n| &&
-             `        Lib.registerCallback("onAfterRendering", once);` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      onItemAdded(oEvent) {` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_uploader_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_uploader_js.clas.abap
@@ -109,13 +109,28 @@ CLASS z2ui5_cl_ui5f_uploader_js IMPLEMENTATION.
              `        },` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
-             `      _readFile(file) {` && |\n| &&
+             `      _readFiles(files) {` && |\n| &&
+             `        this._queue = (this._queue || []).concat(files);` && |\n| &&
+             `        if (!this._reading) this._readNext();` && |\n| &&
+             `      },` && |\n| &&
+             `` && |\n| &&
+             `      _readNext() {` && |\n| &&
+             `        const file = this._queue.shift();` && |\n| &&
+             `        if (!file) {` && |\n| &&
+             `          this._reading = false;` && |\n| &&
+             `          return;` && |\n| &&
+             `        }` && |\n| &&
+             `        this._reading = true;` && |\n| &&
              `        Lib.readFileAsDataURL(` && |\n| &&
              `          file,` && |\n| &&
              `          this,` && |\n| &&
              `          (result) => {` && |\n| &&
              `            this.setProperty("value", result);` && |\n| &&
              `            this.fireUpload();` && |\n| &&
+             `            this._cancelWait = Lib.afterRoundtrip(this, () => {` && |\n| &&
+             `              this._cancelWait = null;` && |\n| &&
+             `              this._readNext();` && |\n| &&
+             `            });` && |\n| &&
              `          },` && |\n| &&
              `          "FileUploader",` && |\n| &&
              `        );` && |\n| &&
@@ -123,6 +138,11 @@ CLASS z2ui5_cl_ui5f_uploader_js IMPLEMENTATION.
              `` && |\n| &&
              `      exit() {` && |\n| &&
              `        if (this._oHBox) this._oHBox.destroy();` && |\n| &&
+             `        this._queue = [];` && |\n| &&
+             `        if (this._cancelWait) {` && |\n| &&
+             `          this._cancelWait();` && |\n| &&
+             `          this._cancelWait = null;` && |\n| &&
+             `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&
              `      _ensureControls(directUpload) {` && |\n| &&
@@ -137,8 +157,8 @@ CLASS z2ui5_cl_ui5f_uploader_js IMPLEMENTATION.
              `            enabled: this.getProperty("path") !== "",` && |\n| &&
              `            press: () => {` && |\n| &&
              `              this.setProperty("path", this.oFileUploader.getProperty("value"));` && |\n| &&
-             `              if (this._pendingFile) {` && |\n| &&
-             `                this._readFile(this._pendingFile);` && |\n| &&
+             `              if (this._pendingFiles?.length) {` && |\n| &&
+             `                this._readFiles(this._pendingFiles);` && |\n| &&
              `              }` && |\n| &&
              `            },` && |\n| &&
              `          });` && |\n| &&
@@ -148,7 +168,7 @@ CLASS z2ui5_cl_ui5f_uploader_js IMPLEMENTATION.
              `          uploadOnChange: directUpload,` && |\n| &&
              `          change: (oEvent) => {` && |\n| &&
              `            const files = oEvent.getParameter("files");` && |\n| &&
-             `            this._pendingFile = files?.[0];` && |\n| &&
+             `            this._pendingFiles = files ? Array.from(files) : [];` && |\n| &&
              `            if (directUpload) return;` && |\n| &&
              `            const value = oEvent.getSource().getProperty("value");` && |\n| &&
              `            this.setProperty("path", value);` && |\n| &&
@@ -160,8 +180,8 @@ CLASS z2ui5_cl_ui5f_uploader_js IMPLEMENTATION.
              `            if (!directUpload) return;` && |\n| &&
              `            const source = oEvent.getSource();` && |\n| &&
              `            this.setProperty("path", source.getProperty("value"));` && |\n| &&
-             `            if (this._pendingFile) {` && |\n| &&
-             `              this._readFile(this._pendingFile);` && |\n| &&
+             `            if (this._pendingFiles?.length) {` && |\n| &&
+             `              this._readFiles(this._pendingFiles);` && |\n| &&
              `            }` && |\n| &&
              `          },` && |\n| &&
              `        });` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_view1_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_view1_js.clas.abap
@@ -58,6 +58,8 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `      },` && |\n| &&
              `` && |\n| &&
              `      async _processAfterRendering(reqSeq) {` && |\n| &&
+             `        let superseded = false;` && |\n| &&
+             `` && |\n| &&
              `        const oResponse = AppState.state.oResponse;` && |\n| &&
              `        if (!oResponse || oResponse._processed) return;` && |\n| &&
              `        oResponse._processed = true;` && |\n| &&
@@ -83,6 +85,7 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `            !Lib.isControllerAlive(this) ||` && |\n| &&
              `            oResponse !== AppState.state.oResponse` && |\n| &&
              `          ) {` && |\n| &&
+             `            superseded = true;` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
              `` && |\n| &&
@@ -101,12 +104,14 @@ CLASS z2ui5_cl_ui5f_view1_js IMPLEMENTATION.
              `            "Unexpected Error Occurred - App Terminated",` && |\n| &&
              `          );` && |\n| &&
              `        } finally {` && |\n| &&
-             `          BusyIndicator.hide();` && |\n| &&
-             `          AppState.state.isBusy = false;` && |\n| &&
+             `          if (!superseded) {` && |\n| &&
+             `            BusyIndicator.hide();` && |\n| &&
+             `            AppState.state.isBusy = false;` && |\n| &&
              `` && |\n| &&
-             `          this._runPendingCustomJs(oResponse);` && |\n| &&
+             `            this._runPendingCustomJs(oResponse);` && |\n| &&
              `` && |\n| &&
-             `          Router.dispatchPendingAppHash();` && |\n| &&
+             `            Router.dispatchPendingAppHash();` && |\n| &&
+             `          }` && |\n| &&
              `        }` && |\n| &&
              `      },` && |\n| &&
              `` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_websock_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_websock_js.clas.abap
@@ -86,14 +86,18 @@ CLASS z2ui5_cl_ui5f_websock_js IMPLEMENTATION.
              `          this._disconnect();` && |\n| &&
              `` && |\n| &&
              `          this._failedAttempts = 0;` && |\n| &&
+             `          this._doneAfterFirst = false;` && |\n| &&
              `        }` && |\n| &&
              `        this._url = url;` && |\n| &&
              `        const active = this.getProperty("checkActive");` && |\n| &&
              `` && |\n| &&
              `        if (active && this._wasInactive) {` && |\n| &&
              `          this._failedAttempts = 0;` && |\n| &&
+             `          this._doneAfterFirst = false;` && |\n| &&
              `        }` && |\n| &&
              `        this._wasInactive = !active;` && |\n| &&
+             `` && |\n| &&
+             `        if (this.getProperty("checkRepeat")) this._doneAfterFirst = false;` && |\n| &&
              `        if (active) {` && |\n| &&
              `          this._connect();` && |\n| &&
              `        } else {` && |\n| &&
@@ -116,6 +120,8 @@ CLASS z2ui5_cl_ui5f_websock_js IMPLEMENTATION.
              `      _connect() {` && |\n| &&
              `        if (this._ws || !this._url) return;` && |\n| &&
              `        if (this._failedAttempts >= MAX_CONNECT_ATTEMPTS) return;` && |\n| &&
+             `` && |\n| &&
+             `        if (this._doneAfterFirst) return;` && |\n| &&
              `        const url = this._url;` && |\n| &&
              `        let ws;` && |\n| &&
              `        try {` && |\n| &&
@@ -140,7 +146,10 @@ CLASS z2ui5_cl_ui5f_websock_js IMPLEMENTATION.
              `            Lib.logError("Websocket: ignored a non-text message");` && |\n| &&
              `            return;` && |\n| &&
              `          }` && |\n| &&
-             `          if (!this.getProperty("checkRepeat")) this._disconnect();` && |\n| &&
+             `          if (!this.getProperty("checkRepeat")) {` && |\n| &&
+             `            this._doneAfterFirst = true;` && |\n| &&
+             `            this._disconnect();` && |\n| &&
+             `          }` && |\n| &&
              `          this._report({ kind: "message", value: event.data });` && |\n| &&
              `        };` && |\n| &&
              `        ws.onerror = () => {` && |\n| &&

--- a/src/02/z2ui5_cl_ui5_http_handler.clas.abap
+++ b/src/02/z2ui5_cl_ui5_http_handler.clas.abap
@@ -699,7 +699,26 @@ CLASS z2ui5_cl_ui5_http_handler IMPLEMENTATION.
     " are structurally identical, so MOVE-CORRESPONDING carries every field
     " including s_stateful - and the public signature stays free of a Layer 1
     " type (see ty_s_http_res above).
-    MOVE-CORRESPONDING lo_post->main( ) TO result.
+    "
+    " A sticky handler answers the NEXT request from whatever action it
+    " holds when this one ends. main( ) replaces the action on every nav
+    " hop, so an exception mid-hop used to leave the CALLED app's action in
+    " place - the next request (factory_by_frontend ignores the id while
+    " the sticky container holds an app) then ran against an app the
+    " frontend never saw, with the state main( ) had left it in. The action
+    " the request started with is put back and its queues cleared before
+    " the exception travels on to _main( )'s single catch; the app's own
+    " state stays what main( ) made of it, like in any stateful ABAP session
+    DATA(lo_action_before) = lo_post->mo_action.
+    TRY.
+        MOVE-CORRESPONDING lo_post->main( ) TO result.
+      CATCH cx_root INTO DATA(lx_main).
+        IF so_sticky_handler IS BOUND.
+          lo_post->mo_action = lo_action_before.
+          CLEAR lo_post->mo_action->ms_next.
+        ENDIF.
+        RAISE EXCEPTION lx_main.
+    ENDTRY.
 
     TRY.
         IF lo_post->mo_action->mo_app->mv_check_sticky = abap_true.


### PR DESCRIPTION
# Description

Third and last follow-up to [#2703](https://github.com/abap2UI5/abap2UI5/pull/2703) and [#2704](https://github.com/abap2UI5/abap2UI5/pull/2704): every remaining finding of the review, including the ones first filed as design gaps or low.

**Backend**

- **A bound scalar the client sends in a refused form** (`1,250.00` typed into an Input bound to a packed field) **failed the whole roundtrip** with `JSON_PARSING_ERROR` and the fatal overlay, while the same value in a table cell was traced. It lands in `t_model_skipped` now (attribute name, row 0, raw value) and the attribute keeps its old value - `to_abap` clears the target before filling it, so the value is kept aside and put back on refusal.
- **Sticky apps put draft ids into KEEP routes and app-state links that were never persisted**: every Back/Forward, reload or shared link landed in "bookmarked app state expired". `main_end_save` saves the draft for a sticky app in exactly those two modes; a sticky app that asked for neither keeps skipping the serialization.
- **A failing roundtrip in a stateful session** left the sticky handler with whatever action `main( )` held mid-hop - the next request ran against a called app the frontend never saw. `_http_post` puts the request's starting action back (queues cleared) before the exception travels on to `_main( )`'s single catch.
- **The 500 body reflected `app_start` unsanitized**; it is stripped to class-name-safe characters, like `factory_first_start` already did.
- **`?app_start=%2Fns%2Fclass`** resolves to the namespaced class it spells.
- **`nav_app_leave( r_data = lo_object )`** reached `conv_copy_ref_data`, which dereferenced the object reference as data. `rtti_check_ref_data` answers true for a reference to DATA only; the object reference is copied as the value it is.
- **`dissolve( )` could recurse without end** through `main_attri_refresh` on a persistently raising `dissolve_run`. One refresh per pass.

**Frontend** (`src/01/03` regenerated via `npm run app2abap`)

- **A superseded response ended the busy state** the superseding request relied on (its `finally` still hid the indicator and ran its custom JS), so a click could dispatch a third request that aborted a Back/Forward restore. The `finally` now leaves busy, custom JS and the parked app hash to the newer request.
- **`Websocket` with `checkRepeat = false` reconnected on every re-render** - "once" meant once per roundtrip. It stays closed until a path change or a `checkActive`/`checkRepeat` toggle asks again.
- **`FileUploader` with `multiple` read only `files[0]`.** Every selected file is read now, one roundtrip each, through the new `Lib.afterRoundtrip(owner, fn)` (runs `fn` once the roundtrip a change started has landed; immediately when none started) - shared with `UploadSetExt`, whose own copy of that wait from #2704 is replaced by it.

## How to test

- `npm run check` (0 findings), `npm run downport && npm run auto_transpile && npm run unit` (1180 tests), `npm run check:js` (1053 specs), `npm run gates` (31 of 31).
- New ABAP tests: `test_refused_scalar_reported`, `test_sticky_keep_saves_draft`, `test_context_info_sanitized`, `test_app_start_encoded_slash`, `test_copy_ref_object`. New specs: the superseded and winning response in `view1Events.spec.js`, `checkRepeat=false` across re-renders in `websocket.spec.js`, multi-select in `fileUploader.spec.js`, `afterRoundtrip` in `utilHelpers.spec.js`.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) - run as its parts: check, gates, downport, auto_transpile, unit, check:js, app2abap drift
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`)
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md)
- [x] Public API in `src/02/` only changed additively - `z2ui5_cl_ui5_http_handler=>_http_post` body only, no signature touched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour - eleven `*` lines
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsvVb8kcFTK95LRwEcHB9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsvVb8kcFTK95LRwEcHB9r)_