### PR TITLE
Keep the URLHELPER table where the linter's mirror check reads it

### DIFF
--- a/app/webapp/core/actions/Browser.js
+++ b/app/webapp/core/actions/Browser.js
@@ -19,35 +19,6 @@ sap.ui.define(
 
     const _URLHelper = mobileLibrary.URLHelper;
 
-    // The URLHELPER sub-actions, each taking the call's params object. Built
-    // ONCE at module level rather than as a fresh object of four closures on
-    // every call, and prototype-less like the dispatch tables in
-    // core/actions/ControlCall.js: the name comes off the wire, and on a
-    // plain object a name Object.prototype carries resolves to a function.
-    const URL_HELPER_ACTIONS = Object.assign(Object.create(null), {
-      REDIRECT: (params) => {
-        if (!Lib.isSafeRedirectProtocol(params.URL)) {
-          MessageBox.error(
-            "Invalid redirect URL. Only http/https protocols are allowed.",
-          );
-          return;
-        }
-        _URLHelper.redirect(params.URL, params.NEW_WINDOW);
-      },
-      TRIGGER_EMAIL: (params) =>
-        _URLHelper.triggerEmail(
-          params.EMAIL,
-          params.SUBJECT,
-          params.BODY,
-          params.CC,
-          params.BCC,
-          params.NEW_WINDOW,
-        ),
-      TRIGGER_SMS: (params) =>
-        _URLHelper.triggerSms(params.TEL, params.TEXT, params.NEW_WINDOW),
-      TRIGGER_TEL: (params) => _URLHelper.triggerTel(params.TEL),
-    });
-
     // ------------------------------------------------------------------
     // Individual event handlers - one per entry in the dispatch table at
     // the bottom. Uniform signature (oController, args) so the dispatch
@@ -257,9 +228,44 @@ sap.ui.define(
         Lib.logError("URLHELPER: blocked CR/LF in parameters");
         return;
       }
+      // A plain literal INSIDE this function on purpose, like the three
+      // tables in core/actions/ControlCall.js: the abap2UI5 linter mirrors
+      // this set and finds it by the exact source text `actions = {` within
+      // `function evUrlHelper` in the embedded carrier (its
+      // scripts/check-upstream.mjs, parseUrlHelperActions). Hoisting it to
+      // module level - built once instead of four closures per call - made
+      // that lookup miss, and the mirror check degraded to "SKIPPED, not
+      // verified": a cross-repository check that stops checking without
+      // failing. Same effect, marker intact. Prototype-less, because the
+      // name comes off the wire and a plain object answers for every name
+      // Object.prototype carries.
+      const actions = {
+        REDIRECT: () => {
+          if (!Lib.isSafeRedirectProtocol(params.URL)) {
+            MessageBox.error(
+              "Invalid redirect URL. Only http/https protocols are allowed.",
+            );
+            return;
+          }
+          _URLHelper.redirect(params.URL, params.NEW_WINDOW);
+        },
+        TRIGGER_EMAIL: () =>
+          _URLHelper.triggerEmail(
+            params.EMAIL,
+            params.SUBJECT,
+            params.BODY,
+            params.CC,
+            params.BCC,
+            params.NEW_WINDOW,
+          ),
+        TRIGGER_SMS: () =>
+          _URLHelper.triggerSms(params.TEL, params.TEXT, params.NEW_WINDOW),
+        TRIGGER_TEL: () => _URLHelper.triggerTel(params.TEL),
+      };
+      Object.setPrototypeOf(actions, null);
       try {
-        const fn = URL_HELPER_ACTIONS[args[1]];
-        if (fn) fn(params);
+        const fn = actions[args[1]];
+        if (fn) fn();
       } catch (e) {
         Lib.logError(`URLHELPER: '${args[1]}' failed`, e);
       }

--- a/src/01/03/z2ui5_cl_ui5f_browser_js.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_browser_js.clas.abap
@@ -39,30 +39,6 @@ CLASS z2ui5_cl_ui5f_browser_js IMPLEMENTATION.
              `` && |\n| &&
              `    const _URLHelper = mobileLibrary.URLHelper;` && |\n| &&
              `` && |\n| &&
-             `    const URL_HELPER_ACTIONS = Object.assign(Object.create(null), {` && |\n| &&
-             `      REDIRECT: (params) => {` && |\n| &&
-             `        if (!Lib.isSafeRedirectProtocol(params.URL)) {` && |\n| &&
-             `          MessageBox.error(` && |\n| &&
-             `            "Invalid redirect URL. Only http/https protocols are allowed.",` && |\n| &&
-             `          );` && |\n| &&
-             `          return;` && |\n| &&
-             `        }` && |\n| &&
-             `        _URLHelper.redirect(params.URL, params.NEW_WINDOW);` && |\n| &&
-             `      },` && |\n| &&
-             `      TRIGGER_EMAIL: (params) =>` && |\n| &&
-             `        _URLHelper.triggerEmail(` && |\n| &&
-             `          params.EMAIL,` && |\n| &&
-             `          params.SUBJECT,` && |\n| &&
-             `          params.BODY,` && |\n| &&
-             `          params.CC,` && |\n| &&
-             `          params.BCC,` && |\n| &&
-             `          params.NEW_WINDOW,` && |\n| &&
-             `        ),` && |\n| &&
-             `      TRIGGER_SMS: (params) =>` && |\n| &&
-             `        _URLHelper.triggerSms(params.TEL, params.TEXT, params.NEW_WINDOW),` && |\n| &&
-             `      TRIGGER_TEL: (params) => _URLHelper.triggerTel(params.TEL),` && |\n| &&
-             `    });` && |\n| &&
-             `` && |\n| &&
              `    function evClipboardCopy(oController, args) {` && |\n| &&
              `      Lib.copyToClipboard(args[1]);` && |\n| &&
              `    }` && |\n| &&
@@ -217,9 +193,34 @@ CLASS z2ui5_cl_ui5f_browser_js IMPLEMENTATION.
              `        Lib.logError("URLHELPER: blocked CR/LF in parameters");` && |\n| &&
              `        return;` && |\n| &&
              `      }` && |\n| &&
+             `` && |\n| &&
+             `      const actions = {` && |\n| &&
+             `        REDIRECT: () => {` && |\n| &&
+             `          if (!Lib.isSafeRedirectProtocol(params.URL)) {` && |\n| &&
+             `            MessageBox.error(` && |\n| &&
+             `              "Invalid redirect URL. Only http/https protocols are allowed.",` && |\n| &&
+             `            );` && |\n| &&
+             `            return;` && |\n| &&
+             `          }` && |\n| &&
+             `          _URLHelper.redirect(params.URL, params.NEW_WINDOW);` && |\n| &&
+             `        },` && |\n| &&
+             `        TRIGGER_EMAIL: () =>` && |\n| &&
+             `          _URLHelper.triggerEmail(` && |\n| &&
+             `            params.EMAIL,` && |\n| &&
+             `            params.SUBJECT,` && |\n| &&
+             `            params.BODY,` && |\n| &&
+             `            params.CC,` && |\n| &&
+             `            params.BCC,` && |\n| &&
+             `            params.NEW_WINDOW,` && |\n| &&
+             `          ),` && |\n| &&
+             `        TRIGGER_SMS: () =>` && |\n| &&
+             `          _URLHelper.triggerSms(params.TEL, params.TEXT, params.NEW_WINDOW),` && |\n| &&
+             `        TRIGGER_TEL: () => _URLHelper.triggerTel(params.TEL),` && |\n| &&
+             `      };` && |\n| &&
+             `      Object.setPrototypeOf(actions, null);` && |\n| &&
              `      try {` && |\n| &&
-             `        const fn = URL_HELPER_ACTIONS[args[1]];` && |\n| &&
-             `        if (fn) fn(params);` && |\n| &&
+             `        const fn = actions[args[1]];` && |\n| &&
+             `        if (fn) fn();` && |\n| &&
              `      } catch (e) {` && |\n| &&
              `        Lib.logError(``URLHELPER: '${args[1]}' failed``, e);` && |\n| &&
              `      }` && |\n| &&

--- a/src/01/03/z2ui5_cl_ui5f_preload.clas.abap
+++ b/src/01/03/z2ui5_cl_ui5f_preload.clas.abap
@@ -14,7 +14,7 @@ CLASS z2ui5_cl_ui5f_preload DEFINITION
 
     " digest of every embedded frontend source, fixed at generation time -
     " part of the GET shell's ETag (z2ui5_cl_ui5_http_handler=>_get_etag)
-    CONSTANTS build_hash TYPE string VALUE 'b11794af7b6e39bb'.
+    CONSTANTS build_hash TYPE string VALUE '58276303f929859a'.
 
     CLASS-METHODS get
       IMPORTING


### PR DESCRIPTION
# Description

Follow-up to #2734. That change hoisted `evUrlHelper`'s action map in `app/webapp/core/actions/Browser.js` to module level. The abap2UI5 linter mirrors this set and finds it by the exact source text `actions = {` inside `function evUrlHelper` in the embedded carrier (`scripts/check-upstream.mjs`, `parseUrlHelperActions`), so the hoist made that lookup miss and the `check:mirrors` gate degraded to "SKIPPED, not verified" - a cross-repository check that stops checking without failing (visible in the `check_gates` log of #2734 as `could not find evUrlHelper's actions map`).

The literal is back inside the function, prototype-less as before, with the marker documented at the code site the way the three tables in `core/actions/ControlCall.js` document theirs. The embedded `src/01/03/` mirror is regenerated (`z2ui5_cl_ui5f_browser_js`, `z2ui5_cl_ui5f_preload`). No behaviour change: same four actions, same guards, same calls.

## How to test

- `npm run check:mirrors` now prints `ok    URLHELPER actions (lib/frontend-actions.mjs): in sync (4 entries)` instead of the "could not find" line. The two `DRIFT` blocks it still lists (`z2ui5_cl_ui5_json` / `z2ui5_t_02` and `HASH_BACK`) predate this change and are drift on the linter's side.
- `npm run check:js` (1173 specs, `browserActions.spec.js` covers URLHELPER), `npm --prefix app run lint`, `npm run check:app2abap`, `npm run gates` (30 of 31; `check:shared` is the pre-existing cross-repository drift that fails on `main` the same way).

## Checklist

- [x] `npm run verify` passes (`npm run verify:full` when `app/webapp/` changed) - the frontend half locally as listed above
- [x] Unit tests added/updated where it makes sense (`.testclasses.abap` / `node/tests/`) - existing spec covers the handler, nothing to add
- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/` (see AGENTS.md) - regenerated via `npm run app2abap`
- [x] Public API in `src/02/` only changed additively - untouched
- [x] `changelog.txt` has a line under `unreleased` when this changes behaviour - not needed, no behaviour change
- [x] Changes were made via abapGit: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HarkggpToJELFYiy9Mm4UH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HarkggpToJELFYiy9Mm4UH)_