### PR TITLE
Point the README at the sample catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
   <a href="https://abap2UI5.org">Documentation</a> •
-  <a href="https://abap2ui5.github.io/samples/">Samples</a> •
+  <a href="https://abap2ui5.github.io/playground/samples/">Samples</a> •
   <a href="#ai-assistants">AI Assistants</a> •
   <a href="https://github.com/abap2UI5/abap2UI5/issues">Issues</a> •
   <a href="https://join.slack.com/t/abapgit/shared_invite/zt-46tqufaht-QlrxTzlDqlx85CWbeUnOqg">Slack</a> •
@@ -57,7 +57,7 @@ ENDCLASS.
 
 That's it – your first UI5 app is ready and abap2UI5 handles the rest! 🎉
 
-Next stop: the [samples](https://abap2ui5.github.io/samples/) – hundreds of ready-to-run apps, from data binding basics to OData, RAP, and Launchpad integration – and the [docs](https://abap2ui5.github.io/docs/) for everything else.
+Next stop: the [sample catalogue](https://abap2ui5.github.io/playground/samples/) – hundreds of ready-to-run apps, from data binding basics to OData, RAP, and Launchpad integration, searchable by control and by the UI5 release your system runs, and most of them one click from running in the browser – and the [docs](https://abap2ui5.github.io/docs/) for everything else.
 
 ## How It Works
 


### PR DESCRIPTION
# Description

Two README links pointed at `abap2ui5.github.io/samples/`, one of three GitHub Pages sites — one per sample repository — being retired. One catalogue over all three is published from the playground instead (**abap2UI5/playground#44**), searchable by control and by the UI5 release a system runs, with most rows one click from running in the browser.

Documentation-only. No `src/` change.

The backlog item that names the old `samples-controls` demo URL (`backlog/items/open-abap-xml-escaping.md`) is left as it is: it is a dated record of where a bug was found, and that page had already gone in August.

## How to test

Follow both links in `README.md` — the header nav and the "Next stop" line after the getting-started snippet — and check they land on the catalogue rather than a 404. They will 404 until abap2UI5/playground#44 deploys, which is the reason this one should merge after it.

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) — n/a, no code changed; nothing under `src/`, `app/` or `node/` is touched
- [x] Unit tests added/updated where it makes sense — n/a, documentation only
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively — unchanged
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour — no behaviour change
- [x] Changes were made via abapGit: no

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqszEpeUbxyEhHKuUFBjEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqszEpeUbxyEhHKuUFBjEr)_