### PR TITLE
The one number in the client interface's documentation had drifted

### DIFF
--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -958,8 +958,9 @@ INTERFACE z2ui5_if_client
   "!
   "! the complete display condition on its own - no OR with check_on_init( )
   "! is needed, and the samples and documentation are written that way.
-  "! Whoever changes the factory keeps this true, or 530 apps stop rendering
-  "! on their first start with nothing raised anywhere.
+  "! Whoever changes the factory keeps this true, or every sample in the three
+  "! catalogues stops rendering on its first start with nothing raised
+  "! anywhere.
   METHODS check_on_navigated
     RETURNING
       VALUE(result) TYPE abap_bool.


### PR DESCRIPTION
`check_on_navigated`'s doc comment closes with a warning to whoever changes the view factory:

> Whoever changes the factory keeps this true, or **530 apps** stop rendering on their first start with nothing raised anywhere.

That comment is not only read in an editor. **abap2UI5/docs generates `resources/api.md` from this interface**, so the sentence is published on the documentation site verbatim — and 530 has been short for a while: the three sample catalogues the warning is about hold considerably more than that between them, and the figure moves every time a sample lands in any of the three.

The warning does not need a count to land. What it says is that *the whole corpus* depends on this, and

> every sample in the three catalogues

says that and cannot go stale. Same reasoning the family already applies elsewhere: a number written by hand beside a list a generator owns is a number nobody updates.

**Found from the other end.** Correcting it in the documentation repository failed `check:api-reference` there — the gate that exists precisely because this text belongs to this file and not to that one. The docs side is [abap2UI5/docs#262](https://github.com/abap2UI5/docs/pull/262); it picks this up on the next `npm run generate:api`.

Comment only — no code changes. Line lengths stay under 255 and there are no tabs, so abapGit round-trips unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8SXJBpjEgfZZnn2PzKYW)_