### PR TITLE
The README's link to the architecture has been a 404 since the docs reorganised

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Everything in between is handled for you:
 * **Rendering** – views are plain UI5 XML built in ABAP with `z2ui5_cl_ui5_view_builder`; every control, property, and aggregation is available 1:1
 * **State** – your app object is serialized and restored on every request, so attributes simply keep their values
 
-Popups, navigation, messages, and frontend actions travel the same protocol – you never touch JSON, HTTP, or JavaScript. The architecture is described in [UI5 Over-the-Wire](https://abap2ui5.github.io/docs/technical/concept.html).
+Popups, navigation, messages, and frontend actions travel the same protocol – you never touch JSON, HTTP, or JavaScript. The architecture is described in [UI5 Over-the-Wire](https://abap2ui5.github.io/docs/advanced/insights/05-ui5-over-the-wire.html).
 
 ## Enterprise Readiness
 * **Security** – Apps run entirely inside your SAP authentication and authorization: a single HTTP endpoint, standard SAP logon, no separate user store


### PR DESCRIPTION
`README.md` says *"The architecture is described in UI5 Over-the-Wire"* and points at `https://abap2ui5.github.io/docs/technical/concept.html`.

That page was `docs/technical/concept.md` in abap2UI5/docs until the whole of `/technical/` became the Know-How series under `/advanced/insights/`. It is `/advanced/insights/05-ui5-over-the-wire.html` now — same title, same article. The old address has answered with the manual's 404 ever since, on the project's front page on GitHub, under the one sentence that explains how the framework works.

Checked the same way for the rest: every link this README makes into the manual, resolved against the built site.

| link | |
|---|---|
| `/docs/advanced/linter.html` | ok |
| `/docs/get_started/ai.html` | ok |
| `/docs/get_started/quickstart.html` | ok |
| `/docs/resources/contribution.html` | ok |
| `/docs/resources/sponsor.html` | ok |
| `/docs/technical/concept.html` | **dead** — fixed here |

One line, no other change.

The old address is being given a redirect in abap2UI5/docs as well ([abap2UI5/docs#257](https://github.com/abap2UI5/docs/pull/257)), for everyone who has it in a bookmark or a blog post. This is the half that should not need one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_