### PR TITLE
message_box_display() renders any data, not just messages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,8 @@ Legend
 
 unreleased
 ----------
++ client->message_box_display( ) shows whatever is thrown at it: messages are still recognized first (BAPIRET2, T100, RAP, symsg, log objects, exceptions - unchanged, severity and title come from the message), and everything that carries none of them is now rendered instead of dropped - a business table, a nested structure or tree, an object, a number, an HTML string (which moves into the details, where UI5 renders it as markup rather than showing the tags). The box gets a headline, the data goes into the details; complex data that is initial still shows nothing at all
+! A structure without a single message component no longer counts as a message: it used to reach the box as one blank line per row (an empty popup), and is now handed to the generic renderer
 ! The draft is written with one database statement per roundtrip instead of two: create( ) inserts first and asks who owns the row only when the key already exists (the SELECT that guarded a MODIFY on every save always hit an empty row on the legitimate paths, the id being a fresh uuid) - a foreign-owned id is still refused, and stays as it was
 ! The user exit is looked up once per request instead of twice: the superseded Z2UI5_IF_EXIT is asked for implementers only when Z2UI5_IF_UI5_EXIT names none, and a system that carries one class per interface now gets the current one instead of whichever sorted first across both lists
 ! The view model is read out of the parsed request in place: the request tree travels with the path of its MODEL node (ty_s_request-model_path) and the model service addresses the attributes below it, where the MODEL container used to be sliced out - a walk over every node of the request and a second copy of the whole delta on a mass edit

--- a/docs/agents/building-apps.md
+++ b/docs/agents/building-apps.md
@@ -555,6 +555,17 @@ The same tree, with the subtree held in a variable:
 - `client->message_toast_display( text )` and
   `client->message_box_display( text type title actions … )` for messages —
   never build your own toast/dialog for these.
+- **`message_box_display( text )` takes anything.** `text` is `TYPE any`, so
+  throw in what you have: a string, a BAPIRET2 / T100 / RAP / `symsg`
+  structure or table, a log object, an exception, an HTML string, a business
+  table, a nested structure or tree, an object, a number. Messages are
+  recognized first — they set the box's severity and title themselves and
+  several of them collapse into one box with a bullet list. Anything else is
+  rendered generically: a headline in the box (`Table with 12 entries`), the
+  data itself in the details. You do not pre-format anything and you do not
+  branch on what you have. The one case that shows no box at all is complex
+  data that is initial, so `message_box_display( lt_return )` after a call
+  that returned nothing stays silent, as it always has.
 - Bind popup data exactly like main-view data; changed bound data reaches
   an open popup automatically.
 - A popup or popover is closed automatically by anything that replaces the

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
@@ -157,6 +157,21 @@ CLASS z2ui5_cl_ui5_util_context DEFINITION
       RETURNING
         VALUE(result) TYPE ty_s_msg_box.
 
+    "! Everything a message box can be built from that is NOT a message.
+    "! ui5_msg_box_format( ) is asked first and answers `skip` when nothing
+    "! it was handed is a message - this is what runs then, so that a box
+    "! the app asked for always has something to show: a character value
+    "! (its own text, markup moved into the details), a number, a table, a
+    "! nested structure or tree, an object, a data reference. `text` gets a
+    "! one-line headline, `details` the data itself rendered as HTML.
+    "! Complex data that is initial answers `skip` - a call over an empty
+    "! table stays as silent as it is over an empty message table.
+    CLASS-METHODS ui5_data_box_format
+      IMPORTING
+        val           TYPE any
+      RETURNING
+        VALUE(result) TYPE ty_s_msg_box.
+
     CLASS-METHODS rtti_check_serializable
       IMPORTING
         val           TYPE REF TO object
@@ -777,6 +792,113 @@ CLASS z2ui5_cl_ui5_util_context DEFINITION
     CLASS-METHODS msg_get_rap_fail_text
       IMPORTING
         cause         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    " What a rendered box stays inside. A data dump is a diagnostic, not a
+    " report: a MessageBox that carries 10.000 rows or follows a reference
+    " graph until it runs out of stack helps nobody, and the roundtrip pays
+    " for every character of it. Both limits are announced in the output
+    " rather than applied silently.
+    CONSTANTS cv_data_max_rows  TYPE i VALUE 100.
+    CONSTANTS cv_data_max_depth TYPE i VALUE 5.
+    " the headline is one line of a MessageBox - what does not fit there is
+    " in the details anyway
+    CONSTANTS cv_data_max_text  TYPE i VALUE 200.
+
+    "! Render any value into the HTML fragment the box details show. Depth
+    "! is the recursion level, checked against cv_data_max_depth.
+    CLASS-METHODS data_render
+      IMPORTING
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS data_render_tab
+      IMPORTING
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS data_render_struc
+      IMPORTING
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS data_render_oref
+      IMPORTING
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS data_render_dref
+      IMPORTING
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! One named value as a list item - the shape a component of a
+    "! structure and an attribute of an object both take.
+    CLASS-METHODS data_render_item
+      IMPORTING
+        name          TYPE clike
+        val           TYPE any
+        depth         TYPE i
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! The one line the box shows without the details being opened.
+    CLASS-METHODS data_get_headline
+      IMPORTING
+        val           TYPE any
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! Any elementary value as its text, and never an exception.
+    CLASS-METHODS data_get_string
+      IMPORTING
+        val           TYPE any
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! The text of an exception object, empty for every other object.
+    CLASS-METHODS data_get_exc_text
+      IMPORTING
+        val           TYPE REF TO object
+      RETURNING
+        VALUE(result) TYPE string.
+
+    CLASS-METHODS html_get_list
+      IMPORTING
+        items         TYPE string_table
+        ordered       TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! Escape what would otherwise be read as markup.
+    CLASS-METHODS html_escape
+      IMPORTING
+        val           TYPE clike
+      RETURNING
+        VALUE(result) TYPE string.
+
+    "! Does this text carry HTML markup?
+    CLASS-METHODS html_check
+      IMPORTING
+        val           TYPE clike
+      RETURNING
+        VALUE(result) TYPE abap_bool.
+
+    "! HTML as the plain text behind it, capped at cv_data_max_text.
+    CLASS-METHODS html_get_plain
+      IMPORTING
+        val           TYPE clike
       RETURNING
         VALUE(result) TYPE string.
 
@@ -1738,6 +1860,14 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
   METHOD ui5_msg_box_format.
 
     DATA(lt_msg) = msg_get_t( val ).
+
+    " a structure that carries none of the message components maps to an
+    " entry with no text at all - that is not a message, it is data, and it
+    " used to reach the box as a popup with a blank line in it. Dropping it
+    " here is what lets `skip` mean "nothing in here is a message" and lets
+    " the caller fall back to ui5_data_box_format( )
+    DELETE lt_msg WHERE text IS INITIAL.
+
     DATA(lv_lines) = lines( lt_msg ).
 
     IF lv_lines = 0.
@@ -1763,6 +1893,365 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
       INSERT |<li>{ lr_msg->text }</li>| INTO TABLE lt_detail_items.
     ENDLOOP.
     result-details = `<ul>` && concat_lines_of( lt_detail_items ) && `</ul>`.
+
+  ENDMETHOD.
+
+  METHOD ui5_data_box_format.
+
+    " a character value is its own text, whatever is in it - an empty one
+    " included, which is the shape message_box_display( lv_text ) has always
+    " had and is not this method's to change
+    IF rtti_check_clike( val ) = abap_true.
+      IF html_check( val ) = abap_true.
+        " markup in the box text would be shown as the tags it is written
+        " with - sap.m.MessageBox renders the text through a sap.m.Text and
+        " the DETAILS through a sap.m.FormattedText, so that is where HTML
+        " belongs. The plain text behind it stays as the headline
+        result-text    = html_get_plain( val ).
+        result-details = val.
+      ELSE.
+        result-text = val.
+      ENDIF.
+      RETURN.
+    ENDIF.
+
+    " a number, a date, a hex value: shown the way the runtime writes it
+    IF rtti_check_printable( val ) = abap_true.
+      result-text = data_get_string( val ).
+      RETURN.
+    ENDIF.
+
+    " complex data that is initial stays silent. An app that hands over the
+    " result table of a call it just made expects no popup when the call
+    " returned nothing, and that expectation predates this method
+    IF val IS INITIAL.
+      result-skip = abap_true.
+      RETURN.
+    ENDIF.
+
+    result-text    = data_get_headline( val ).
+    result-details = data_render( val   = val
+                                  depth = 0 ).
+
+    IF result-text IS INITIAL AND result-details IS INITIAL.
+      result-skip = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD data_render.
+
+    " the recursion stops here rather than in every branch below, and says
+    " in the output that it did
+    IF depth > cv_data_max_depth.
+      result = `<em>...</em>`.
+      RETURN.
+    ENDIF.
+
+    CASE rtti_get_type_kind( val ).
+      WHEN cl_abap_datadescr=>typekind_table.
+        result = data_render_tab( val   = val
+                                  depth = depth ).
+      WHEN cl_abap_datadescr=>typekind_struct1 OR cl_abap_datadescr=>typekind_struct2.
+        result = data_render_struc( val   = val
+                                    depth = depth ).
+      WHEN cl_abap_datadescr=>typekind_oref.
+        result = data_render_oref( val   = val
+                                   depth = depth ).
+      WHEN cl_abap_datadescr=>typekind_dref.
+        result = data_render_dref( val   = val
+                                   depth = depth ).
+      WHEN OTHERS.
+        result = html_escape( data_get_string( val ) ).
+    ENDCASE.
+
+  ENDMETHOD.
+
+  METHOD data_render_tab.
+
+    DATA lt_item TYPE string_table.
+    DATA lv_no   TYPE i.
+
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
+    ASSIGN val TO <tab>.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    LOOP AT <tab> ASSIGNING FIELD-SYMBOL(<row>).
+      lv_no = lv_no + 1.
+      IF lv_no > cv_data_max_rows.
+        INSERT |<li><em>... { lines( <tab> ) - cv_data_max_rows } more entries</em></li>|
+               INTO TABLE lt_item.
+        EXIT.
+      ENDIF.
+      INSERT |<li>{ data_render( val   = <row>
+                                 depth = depth + 1 ) }</li>| INTO TABLE lt_item.
+    ENDLOOP.
+
+    result = html_get_list( items   = lt_item
+                            ordered = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD data_render_struc.
+
+    DATA lt_item TYPE string_table.
+
+    FIELD-SYMBOLS <comp> TYPE any.
+
+    TRY.
+        DATA(lt_attri) = rtti_get_t_attri_by_any( val ).
+      CATCH cx_root.
+        " a structure RTTI cannot describe still has a value - the caller
+        " keeps the headline, the details stay empty
+        RETURN.
+    ENDTRY.
+
+    LOOP AT lt_attri REFERENCE INTO DATA(lr_attri).
+      DATA(lv_name) = CONV string( lr_attri->name ).
+      ASSIGN COMPONENT lv_name OF STRUCTURE val TO <comp>.
+      IF sy-subrc <> 0.
+        CONTINUE.
+      ENDIF.
+      INSERT data_render_item( name  = lv_name
+                               val   = <comp>
+                               depth = depth ) INTO TABLE lt_item.
+    ENDLOOP.
+
+    result = html_get_list( lt_item ).
+
+  ENDMETHOD.
+
+  METHOD data_render_oref.
+
+    DATA lo_obj  TYPE REF TO object.
+    DATA lt_item TYPE string_table.
+
+    FIELD-SYMBOLS <comp> TYPE any.
+
+    TRY.
+        lo_obj = val.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
+    IF lo_obj IS NOT BOUND.
+      RETURN.
+    ENDIF.
+
+    " an exception carries its own text, and that text is the whole story -
+    " its attributes are the placeholders that are already substituted in it
+    result = data_get_exc_text( lo_obj ).
+    IF result IS NOT INITIAL.
+      result = html_escape( result ).
+      RETURN.
+    ENDIF.
+
+    TRY.
+        DATA(lt_attri) = rtti_get_t_attri_by_oref( lo_obj ).
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
+
+    " the public state is what an object can show of itself; a constant is
+    " the type's, not this instance's, and a class attribute is nobody's
+    LOOP AT lt_attri REFERENCE INTO DATA(lr_attri)                  "#EC CI_SORTSEQ
+         WHERE visibility  = cv_objectdescr_public
+           AND is_constant = abap_false
+           AND is_class    = abap_false.
+      DATA(lv_name) = CONV string( lr_attri->name ).
+      ASSIGN lo_obj->(lv_name) TO <comp>.
+      IF sy-subrc <> 0.
+        CONTINUE.
+      ENDIF.
+      INSERT data_render_item( name  = lv_name
+                               val   = <comp>
+                               depth = depth ) INTO TABLE lt_item.
+    ENDLOOP.
+
+    result = html_get_list( lt_item ).
+
+  ENDMETHOD.
+
+  METHOD data_render_dref.
+
+    DATA lr_data TYPE REF TO data.
+
+    FIELD-SYMBOLS <val> TYPE any.
+
+    TRY.
+        lr_data = val.
+      CATCH cx_root.
+        RETURN.
+    ENDTRY.
+    IF lr_data IS NOT BOUND.
+      RETURN.
+    ENDIF.
+
+    ASSIGN lr_data->* TO <val>.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    " a reference is no level of its own for the reader, but it is one for
+    " the recursion: a structure that points at itself would otherwise
+    " never reach the depth limit
+    result = data_render( val   = <val>
+                          depth = depth + 1 ).
+
+  ENDMETHOD.
+
+  METHOD data_render_item.
+
+    DATA(lv_val) = data_render( val   = val
+                                depth = depth + 1 ).
+
+    result = |<li><strong>{ html_escape( name ) }</strong>: { lv_val }</li>|.
+
+  ENDMETHOD.
+
+  METHOD data_get_headline.
+
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
+    CASE rtti_get_type_kind( val ).
+
+      WHEN cl_abap_datadescr=>typekind_table.
+        ASSIGN val TO <tab>.
+        DATA(lv_lines) = lines( <tab> ).
+        IF lv_lines = 1.
+          result = `Table with 1 entry`.
+        ELSE.
+          result = |Table with { lv_lines } entries|.
+        ENDIF.
+
+      WHEN cl_abap_datadescr=>typekind_struct1 OR cl_abap_datadescr=>typekind_struct2.
+        TRY.
+            DATA(lt_attri) = rtti_get_t_attri_by_any( val ).
+            result = |Structure with { lines( lt_attri ) } fields|.
+          CATCH cx_root.
+            result = `Structure`.
+        ENDTRY.
+
+      WHEN cl_abap_datadescr=>typekind_oref.
+        DATA lo_obj TYPE REF TO object.
+        TRY.
+            lo_obj = val.
+            result = |Object { rtti_get_classname_by_ref( lo_obj ) }|.
+          CATCH cx_root.
+            result = `Object`.
+        ENDTRY.
+
+      WHEN OTHERS.
+        result = `Data`.
+
+    ENDCASE.
+
+  ENDMETHOD.
+
+  METHOD data_get_string.
+
+    " the plain assignment is what turns an elementary value into its text
+    " - the same trick get_comp_str( ) uses. A value the runtime refuses to
+    " convert must not be the reason a box does not appear
+    TRY.
+        result = val.
+      CATCH cx_root ##NO_HANDLER.
+    ENDTRY.
+
+    " a number reaches a character target right-aligned in the length its
+    " type needs (` 12` for an i on some runtimes), and a CHAR field brings
+    " its padding along - neither is what the value says
+    result = c_trim( result ).
+
+  ENDMETHOD.
+
+  METHOD data_get_exc_text.
+
+    TRY.
+        DATA(lx) = CAST cx_root( val ).
+        result = lx->get_text( ).
+      CATCH cx_root ##NO_HANDLER.
+        " not an exception, or one that cannot render itself
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD html_get_list.
+
+    IF items IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    IF ordered = abap_true.
+      result = `<ol>` && concat_lines_of( items ) && `</ol>`.
+    ELSE.
+      result = `<ul>` && concat_lines_of( items ) && `</ul>`.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD html_escape.
+
+    " the ampersand first: escaping it afterwards would hit the ones the
+    " two replacements below have just written
+    result = val.
+    REPLACE ALL OCCURRENCES OF `&` IN result WITH `&amp;`.
+    REPLACE ALL OCCURRENCES OF `<` IN result WITH `&lt;`.
+    REPLACE ALL OCCURRENCES OF `>` IN result WITH `&gt;`.
+
+  ENDMETHOD.
+
+  METHOD html_check.
+
+    " a closing tag is the one shape a business text does not produce by
+    " accident; the void elements are the ones that have none. CS ignores
+    " case, so `</DIV>` and `<BR/>` are covered with it
+    result = xsdbool( val CS `</`
+                   OR val CS `<br`
+                   OR val CS `<hr`
+                   OR val CS `<img` ).
+
+  ENDMETHOD.
+
+  METHOD html_get_plain.
+
+    DATA lv_rest TYPE string.
+    DATA lv_pos  TYPE i.
+
+    lv_rest = val.
+
+    " everything between < and > goes, and a blank takes its place so that
+    " `<td>a</td><td>b</td>` does not read as `ab`
+    WHILE lv_rest CS `<`.
+      lv_pos = sy-fdpos.
+      result = result && substring( val = lv_rest
+                                    len = lv_pos ) && ` `.
+      lv_rest = substring( val = lv_rest
+                           off = lv_pos ).
+      IF lv_rest CS `>`.
+        lv_pos = sy-fdpos + 1.
+        lv_rest = substring( val = lv_rest
+                             off = lv_pos ).
+      ELSE.
+        CLEAR lv_rest.
+      ENDIF.
+    ENDWHILE.
+
+    result = result && lv_rest.
+
+    " the entities the stripped text would otherwise show as written
+    REPLACE ALL OCCURRENCES OF `&nbsp;` IN result WITH ` `.
+    REPLACE ALL OCCURRENCES OF `&lt;` IN result WITH `<`.
+    REPLACE ALL OCCURRENCES OF `&gt;` IN result WITH `>`.
+    REPLACE ALL OCCURRENCES OF `&amp;` IN result WITH `&`.
+    CONDENSE result.
+
+    IF strlen( result ) > cv_data_max_text.
+      result = substring( val = result
+                          len = cv_data_max_text ) && `...`.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.testclasses.abap
@@ -664,6 +664,7 @@ CLASS ltcl_msg DEFINITION FINAL
     METHODS test_box_single       FOR TESTING RAISING cx_static_check.
     METHODS test_box_multiple     FOR TESTING RAISING cx_static_check.
     METHODS test_token_by_range   FOR TESTING RAISING cx_static_check.
+    METHODS test_box_no_msg_skips FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -737,6 +738,27 @@ CLASS ltcl_msg IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = `<ul><li>first</li><li>second</li></ul>`
         act = ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_box_no_msg_skips.
+
+    " a business table has none of the message components, so the message
+    " formatter answers `skip` - it used to answer with one blank message
+    " per row, which is what put an empty popup on the screen. `skip` is
+    " what hands the data to ui5_data_box_format( )
+    TYPES:
+      BEGIN OF ty_s_row,
+        carrid TYPE string,
+        seats  TYPE i,
+      END OF ty_s_row.
+    DATA lt_row TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+
+    lt_row = VALUE #( ( carrid = `LH` seats = 12 ) ).
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_msg_box_format( lt_row ).
+
+    cl_abap_unit_assert=>assert_true( ls_box-skip ).
 
   ENDMETHOD.
 
@@ -939,6 +961,176 @@ CLASS ltcl_msg_rap IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = abap_false
         act = z2ui5_cl_ui5_util_context=>check_is_rap_struct( ls_plain ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+" The generic renderer behind client->message_box_display( ): what an app
+" throws in that is NOT a message. Every case here reached the box as
+" nothing at all before - a blank popup, or no popup.
+CLASS ltcl_data_box DEFINITION FINAL
+  FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+
+  PRIVATE SECTION.
+    TYPES:
+      BEGIN OF ty_s_row,
+        carrid TYPE string,
+        seats  TYPE i,
+      END OF ty_s_row.
+    TYPES ty_t_row TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+
+    TYPES:
+      BEGIN OF ty_s_node,
+        name  TYPE string,
+        nodes TYPE ty_t_row,
+      END OF ty_s_node.
+
+    METHODS test_text_plain      FOR TESTING RAISING cx_static_check.
+    METHODS test_text_html       FOR TESTING RAISING cx_static_check.
+    METHODS test_number          FOR TESTING RAISING cx_static_check.
+    METHODS test_table           FOR TESTING RAISING cx_static_check.
+    METHODS test_tree            FOR TESTING RAISING cx_static_check.
+    METHODS test_empty_table     FOR TESTING RAISING cx_static_check.
+    METHODS test_escapes_markup  FOR TESTING RAISING cx_static_check.
+    METHODS test_row_limit       FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_data_box IMPLEMENTATION.
+
+  METHOD test_text_plain.
+
+    " a character value is its own text and needs no details
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( `Hello World` ).
+
+    cl_abap_unit_assert=>assert_false( ls_box-skip ).
+    cl_abap_unit_assert=>assert_equals( exp = `Hello World`
+                                        act = ls_box-text ).
+    cl_abap_unit_assert=>assert_initial( ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_text_html.
+
+    " markup in the box TEXT would be shown as the tags it is written with,
+    " so it moves to the details ( a FormattedText in UI5 ) and the headline
+    " becomes the plain text behind it
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format(
+                       `<p>Order <strong>4711</strong> booked</p>` ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `Order 4711 booked`
+                                        act = ls_box-text ).
+    cl_abap_unit_assert=>assert_equals( exp = `<p>Order <strong>4711</strong> booked</p>`
+                                        act = ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_number.
+
+    " a number is shown as the number, not as a right-aligned char field
+    DATA lv_int TYPE i.
+
+    lv_int = 42.
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( lv_int ).
+
+    cl_abap_unit_assert=>assert_false( ls_box-skip ).
+    cl_abap_unit_assert=>assert_equals( exp = `42`
+                                        act = ls_box-text ).
+
+  ENDMETHOD.
+
+  METHOD test_table.
+
+    " a business table: the headline counts, the details carry every row
+    " with its component names
+    DATA lt_row TYPE ty_t_row.
+
+    lt_row = VALUE #( ( carrid = `LH` seats = 12 ) ).
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( lt_row ).
+
+    cl_abap_unit_assert=>assert_false( ls_box-skip ).
+    cl_abap_unit_assert=>assert_equals( exp = `Table with 1 entry`
+                                        act = ls_box-text ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `<ol><li><ul><li><strong>CARRID</strong>: LH</li>` &&
+              `<li><strong>SEATS</strong>: 12</li></ul></li></ol>`
+        act = ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_tree.
+
+    " a node with children below it - the recursion renders the nested table
+    " as a nested list instead of stopping at the first level
+    DATA ls_node TYPE ty_s_node.
+
+    ls_node = VALUE #( name  = `root`
+                       nodes = VALUE #( ( carrid = `LH` seats = 1 ) ) ).
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( ls_node ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `Structure with 2 fields`
+                                        act = ls_box-text ).
+    cl_abap_unit_assert=>assert_equals(
+        exp = `<ul><li><strong>NAME</strong>: root</li>` &&
+              `<li><strong>NODES</strong>: <ol><li><ul>` &&
+              `<li><strong>CARRID</strong>: LH</li>` &&
+              `<li><strong>SEATS</strong>: 1</li>` &&
+              `</ul></li></ol></li></ul>`
+        act = ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_empty_table.
+
+    " an app that hands over the result of a call it just made expects no
+    " popup when the call returned nothing - the same silence an empty
+    " message table has always produced
+    DATA lt_row TYPE ty_t_row.
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( lt_row ).
+
+    cl_abap_unit_assert=>assert_true( ls_box-skip ).
+
+  ENDMETHOD.
+
+  METHOD test_escapes_markup.
+
+    " a value that looks like markup is data, not markup - it must not be
+    " able to close the list the renderer is building
+    DATA lt_row TYPE ty_t_row.
+
+    lt_row = VALUE #( ( carrid = `</ul><script>` ) ).
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( lt_row ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `<ol><li><ul><li><strong>CARRID</strong>: &lt;/ul&gt;&lt;script&gt;</li>` &&
+              `<li><strong>SEATS</strong>: 0</li></ul></li></ol>`
+        act = ls_box-details ).
+
+  ENDMETHOD.
+
+  METHOD test_row_limit.
+
+    " a dump is a diagnostic, not a report: the box stops after 100 rows and
+    " says how many it left out
+    DATA lt_row TYPE ty_t_row.
+
+    DO 105 TIMES.
+      INSERT VALUE #( seats = sy-index ) INTO TABLE lt_row.
+    ENDDO.
+
+    DATA(ls_box) = z2ui5_cl_ui5_util_context=>ui5_data_box_format( lt_row ).
+
+    cl_abap_unit_assert=>assert_equals( exp = `Table with 105 entries`
+                                        act = ls_box-text ).
+    cl_abap_unit_assert=>assert_true( xsdbool( ls_box-details CS `... 5 more entries` ) ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
+++ b/src/01/02/z2ui5_cl_ui5_client.clas.testclasses.abap
@@ -86,6 +86,8 @@ CLASS ltcl_test_client DEFINITION FINAL
     METHODS test_message_box_display  FOR TESTING RAISING cx_static_check.
     METHODS test_message_box_dependent FOR TESTING RAISING cx_static_check.
     METHODS test_message_box_type     FOR TESTING RAISING cx_static_check.
+    METHODS test_message_box_data     FOR TESTING RAISING cx_static_check.
+    METHODS test_message_box_no_data  FOR TESTING RAISING cx_static_check.
     METHODS test_message_toast        FOR TESTING RAISING cx_static_check.
     METHODS test_set_nav_routing      FOR TESTING RAISING cx_static_check.
     METHODS test_set_nav_routing_default FOR TESTING RAISING cx_static_check.
@@ -427,6 +429,52 @@ CLASS ltcl_test_client IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
         exp = `["MESSAGE_BOX","error","Error occurred"]`
         act = mo_action->ms_next-s_action-t_custom[ 1 ]-o_json->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD test_message_box_data.
+
+    " a business table carries no messages at all - it used to reach the box
+    " as one blank line per row. The whole point of the API is that an app
+    " hands over what it has without pre-formatting it
+    TYPES:
+      BEGIN OF ty_s_row,
+        carrid TYPE string,
+      END OF ty_s_row.
+    DATA lt_row TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+
+    li_client ?= mo_client.
+    lt_row = VALUE #( ( carrid = `LH` ) ).
+
+    li_client->message_box_display( lt_row ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = `["MESSAGE_BOX","show","Table with 1 entry",` &&
+              `{"details":"<ol><li><ul><li><strong>CARRID</strong>: LH</li></ul></li></ol>",` &&
+              `"title":"Information"}]`
+        act = mo_action->ms_next-s_action-t_custom[ 1 ]-o_json->stringify( ) ).
+
+  ENDMETHOD.
+
+  METHOD test_message_box_no_data.
+
+    " ...and an empty one still queues nothing: an app that shows the result
+    " of a call it just made must not get a popup when there was no result
+    TYPES:
+      BEGIN OF ty_s_row,
+        carrid TYPE string,
+      END OF ty_s_row.
+    DATA lt_row TYPE STANDARD TABLE OF ty_s_row WITH EMPTY KEY.
+
+    DATA li_client TYPE REF TO z2ui5_if_client.
+
+    li_client ?= mo_client.
+
+    li_client->message_box_display( lt_row ).
+
+    cl_abap_unit_assert=>assert_initial( mo_action->ms_next-s_action-t_custom ).
 
   ENDMETHOD.
 

--- a/src/01/02/z2ui5_cl_ui5_frontend.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_frontend.clas.abap
@@ -589,21 +589,36 @@ CLASS z2ui5_cl_ui5_frontend IMPLEMENTATION.
                              ( `success` ) ).
     ENDIF.
 
+    " MESSAGES FIRST. A BAPIRET2 table, a RAP response, a log object, an
+    " exception, a plain message structure - that is what most apps hand
+    " over, and the formatter is the one place that knows all of their
+    " shapes, their severity and their titles. Only when NOTHING in there is
+    " a message does the generic renderer below get a turn, so nothing about
+    " the message path changes for an app that was already using it
+    DATA(lv_is_msg) = abap_false.
     IF z2ui5_cl_ui5_util_context=>rtti_check_clike( text ) = abap_false.
       result = z2ui5_cl_ui5_util_context=>ui5_msg_box_format( text ).
-      IF result-skip = abap_true.
-        RETURN.
-      ENDIF.
+      lv_is_msg = xsdbool( result-skip = abap_false ).
+    ENDIF.
+
+    IF lv_is_msg = abap_true.
       IF title IS NOT INITIAL.
         result-title = title.
       ENDIF.
     ELSE.
+      " no messages in there, or a character value, which is its own text:
+      " show the DATA. A table, a nested structure, a tree, an object, an
+      " HTML string, a number - the app throws in what it has and the box
+      " renders it rather than staying empty or not appearing at all
+      result = z2ui5_cl_ui5_util_context=>ui5_data_box_format( text ).
+      IF result-skip = abap_true.
+        RETURN.
+      ENDIF.
+
       " lowercased right here, so `Information` gets the same show-mapping
       " and default title as `information`
-      result = VALUE #( text    = text
-                        type    = to_lower( type )
-                        title   = title
-                        details = details ).
+      result-type  = to_lower( type ).
+      result-title = title.
 
       IF result-type = `information`.
         result-type = `show`.
@@ -611,6 +626,13 @@ CLASS z2ui5_cl_ui5_frontend IMPLEMENTATION.
           result-title = `Information`.
         ENDIF.
       ENDIF.
+    ENDIF.
+
+    " the details the app passed fill the slot the resolver left empty -
+    " they never overwrite a rendering, which IS the data the app asked to
+    " see
+    IF result-details IS INITIAL.
+      result-details = details.
     ENDIF.
 
     " MessageBox display methods are lowercase (show, error, warning, ...) but

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -487,6 +487,14 @@ INTERFACE z2ui5_if_client
     RETURNING
       VALUE(result) TYPE string.
 
+  "! Show a sap.m.MessageBox. `text` is TYPE any and takes whatever the app
+  "! has: a text, a message structure or table (BAPIRET2, T100, RAP,
+  "! symsg, a log object, an exception), an HTML string, a business table, a
+  "! nested structure or tree, an object, a number. Messages are recognized
+  "! first and set the box's severity and title themselves; everything else
+  "! is rendered - a headline in the box, the data itself in the details.
+  "! The one case that shows nothing at all is complex data that is initial
+  "! (an empty message table stays as silent as it always was).
   METHODS message_box_display
     IMPORTING
       text              TYPE any


### PR DESCRIPTION
## Description

Extends `client->message_box_display()` to accept and render any data type, not just messages. When the input contains no message structures (BAPIRET2, T100, RAP, symsg, log objects, exceptions), the new `ui5_data_box_format()` method renders it as structured data instead of showing nothing or a blank popup.

**Key changes:**

- **`ui5_data_box_format()`**: New method that renders any value (tables, structures, objects, numbers, HTML strings) into a message box with a headline and HTML details
- **Data rendering pipeline**: New helper methods (`data_render`, `data_render_tab`, `data_render_struc`, `data_render_oref`, `data_render_dref`, `data_render_item`) recursively render complex types as nested HTML lists
- **HTML utilities**: New helpers (`html_escape`, `html_check`, `html_get_plain`, `html_get_list`) handle markup detection and safe rendering
- **Limits**: Recursion depth capped at 5 levels, tables capped at 100 rows, headlines capped at 200 characters — all announced in output
- **Message path unchanged**: `ui5_msg_box_format()` still runs first; only when it answers `skip` does the data renderer take over
- **Empty data stays silent**: Empty tables/structures return `skip=true`, preserving the existing behavior where no result means no popup

**API impact:** `message_box_display()` signature unchanged; `text` parameter already `TYPE any`, now actually accepts and renders any type.

## How to test

Unit tests added in `ltcl_data_box` class cover:
- Plain text and HTML strings
- Numbers
- Business tables (single and multiple rows)
- Nested structures (trees)
- Empty tables (no popup)
- Markup escaping (prevents injection)
- Row limit enforcement (100 rows max)

Integration tests in `ltcl_test_client` verify the box is queued with correct JSON structure for table data.

Existing message tests remain unchanged and pass — the message path is unaffected.

## Checklist

- [x] Unit tests added (`ltcl_data_box` with 8 test methods, `ltcl_test_client` with 2 new tests)
- [x] Public API in `src/02/` only changed additively (interface documentation updated, no signature changes)
- [x] `changelog.txt` updated with behavior change note
- [x] No manual edits to generated code

https://claude.ai/code/session_011jhWhSZx39bE5uuzBpLk9u