### PR TITLE
Fix SLIN "Redundant conversion for type STRING" in util_context

### DIFF
--- a/.claude/skills/abap-check/SKILL.md
+++ b/.claude/skills/abap-check/SKILL.md
@@ -516,6 +516,40 @@ pitfalls".
   all nine **and found four more the system run had not** — 356 once, 363
   three times. A system run sees one package at a time; the gate sees the
   corpus.
+
+  **Same finding, `CONV string( )`, in THIS repository (2026-09-03).** A user's
+  system reported `z2ui5_cl_ui5_util_context->data_render_struc @16` —
+  *"Redundant conversion for type STRING"* on
+  `DATA(lv_name) = CONV string( lr_attri->name )`, an RTTI attribute name
+  inlined through a CONV. Three more of the identical shape sat in the same
+  class — `error_get_attributes`, `data_render_oref`, and
+  `rtti_get_t_attri_by_any`'s `CONV string( lo_struct->absolute_name )`. All
+  four are now a declared `DATA … TYPE string.` plus a plain assignment, which
+  keeps the string type (the RTTI name is a CHAR field whose trailing blanks
+  must not travel) without a conversion operator. That also retires the "a
+  redundant `CONV string( )`" line in the BUNDLE paragraph below, where it was
+  filed as a possible artefact of the fold: it was this code all along.
+
+  **The generic-parameter form is NOT this finding and has to stay.**
+  `DATA(lv_url) = CONV string( url )` with `url TYPE clike` is the prescribed
+  fix for the *"fixed type STRING for the generic type CLIKE"* trap above, and
+  no system run has ever reported one of the sixteen in `src`. The
+  discriminator is the operand: concretely typed → the assignment converts by
+  itself and the CONV is redundant; generic → the CONV has to be there, it is
+  what fixes the type. Two sites in `src` still have the flagged shape and were
+  left alone because no system run has named them:
+  `z2ui5_cl_ui5_util_http`'s `CONV string( …cv_char_util_cr_lf(1) )` pair, a
+  CHAR constant with an offset. Fix them when a run does.
+
+  **abaplint has a rule for this and it does not reach it.**
+  `redundant_conversion` reports only a CONV whose operand ALREADY has the
+  target type (`text = CONV string( text )`), not one whose target does.
+  Measured on 2.120.38 against the pre-fix file with the rule switched on: **0
+  findings**; the control probe (`lv_probe = CONV string( lv_probe )` in that
+  same method) fired immediately. The rule is on in `abaplint.jsonc` since this
+  fix — as a floor, not as the gate for this finding. What would decide this
+  one is `redundant-conv-i`'s shape generalized from `i` to any concrete type
+  with a concretely-typed operand, and that is not written yet.
 - **An Open SQL literal is a host expression: `@( … )`.** In strict Open SQL
   every value in a WHERE comparison is escaped, a literal included — bare
   `WHERE id = \`TEST_COUNT_FOREIGN\`` becomes
@@ -579,11 +613,14 @@ sources into that repository, where a script folds them into ONE class whose
 `z2ui5_cl_abap2ui5_local` (2026-08-23) reported eight SLIN warnings against
 that folded include — POSIX regex twice, ABAP Doc position, `<CLASS>` not
 supported / not closed three times, a redundant `CONV string( )` — at character
-OFFSETS (`@16232`, `@38704`), not at lines in any file here. All four kinds are
-the families above, and all four are silenced in `src/` by a pragma, a
+OFFSETS (`@16232`, `@38704`), not at lines in any file here. Three of the four
+kinds are the families above and are silenced in `src/` by a pragma, a
 `##REGEX_POSIX`, or an escape. **They come back after the fold**, so what the
 fold does to those annotations is the thing to establish; the sources on this
-side are clean and no change here would move them. The `<CLASS>` pair is worth
+side are clean and no change here would move them. The fourth, the redundant
+`CONV string( )`, turned out NOT to be a fold artefact — the same finding came
+back on 2026-09-03 with a location in this tree (`data_render_struc @16`, the
+entry above), and the four sites it named are fixed here. The `<CLASS>` pair is worth
 looking at first: `<p class="shorttext synchronized">` is the standard ADT
 shorttext form, and a tag scanner that splits on whitespace reads the attribute
 name as a second tag — which would make it an artefact of the fold rather than

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -302,6 +302,12 @@
       "severity": "Warning"
     },
     "reduce_string_templates": true,
+    // catches `x = CONV string( x )` only - SLIN's "Redundant conversion for
+    // type STRING" is wider (it fires on any CONV that is the whole
+    // right-hand side of an assignment, the operand's type notwithstanding),
+    // so this rule is a floor, not the gate for that finding. Measured on
+    // 2.120.38: 0 findings over src, control probe fired
+    "redundant_conversion": true,
     "release_idoc": true,
     "remove_descriptions": {
       "exclude": [],

--- a/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
+++ b/src/00/03/z2ui5_cl_ui5_util_context.clas.abap
@@ -1322,8 +1322,10 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
 
   METHOD rtti_get_t_attri_by_any.
 
-    DATA lo_struct TYPE REF TO cl_abap_structdescr.
-    DATA lo_type   TYPE REF TO cl_abap_typedescr.
+    DATA lo_struct        TYPE REF TO cl_abap_structdescr.
+    DATA lo_type          TYPE REF TO cl_abap_typedescr.
+    " declared, not CONV string( ) - see error_get_attributes
+    DATA lv_absolute_name TYPE string.
 
     TRY.
         lo_type = cl_abap_typedescr=>describe_by_data( val ).
@@ -1349,7 +1351,7 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
 
     " descriptor instances are singletons per type, so the identity check
     " guards against absolute names reused by other (local/anonymous) types
-    DATA(lv_absolute_name) = CONV string( lo_struct->absolute_name ).
+    lv_absolute_name = lo_struct->absolute_name.
     READ TABLE mt_attri_cache REFERENCE INTO DATA(lr_cache)
          WITH TABLE KEY absolute_name = lv_absolute_name.
     IF sy-subrc = 0 AND lr_cache->o_struct = lo_struct.
@@ -1714,6 +1716,13 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
 
   METHOD error_get_attributes.
 
+    " declared, NOT `DATA(lv_name) = CONV string( lr_attri->name )`: a CONV
+    " that is the whole right-hand side of an assignment is "Redundant
+    " conversion for type STRING" in SLIN - the assignment converts by
+    " itself. The variable stays a string on purpose: the RTTI name is a
+    " CHAR field whose trailing blanks have no business in the rendered name
+    DATA lv_name TYPE string.
+
     FIELD-SYMBOLS <comp> TYPE any.
 
     IF val IS NOT BOUND.
@@ -1738,7 +1747,7 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
           CONTINUE.
       ENDCASE.
 
-      DATA(lv_name) = CONV string( lr_attri->name ).
+      lv_name = lr_attri->name.
       ASSIGN val->(lv_name) TO <comp>.
       IF sy-subrc <> 0.
         CONTINUE.
@@ -1998,6 +2007,8 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
   METHOD data_render_struc.
 
     DATA lt_item TYPE string_table.
+    " declared, not CONV string( ) - see error_get_attributes
+    DATA lv_name TYPE string.
 
     FIELD-SYMBOLS <comp> TYPE any.
 
@@ -2010,7 +2021,7 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
     ENDTRY.
 
     LOOP AT lt_attri REFERENCE INTO DATA(lr_attri).
-      DATA(lv_name) = CONV string( lr_attri->name ).
+      lv_name = lr_attri->name.
       ASSIGN COMPONENT lv_name OF STRUCTURE val TO <comp>.
       IF sy-subrc <> 0.
         CONTINUE.
@@ -2028,6 +2039,8 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
 
     DATA lo_obj  TYPE REF TO object.
     DATA lt_item TYPE string_table.
+    " declared, not CONV string( ) - see error_get_attributes
+    DATA lv_name TYPE string.
 
     FIELD-SYMBOLS <comp> TYPE any.
 
@@ -2060,7 +2073,7 @@ CLASS z2ui5_cl_ui5_util_context IMPLEMENTATION.
          WHERE visibility  = cv_objectdescr_public
            AND is_constant = abap_false
            AND is_class    = abap_false.
-      DATA(lv_name) = CONV string( lr_attri->name ).
+      lv_name = lr_attri->name.
       ASSIGN lo_obj->(lv_name) TO <comp>.
       IF sy-subrc <> 0.
         CONTINUE.


### PR DESCRIPTION
# Description

A user's system reported `z2ui5_cl_ui5_util_context->data_render_struc @16` — *"Redundant conversion for type STRING"* on

```abap
DATA(lv_name) = CONV string( lr_attri->name ).
```

A `CONV` that is the whole right-hand side of an assignment is redundant for the extended check: the assignment converts by itself. Same family as the already-catalogued `slider_value = CONV i( client->get_event_arg( ) )` ("Redundant conversion for type I") in `samples-controls`.

Three more sites in the same class had the identical shape — the RTTI attribute name in `error_get_attributes` and `data_render_oref`, and the descriptor's `absolute_name` in `rtti_get_t_attri_by_any`. All four are now a declared `DATA … TYPE string.` plus a plain assignment, which keeps the string type (and drops the CHAR field's trailing blanks) without a conversion operator. **Behaviour is unchanged**, which is why there is no `changelog.txt` line — earlier SLIN sweeps got none either.

The generic-parameter form is deliberately untouched: `DATA(lv_url) = CONV string( url )` with `url TYPE clike` is the prescribed fix for the *"fixed type STRING for the generic type CLIKE"* trap, and no system run has reported one of the sixteen in `src`. The discriminator is the operand — concretely typed → the assignment converts by itself and the CONV is redundant; generic → the CONV is what fixes the type.

## Why nothing here caught it

Measured, control probe passed:

- **abaplint has a rule for it and it was not enabled.** `redundant_conversion` was in no config. It is on in `abaplint.jsonc` now (0 findings over `src`).
- **Enabled, it still does not reach this line.** abaplint reports only a CONV whose *operand* already has the target type (`text = CONV string( text )`); SLIN reports one whose *assignment target* does. Measured on 2.120.38 against the pre-fix file with the rule switched on: **0 findings**; the control probe (`lv_probe = CONV string( lv_probe )` in that same method) fired immediately. So the rule is a floor, not the gate for this finding.
- **The repository's own gate for this SLIN family is scoped too narrowly.** `abap2ui5lint`'s `redundant-conv-i` covers `CONV i( )` into a name declared `TYPE i` — the shape of the one earlier report. Generalizing it to any concrete target type with a concretely-typed operand is what would decide this one, and is not written yet.

The case is recorded in the `abap-check` skill, which also retires the guess that the "redundant `CONV string( )`" a system reported on `abap2UI5-local` (2026-08-23, at a character offset in the folded class) was an artefact of the fold — it was this code.

## How to test

```
npm run check        # abaplint, now with redundant_conversion on
npm run verify
```

Run in this branch: `npm run check` (0 issues), `npm run gates` (30 of 31; `check:shared` fails identically on a clean `main` — it is about downstream copies of `docs/agents/building-apps.md` and of the `check-family-nav` shared files, untouched here), `check:standard`, `check:cloud`, `check:abap2ui5`, `check:eslint`, `check:format`, then `downport` → `auto_transpile` → `unit` → `check:js` → `check:app2abap` → `check:frontend`, all green.

The behaviour the four sites carry is covered by the existing tests of `z2ui5_cx_ui5_util_error` (attribute rendering, `test_structured_val_no_dump`, `test_chain_texts`) and by the `message_box_display` data-render tests.

## Checklist

- [x] `npm run verify` passes (`app/webapp/` unchanged, so not `verify:full`) — with the one pre-existing `check:shared` failure noted above
- [x] Unit tests added/updated where it makes sense — none needed: no behaviour change, the four sites are covered by existing tests
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively — `src/02/` is not touched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour — nothing changes behaviour, so no line
- [ ] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L96wfLQmuuTUS3f7xpRBeA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L96wfLQmuuTUS3f7xpRBeA)_