### PR TITLE
Clarify AJSON parameter deprecation in _bind and _bind_edit

### DIFF
--- a/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
+++ b/src/01/02/z2ui5_cl_ui5_srv_model.clas.abap
@@ -546,6 +546,16 @@ CLASS z2ui5_cl_ui5_srv_model IMPLEMENTATION.
           " a mapper or filter is attached to an ajson INSTANCE, so those
           " attributes keep the scratch-instance detour the direct set cannot
           " express: convert into the scratch, filter, copy into the result
+          "
+          " This branch is COMPATIBILITY ONLY - _bind( custom_mapper ) and
+          " _bind( custom_filter ) are obsolete (the note on those parameters
+          " in z2ui5_if_client says why and what to write instead), and no app
+          " class in samples, samples-controls or samples-stack has ever
+          " reached them. Do not extend it, and do not route a new feature
+          " through it: the branch above is where a declarative flag belongs -
+          " omit_initial was built exactly there, out of the one filter this
+          " slot was really used for (create_empty_filter). Kept because a
+          " customer app that passes one must keep working
           IF lr_attri->custom_mapper IS BOUND OR lr_attri->custom_filter IS BOUND.
             IF lr_attri->custom_mapper IS BOUND.
               READ TABLE lt_mapper_cache REFERENCE INTO DATA(lr_mapper_cache)

--- a/src/02/z2ui5_if_client.intf.abap
+++ b/src/02/z2ui5_if_client.intf.abap
@@ -1006,16 +1006,36 @@ INTERFACE z2ui5_if_client
       path                 TYPE abap_bool                     DEFAULT abap_false
       "obsolete - inactive, not passed on internally
       view                 TYPE clike                         DEFAULT cs_view-main
-      "obsolete - still evaluated, but do not use in new code. Both hand an
-      "app a reference to the bundled AJSON library (src/00/01), which is a
-      "MIRRORED copy of an external project, not a contract this framework
-      "owns: an app implementing z2ui5_if_ajson_mapping / _filter binds
-      "itself to whatever that mirror looks like today. Everything they were
-      "reached for has a declarative counterpart on this method now -
-      "omit_initial / omit_initial_paths drop initial fields, json splices a
-      "JSON node - and the ABAP side can shape the value before it is bound
+      "obsolete - still evaluated, but NO AJSON TYPE BELONGS IN A BIND CALL
+      "any more. Both hand an app a reference to the bundled AJSON library
+      "(src/00/01), which is a MIRRORED copy of an external project, not a
+      "contract this framework owns: an app implementing
+      "z2ui5_if_ajson_mapping / _filter binds itself to whatever that mirror
+      "looks like today, and a resync of the mirror is free to break it.
+      "Everything they were ever reached for is declarative on this method
+      "now, and each replacement has a sample that proves it:
+      "  drop initial fields   -> omit_initial / omit_initial_paths
+      "                           (z2ui5_cl_smp_app_507)
+      "  a model NODE instead
+      "  of a quoted string,
+      "  under keys no ABAP
+      "  component can carry   -> json = abap_true
+      "                           (z2ui5_cl_smp_app_509)
+      "  anything else         -> shape the value in ABAP before binding it
+      "The one thing _bind( ) deliberately cannot do is a mapping that
+      "differs per direction - see the _back pair on _bind_edit( ), which is
+      "dead there. Measured 2026-09-13 across samples, samples-controls and
+      "samples-stack: not one app class passes either parameter or
+      "implements either interface, and none ever did in their git history -
+      "so nothing has to be migrated, only nothing new written. AJSON itself
+      "stays: it is the model engine (z2ui5_cl_ui5_srv_model), and json =
+      "abap_true is implemented with it. What goes is the LEAK of the
+      "mirrored library into the app-facing interface.
       custom_mapper        TYPE REF TO z2ui5_if_ajson_mapping OPTIONAL
-      "obsolete - the filter half of custom_mapper, see there
+      "obsolete - the filter half of custom_mapper, see there. This is the
+      "half that had the one real use - do not send initial fields, i.e.
+      "z2ui5_cl_ajson_filter_lib=>create_empty_filter - and that use is
+      "exactly what omit_initial replaced: it is wired into this very slot
       custom_filter        TYPE REF TO z2ui5_if_ajson_filter  OPTIONAL
       tab                  TYPE data                          OPTIONAL
       tab_index            TYPE i                             OPTIONAL
@@ -1029,6 +1049,13 @@ INTERFACE z2ui5_if_client
   "! obsolete - alias of _bind with identical behaviour, please use _bind.
   "! custom_mapper_back / custom_filter_back are still accepted for source
   "! compatibility but are no longer evaluated.
+  "!
+  "! All four AJSON parameters here are dead ends: this is the only place
+  "! that ever offered a per-direction mapping, and the two _back halves
+  "! that made it one are inert. Do not reach for any of them in new code -
+  "! bind with _bind( ) and say what you mean with omit_initial /
+  "! omit_initial_paths or json = abap_true, whose notes on _bind( ) carry
+  "! the full reasoning and a sample each.
   "!
   "! @parameter val | as _bind( ).
   "! @parameter path | as _bind( ).


### PR DESCRIPTION
# Description

This PR updates documentation comments in the client interface and model service to clarify the deprecation status of AJSON-related parameters (`custom_mapper`, `custom_filter`, `custom_mapper_back`, `custom_filter_back`) in the `_bind()` and `_bind_edit()` methods.

## Changes

**src/02/z2ui5_if_client.intf.abap:**
- Expanded comments on `custom_mapper` and `custom_filter` parameters in `_bind()` to explain why they are obsolete and what declarative alternatives should be used instead
- Added specific examples referencing sample apps (z2ui5_cl_smp_app_507, z2ui5_cl_smp_app_509) that demonstrate the replacements
- Clarified that `omit_initial` / `omit_initial_paths` replace the empty-filter use case
- Clarified that `json = abap_true` replaces the model-node mapping use case
- Added comprehensive note to `_bind_edit()` explaining that all four AJSON parameters are dead ends and should not be used in new code

**src/01/02/z2ui5_cl_ui5_srv_model.clas.abap:**
- Added detailed comment in the compatibility branch explaining that custom mapper/filter handling is for backward compatibility only
- Noted that no app in the codebase currently uses these parameters
- Advised against extending this branch for new features

## Rationale

These changes document the framework's migration away from exposing the mirrored AJSON library in the app-facing interface. The parameters remain functional for backward compatibility, but all their use cases now have declarative alternatives that are safer and more maintainable. The comments guide developers toward the correct modern approach.

## How to test

N/A — documentation-only change with no behavioral modifications.

## Checklist

- [x] No manual edits under `src/00/01/`, `src/00/02/` or `src/01/03/`
- [x] Public API in `src/02/` only changed additively (comments only, no signature changes)
- [x] No behavior changes requiring changelog entry

https://claude.ai/code/session_01DDtdyKmZunhYQE5RE88hC3