### PR TITLE
shared-file: gate the two paths web-abap2UI5 reads out of a clone

### DIFF
--- a/.github/scripts/shared-file-gate.mjs
+++ b/.github/scripts/shared-file-gate.mjs
@@ -402,6 +402,57 @@ if (manifestArg !== -1) {
   },
 ];
 
+/* Files this repository owns that a downstream repository does not COPY but
+ * READS, straight out of a clone of this one.
+ *
+ * web-abap2UI5 clones abap2UI5 every night, downports it, transpiles it and
+ * publishes the result as the in-browser demo. It used to keep its own
+ * transcription of two of these files and paid for it twice: its nightly went
+ * red on 2026-08-03 and again on 2026-09-02, both times because a test landed
+ * here together with the `skip` entry saying it cannot run under the
+ * transpiler, and only the test reached the copy. It now reads both files out
+ * of the clone instead, which ends the drift — and creates a new obligation
+ * here: these paths, and the shape of what is at them, are an interface.
+ *
+ * Not part of SHARED above, because nothing is compared: there is no second
+ * copy to differ from. What can still break the consumer is this repository
+ * MOVING one of them or changing what it holds, and that is what these
+ * entries check — cheaply, locally, in the pull request that does it, rather
+ * than in somebody else's build the next morning.
+ *
+ * `shape` states the assumption the consumer actually makes, so renaming a
+ * key is caught as well as deleting the file. Keep it to that; a consumer
+ * asserting the CONTENT of a config here would be this repository's tail
+ * wagged by another repository's build, which is precisely what the entries
+ * are meant to avoid.
+ */
+const CONSUMED = [
+  {
+    file: 'node/setup/abap_transpile.json',
+    key: 'options.skip',
+    consumer: 'web-abap2UI5',
+    why: 'the unit tests that cannot run under the transpiler — declared here,'
+      + ' in the same commit as the test, and read from the clone by the'
+      + " nightly that transpiles these same sources",
+    shape: (text) => {
+      const skip = parseJsonc(text)?.options?.skip;
+      if (!Array.isArray(skip)) throw new Error('options.skip is not an array');
+    },
+  },
+  {
+    file: '.github/abaplint/abap_702.jsonc',
+    key: 'rules / syntax',
+    consumer: 'web-abap2UI5',
+    why: 'the downport rule set and syntax version — the consumer downports the'
+      + ' same sources and has to be judged by the same rules',
+    shape: (text) => {
+      const cfg = parseJsonc(text);
+      if (!cfg?.rules || typeof cfg.rules !== 'object') throw new Error('no rules object');
+      if (!cfg?.syntax?.version) throw new Error('no syntax.version');
+    },
+  },
+];
+
 /* The body of a family-nav checker: everything from its first `import` down.
  *
  * Above that line each repository owns three constants — SELF, PAGE_HTML,
@@ -593,8 +644,32 @@ for (const entry of SHARED) {
   }
 }
 
+/* The consumed-path check. Local and offline on purpose: it asks only whether
+ * THIS repository still holds up its end, which is a question this checkout
+ * can answer on its own. */
+for (const entry of CONSUMED) {
+  const source = path.join(ROOT, entry.file);
+  if (!fs.existsSync(source)) {
+    problems.push(
+      `${entry.file}: read directly from a clone by ${entry.consumer} (${entry.why}), and it is gone.\n`
+      + `    Moving it breaks that build on its next run. Restore the path, or move it and`
+      + ` update ${entry.consumer} in the same breath.`,
+    );
+    continue;
+  }
+  try {
+    entry.shape(fs.readFileSync(source, 'utf8'));
+  } catch (err) {
+    problems.push(
+      `${entry.file}: ${entry.consumer} reads ${entry.key} out of this file and ${err.message}.\n`
+      + `    ${entry.why}`,
+    );
+  }
+}
+
 console.log(
-  `shared-file: ${SHARED.length} shared file(s), compared against ${compared} of ${expected} copy/copies`,
+  `shared-file: ${SHARED.length} shared file(s), compared against ${compared} of ${expected} copy/copies`
+  + `; ${CONSUMED.length} path(s) read from a clone downstream`,
 );
 for (const n of notes) console.log(`  ${n}`);
 


### PR DESCRIPTION
# Description

`web-abap2UI5` clones this repository every night, downports it, transpiles it and publishes the result as the in-browser demo. Until today it kept its own transcription of two files from here, and it paid for that twice:

- **2026-08-03** ([web-abap2UI5#63](https://github.com/abap2UI5/web-abap2UI5/issues/63)) — `test_tab_ref_gen` landed with its `skip` entry in `node/setup/abap_transpile.json`; only the test reached the copy.
- **2026-09-02** ([web-abap2UI5#84](https://github.com/abap2UI5/web-abap2UI5/issues/84)) — the same thing with `test_skip_sorted_table`, from #2704. The `skip` entry was **57 minutes old** when that build consumed it.

[web-abap2UI5#85](https://github.com/abap2UI5/web-abap2UI5/pull/85) ends the transcription: it now reads `options.skip` from `node/setup/abap_transpile.json` and `rules` / `syntax` from `.github/abaplint/abap_702.jsonc` straight out of the clone. (That also recovered `xml_bom`, which had silently dropped out of its copy of the rule set.)

What it cannot do from its side is notice **this** repository moving one of those files, or changing what is at them. It would find out on the next nightly, as a build that stops with a path in the message. So the two paths are declared here, where the move would happen.

Not an entry in `SHARED`: nothing is compared, because there is no second copy to differ from. A new `CONSUMED` list, checked locally and offline, asks only whether this repository still holds up its end — the file is there, and the key the consumer reads is still shaped the way it reads it. That turns a rename into a failing check in the pull request that does it, rather than a discovery somewhere else the next morning.

`shape` deliberately stops at the key and does not look at content. A consumer asserting what is *in* a config here would be this repository's tail wagged by another repository's build, which is the thing these entries exist to prevent — moving a file stays allowed, doing it silently does not.

## How to test

```bash
npm run check:shared
# shared-file: 15 shared file(s), compared against 37 of 37 copy/copies; 2 path(s) read from a clone downstream
# every copy matches its source here - OK
```

Both entries were checked the other way round as well. Moving the file away:

```
node/setup/abap_transpile.json: read directly from a clone by web-abap2UI5 (…), and it is gone.
    Moving it breaks that build on its next run. Restore the path, or move it and update web-abap2UI5 in the same breath.
```

Renaming the key it reads:

```
.github/abaplint/abap_702.jsonc: web-abap2UI5 reads rules / syntax out of this file and no rules object.
    the downport rule set and syntax version — the consumer downports the same sources and has to be judged by the same rules
```

## Checklist

- [x] `npm run gates` passes — 31 checked, all OK — and `npm run check:eslint` is clean. `npm run verify` was not run in full: this diff is one CI script, touching no ABAP.
- [ ] Unit tests added/updated where it makes sense — no test framework for the gate scripts; both entries were exercised by hand in both directions, shown above
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` — nothing under `src/` is touched
- [x] Public API in `src/02/` only changed additively — untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour — no behaviour change; a CI gate only, and `check:changelog-entry` scopes the requirement to `src/02/**` and `.github/api-snapshot.json`
- [ ] Changes were made via abapGit: **no** — a `.mjs` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ieKEMrEpR7hoZQcNMTuJr

---
_Generated by [Claude Code](https://claude.ai/code/session_011ieKEMrEpR7hoZQcNMTuJr)_